### PR TITLE
Parse Hexidecimal and Binary literals as Integers

### DIFF
--- a/Integration.Tests/python/test_defaults.py
+++ b/Integration.Tests/python/test_defaults.py
@@ -6,3 +6,6 @@ def test_default_int_arg(a: int = 1337) -> int:
 
 def test_default_float_arg(a: float = -1) -> float:
     return a
+
+def test_int_literals(a: int = 0x1337, b: int = 0b10101011) -> int:
+    return a

--- a/PythonSourceGenerator.Tests/BasicSmokeTests.cs
+++ b/PythonSourceGenerator.Tests/BasicSmokeTests.cs
@@ -29,6 +29,7 @@ namespace PythonSourceGenerator.Tests
         [InlineData("def hello_world(a: bool, b: str, c: list[tuple[int, float]]) -> bool: \n ...\n", "bool HelloWorld(bool a, string b, IEnumerable<Tuple<long, double>> c)")]
         [InlineData("def hello_world(a: bool = True, b: str = None) -> bool: \n ...\n", "bool HelloWorld(bool a = true, string b = null)")]
         [InlineData("def hello_world(a: str, *args) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args)")]
+        [InlineData("def hello(a: int = 0xdeadbeef) -> None:\n ...\n", "void Hello(long a = 0xDEADBEEF)")]
         [InlineData("def hello_world(a: str, *, b: int) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b)")]
         [InlineData("def hello_world(a: str, *, b: int = 3) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b = 3)")]
         [InlineData("def hello_world(a: str, *args, **kwargs) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, IReadOnlyDictionary<string, PyObject> kwargs)")]

--- a/PythonSourceGenerator.Tests/BasicSmokeTests.cs
+++ b/PythonSourceGenerator.Tests/BasicSmokeTests.cs
@@ -30,7 +30,7 @@ namespace PythonSourceGenerator.Tests
         [InlineData("def hello_world(a: bool = True, b: str = None) -> bool: \n ...\n", "bool HelloWorld(bool a = true, string b = null)")]
         [InlineData("def hello_world(a: str, *args) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args)")]
         [InlineData("def hello_world(a: str, *, b: int) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b)")]
-        [InlineData("def hello_world(a: str, *, b: int = 3) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b = 3)")]
+        [InlineData("def hello_world(a: str, *, b: int = 3) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b = 3L)")]
         [InlineData("def hello_world(a: str, *args, **kwargs) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, IReadOnlyDictionary<string, PyObject> kwargs)")]
         public void TestGeneratedSignature(string code, string expected)
         {

--- a/PythonSourceGenerator.Tests/BasicSmokeTests.cs
+++ b/PythonSourceGenerator.Tests/BasicSmokeTests.cs
@@ -30,7 +30,7 @@ namespace PythonSourceGenerator.Tests
         [InlineData("def hello_world(a: bool = True, b: str = None) -> bool: \n ...\n", "bool HelloWorld(bool a = true, string b = null)")]
         [InlineData("def hello_world(a: str, *args) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args)")]
         [InlineData("def hello_world(a: str, *, b: int) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b)")]
-        [InlineData("def hello_world(a: str, *, b: int = 3) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b = 3L)")]
+        [InlineData("def hello_world(a: str, *, b: int = 3) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b = 3)")]
         [InlineData("def hello_world(a: str, *args, **kwargs) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, IReadOnlyDictionary<string, PyObject> kwargs)")]
         public void TestGeneratedSignature(string code, string expected)
         {

--- a/PythonSourceGenerator.Tests/BasicSmokeTests.cs
+++ b/PythonSourceGenerator.Tests/BasicSmokeTests.cs
@@ -30,6 +30,7 @@ namespace PythonSourceGenerator.Tests
         [InlineData("def hello_world(a: bool = True, b: str = None) -> bool: \n ...\n", "bool HelloWorld(bool a = true, string b = null)")]
         [InlineData("def hello_world(a: str, *args) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args)")]
         [InlineData("def hello(a: int = 0xdeadbeef) -> None:\n ...\n", "void Hello(long a = 0xDEADBEEF)")]
+        [InlineData("def hello(a: int = 0b10101010) -> None:\n ...\n", "void Hello(long a = 0b10101010)")]
         [InlineData("def hello_world(a: str, *, b: int) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b)")]
         [InlineData("def hello_world(a: str, *, b: int = 3) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, long b = 3)")]
         [InlineData("def hello_world(a: str, *args, **kwargs) -> None: \n ...\n", "void HelloWorld(string a, Tuple<PyObject> args, IReadOnlyDictionary<string, PyObject> kwargs)")]

--- a/PythonSourceGenerator.Tests/TokenizerTests.cs
+++ b/PythonSourceGenerator.Tests/TokenizerTests.cs
@@ -418,6 +418,7 @@ def bar(a: int, b:= str) -> None:
     /* See https://github.com/python/cpython/blob/main/Lib/test/test_tokenize.py#L2063-L2126 */
     [InlineData("255", 255)]
     [InlineData("0b10", 0b10)]
+    [InlineData("0b10101101", 0b10101101)]
     // [InlineData("0o123", 0o123)] Octal literals are not supported in C#
     [InlineData("1234567", 1234567)]
     [InlineData("-1234567", -1234567)]

--- a/PythonSourceGenerator/Parser/PythonSignatureParser.Constants.cs
+++ b/PythonSourceGenerator/Parser/PythonSignatureParser.Constants.cs
@@ -43,47 +43,49 @@ public static partial class PythonSignatureParser
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> DoubleQuotedStringConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.DoubleQuotedString)
         .Apply(ConstantParsers.DoubleQuotedString)
-        .Select(s => new PythonConstant { IsString = true, StringValue = s })
+        .Select(s => new PythonConstant(s))
         .Named("Double Quoted String Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> SingleQuotedStringConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.SingleQuotedString)
         .Apply(ConstantParsers.SingleQuotedString)
-        .Select(s => new PythonConstant { IsString = true, StringValue = s })
+        .Select(s => new PythonConstant(s))
         .Named("Single Quoted String Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> DecimalConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.Decimal)
         .Apply(Numerics.DecimalDouble)
-        .Select(d => new PythonConstant { IsFloat = true, FloatValue = d })
+        .Select(d => new PythonConstant(d))
         .Named("Decimal Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> IntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.Integer)
         .Apply(Numerics.IntegerInt64)
-        .Select(d => new PythonConstant { IsInteger = true, IntegerValue = d })
+        .Select(d => new PythonConstant(d))
         .Named("Integer Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> HexidecimalIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.HexidecimalInteger)
         .Apply(ConstantParsers.HexidecimalConstantParser)
-        .Select(d => new PythonConstant { IsInteger = true, IntegerValue = (long)d })
+        // TODO: Emit as a hexidecimal literal
+        .Select(d => new PythonConstant { Type = PythonConstant.ConstantType.HexidecimalInteger, IntegerValue = (long)d })
         .Named("Hexidecimal Integer Constant");
     
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> BinaryIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.BinaryInteger)
         .Apply(ConstantParsers.BinaryConstantParser)
-        .Select(d => new PythonConstant { IsInteger = true, IntegerValue = (long)d })
+        // TODO: Emit as a binary literal
+        .Select(d => new PythonConstant { Type = PythonConstant.ConstantType.BinaryInteger, IntegerValue = (long)d })
         .Named("Binary Integer Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> BoolConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.True).Or(Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.False))
-        .Select(d => new PythonConstant { IsBool = true, BoolValue = d.Kind == PythonSignatureTokens.PythonSignatureToken.True })
+        .Select(d => new PythonConstant(d.Kind == PythonSignatureTokens.PythonSignatureToken.True ))
         .Named("Bool Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> NoneConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.None)
-        .Select(d => new PythonConstant { IsNone = true })
+        .Select(d => new PythonConstant { Type = PythonConstant.ConstantType.None })
         .Named("None Constant");
 
     // Any constant value

--- a/PythonSourceGenerator/Parser/PythonSignatureParser.Constants.cs
+++ b/PythonSourceGenerator/Parser/PythonSignatureParser.Constants.cs
@@ -18,6 +18,11 @@ public static partial class PythonSignatureParser
         from rest in Character.Digit.Many()
         select Unit.Value;
 
+    public static TextParser<Unit> HexidecimalConstantToken { get; } =
+        from prefix in Span.EqualTo("0x")
+        from digits in Character.HexDigit.AtLeastOnce()
+        select Unit.Value;
+
     public static TextParser<Unit> DoubleQuotedStringConstantToken { get; } =
         from open in Character.EqualTo('"')
         from chars in Character.ExceptIn('"').Many()
@@ -44,15 +49,21 @@ public static partial class PythonSignatureParser
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> DecimalConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.Decimal)
-        .Apply(ConstantParsers.Decimal)
+        .Apply(Numerics.DecimalDouble)
         .Select(d => new PythonConstant { IsFloat = true, FloatValue = d })
         .Named("Decimal Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> IntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.Integer)
-        .Apply(ConstantParsers.Integer)
+        .Apply(Numerics.IntegerInt64)
         .Select(d => new PythonConstant { IsInteger = true, IntegerValue = d })
         .Named("Integer Constant");
+
+    public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> HexidecimalIntegerConstantTokenizer { get; } =
+        Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.HexidecimalInteger)
+        .Apply(ConstantParsers.HexidecimalConstantParser)
+        .Select(d => new PythonConstant { IsInteger = true, IntegerValue = (long)d })
+        .Named("Hexidecimal Integer Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> BoolConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.True).Or(Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.False))
@@ -68,6 +79,7 @@ public static partial class PythonSignatureParser
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant?> ConstantValueTokenizer { get; } =
         DecimalConstantTokenizer.AsNullable()
         .Or(IntegerConstantTokenizer.AsNullable())
+        .Or(HexidecimalIntegerConstantTokenizer.AsNullable())
         .Or(BoolConstantTokenizer.AsNullable())
         .Or(NoneConstantTokenizer.AsNullable())
         .Or(DoubleQuotedStringConstantTokenizer.AsNullable())
@@ -100,25 +112,9 @@ public static partial class PythonSignatureParser
             from close in Character.EqualTo('\'')
             select new string(chars);
 
-        public static TextParser<int> Integer { get; } =
-            from sign in Character.EqualTo('-').Value(-1).OptionalOrDefault(1)
-            from whole in Numerics.Natural.Select(n => int.Parse(n.ToStringValue()))
-            select whole * sign;
-
-        // TODO: (track) This a copy from the JSON spec and probably doesn't reflect Python's other numeric literals like Hex and Real
-        public static TextParser<double> Decimal { get; } =
-            from sign in Character.EqualTo('-').Value(-1.0).OptionalOrDefault(1.0)
-            from whole in Numerics.Natural.Select(n => double.Parse(n.ToStringValue()))
-            from frac in Character.EqualTo('.')
-                .IgnoreThen(Numerics.Natural)
-                .Select(n => double.Parse(n.ToStringValue()) * Math.Pow(10, -n.Length))
-                .OptionalOrDefault()
-            from exp in Character.EqualToIgnoreCase('e')
-                .IgnoreThen(Character.EqualTo('+').Value(1.0)
-                    .Or(Character.EqualTo('-').Value(-1.0))
-                    .OptionalOrDefault(1.0))
-                .Then(expsign => Numerics.Natural.Select(n => double.Parse(n.ToStringValue()) * expsign))
-                .OptionalOrDefault()
-            select (whole + frac) * sign * Math.Pow(10, exp);
+        public static TextParser<UInt64> HexidecimalConstantParser { get; } =
+            from prefix in Span.EqualTo("0x")
+            from digits in Character.HexDigit.AtLeastOnce()
+            select UInt64.Parse(new string(digits), System.Globalization.NumberStyles.HexNumber);
     }
 }

--- a/PythonSourceGenerator/Parser/PythonSignatureParser.Constants.cs
+++ b/PythonSourceGenerator/Parser/PythonSignatureParser.Constants.cs
@@ -23,6 +23,11 @@ public static partial class PythonSignatureParser
         from digits in Character.HexDigit.AtLeastOnce()
         select Unit.Value;
 
+    public static TextParser<Unit> BinaryConstantToken { get; } =
+        from prefix in Span.EqualTo("0b")
+        from digits in Character.EqualTo('0').Or(Character.EqualTo('1')).AtLeastOnce()
+        select Unit.Value;
+
     public static TextParser<Unit> DoubleQuotedStringConstantToken { get; } =
         from open in Character.EqualTo('"')
         from chars in Character.ExceptIn('"').Many()
@@ -64,6 +69,12 @@ public static partial class PythonSignatureParser
         .Apply(ConstantParsers.HexidecimalConstantParser)
         .Select(d => new PythonConstant { IsInteger = true, IntegerValue = (long)d })
         .Named("Hexidecimal Integer Constant");
+    
+    public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> BinaryIntegerConstantTokenizer { get; } =
+        Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.BinaryInteger)
+        .Apply(ConstantParsers.BinaryConstantParser)
+        .Select(d => new PythonConstant { IsInteger = true, IntegerValue = (long)d })
+        .Named("Binary Integer Constant");
 
     public static TokenListParser<PythonSignatureTokens.PythonSignatureToken, PythonConstant> BoolConstantTokenizer { get; } =
         Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.True).Or(Token.EqualTo(PythonSignatureTokens.PythonSignatureToken.False))
@@ -80,6 +91,7 @@ public static partial class PythonSignatureParser
         DecimalConstantTokenizer.AsNullable()
         .Or(IntegerConstantTokenizer.AsNullable())
         .Or(HexidecimalIntegerConstantTokenizer.AsNullable())
+        .Or(BinaryIntegerConstantTokenizer.AsNullable())
         .Or(BoolConstantTokenizer.AsNullable())
         .Or(NoneConstantTokenizer.AsNullable())
         .Or(DoubleQuotedStringConstantTokenizer.AsNullable())
@@ -116,5 +128,10 @@ public static partial class PythonSignatureParser
             from prefix in Span.EqualTo("0x")
             from digits in Character.HexDigit.AtLeastOnce()
             select UInt64.Parse(new string(digits), System.Globalization.NumberStyles.HexNumber);
+    
+        public static TextParser<UInt64> BinaryConstantParser { get; } =
+            from prefix in Span.EqualTo("0b")
+            from digits in Character.EqualTo('0').Or(Character.EqualTo('1')).AtLeastOnce()
+            select Convert.ToUInt64(new string(digits), 2);
     }
 }

--- a/PythonSourceGenerator/Parser/PythonSignatureTokenizer.cs
+++ b/PythonSourceGenerator/Parser/PythonSignatureTokenizer.cs
@@ -29,6 +29,7 @@ public static class PythonSignatureTokenizer
         .Match(Identifier.CStyle, PythonSignatureTokens.PythonSignatureToken.Identifier, requireDelimiters: true) // TODO: (track) Does this require delimiters?
         .Match(PythonSignatureParser.IntegerConstantToken, PythonSignatureTokens.PythonSignatureToken.Integer, requireDelimiters: true)
         .Match(PythonSignatureParser.DecimalConstantToken, PythonSignatureTokens.PythonSignatureToken.Decimal, requireDelimiters: true)
+        .Match(PythonSignatureParser.HexidecimalConstantToken, PythonSignatureTokens.PythonSignatureToken.HexidecimalInteger, requireDelimiters: true)
         .Match(PythonSignatureParser.DoubleQuotedStringConstantToken, PythonSignatureTokens.PythonSignatureToken.DoubleQuotedString)
         .Match(PythonSignatureParser.SingleQuotedStringConstantToken, PythonSignatureTokens.PythonSignatureToken.SingleQuotedString)
         .Build();

--- a/PythonSourceGenerator/Parser/PythonSignatureTokenizer.cs
+++ b/PythonSourceGenerator/Parser/PythonSignatureTokenizer.cs
@@ -30,6 +30,7 @@ public static class PythonSignatureTokenizer
         .Match(PythonSignatureParser.IntegerConstantToken, PythonSignatureTokens.PythonSignatureToken.Integer, requireDelimiters: true)
         .Match(PythonSignatureParser.DecimalConstantToken, PythonSignatureTokens.PythonSignatureToken.Decimal, requireDelimiters: true)
         .Match(PythonSignatureParser.HexidecimalConstantToken, PythonSignatureTokens.PythonSignatureToken.HexidecimalInteger, requireDelimiters: true)
+        .Match(PythonSignatureParser.BinaryConstantToken, PythonSignatureTokens.PythonSignatureToken.BinaryInteger, requireDelimiters: true)
         .Match(PythonSignatureParser.DoubleQuotedStringConstantToken, PythonSignatureTokens.PythonSignatureToken.DoubleQuotedString)
         .Match(PythonSignatureParser.SingleQuotedStringConstantToken, PythonSignatureTokens.PythonSignatureToken.SingleQuotedString)
         .Build();

--- a/PythonSourceGenerator/Parser/PythonSignatureTokens.cs
+++ b/PythonSourceGenerator/Parser/PythonSignatureTokens.cs
@@ -49,6 +49,7 @@ public class PythonSignatureTokens
         Integer,
         Decimal,
         HexidecimalInteger,
+        BinaryInteger,
         DoubleQuotedString,
         SingleQuotedString,
         True,

--- a/PythonSourceGenerator/Parser/PythonSignatureTokens.cs
+++ b/PythonSourceGenerator/Parser/PythonSignatureTokens.cs
@@ -48,6 +48,7 @@ public class PythonSignatureTokens
 
         Integer,
         Decimal,
+        HexidecimalInteger,
         DoubleQuotedString,
         SingleQuotedString,
         True,

--- a/PythonSourceGenerator/Parser/Types/PythonConstant.cs
+++ b/PythonSourceGenerator/Parser/Types/PythonConstant.cs
@@ -3,7 +3,7 @@
 public class PythonConstant
 {
     public bool IsInteger { get; set; }
-    public int IntegerValue { get; set; }
+    public long IntegerValue { get; set; }
 
     public bool IsString { get; set; }
     public string? StringValue { get; set; }

--- a/PythonSourceGenerator/Parser/Types/PythonConstant.cs
+++ b/PythonSourceGenerator/Parser/Types/PythonConstant.cs
@@ -2,42 +2,75 @@
 
 public class PythonConstant
 {
-    public bool IsInteger { get; set; }
+    public enum ConstantType
+    {
+        Integer,
+        HexidecimalInteger,
+        BinaryInteger,
+        Float,
+        String,
+        Bool,
+        None,
+    }
+
+    public PythonConstant() { }
+
+    public PythonConstant(long value)
+    {
+        Type = ConstantType.Integer;
+        IntegerValue = value;
+    }
+
+    public PythonConstant(double value)
+    {
+        Type = ConstantType.Float;
+        FloatValue = value;
+    }
+
+    public PythonConstant(string value)
+    {
+        Type = ConstantType.String;
+        StringValue = value;
+    }
+
+    public PythonConstant(bool value)
+    {
+        Type = ConstantType.Bool;
+        BoolValue = value;
+    }
+
+    public ConstantType Type { get; set; }
+
     public long IntegerValue { get; set; }
 
-    public bool IsString { get; set; }
     public string? StringValue { get; set; }
 
-    public bool IsNone { get; set; }
-
-    public bool IsFloat { get; set; }
     public double FloatValue { get; set; }
 
-    public bool IsBool { get; set; }
     public bool BoolValue { get; set; }
+
+    public bool IsInteger { get => Type == ConstantType.Integer || Type == ConstantType.BinaryInteger || Type == ConstantType.HexidecimalInteger; }
 
     public override string ToString()
     {
-        if (IsInteger)
+        switch (Type)
         {
-            return IntegerValue.ToString();
+            case ConstantType.Integer:
+                return IntegerValue.ToString();
+            case ConstantType.HexidecimalInteger:
+                return $"0x{IntegerValue:X}";
+            case ConstantType.BinaryInteger:
+                return $"0b{IntegerValue:X}";
+            case ConstantType.Float:
+                return FloatValue.ToString();
+            case ConstantType.Bool:
+                return BoolValue.ToString();
+            case ConstantType.String:
+                return StringValue ?? throw new ArgumentNullException(nameof(StringValue));
+            case ConstantType.None:
+                return "None";
+            default:
+                return "unknown";
         }
-        if (IsString)
-        {
-            return StringValue ?? throw new ArgumentNullException(nameof(StringValue));
-        }
-        if (IsFloat)
-        {
-            return FloatValue.ToString();
-        }
-        if (IsNone)
-        {
-            return "None";
-        }
-        if (IsBool)
-        {
-            return BoolValue.ToString();
-        }
-        return "unknown";
     }
 }

--- a/PythonSourceGenerator/Reflection/ArgumentReflection.cs
+++ b/PythonSourceGenerator/Reflection/ArgumentReflection.cs
@@ -64,7 +64,7 @@ public class ArgumentReflection
                 case PythonConstant.ConstantType.HexidecimalInteger:
                     literalExpressionSyntax = SyntaxFactory.LiteralExpression(
                                                             SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal(string.Format("{0:X}", parameter.DefaultValue.IntegerValue), parameter.DefaultValue.IntegerValue));
+                                                            SyntaxFactory.Literal(string.Format("0x{0:X}", parameter.DefaultValue.IntegerValue), parameter.DefaultValue.IntegerValue));
                     break;
                 case PythonConstant.ConstantType.BinaryInteger:
                     literalExpressionSyntax = SyntaxFactory.LiteralExpression(

--- a/PythonSourceGenerator/Reflection/ArgumentReflection.cs
+++ b/PythonSourceGenerator/Reflection/ArgumentReflection.cs
@@ -29,35 +29,54 @@ public class ArgumentReflection
         else
         {
             LiteralExpressionSyntax literalExpressionSyntax;
-            if (parameter.DefaultValue.IsInteger)
+
+            switch (parameter.DefaultValue.Type)
             {
-                // Downcast long to int if the value is small as the code is more readable without the L suffix
-                if (parameter.DefaultValue.IntegerValue <= int.MaxValue && parameter.DefaultValue.IntegerValue >= int.MinValue)
+                case PythonConstant.ConstantType.Integer:
+                    // Downcast long to int if the value is small as the code is more readable without the L suffix
+                    if (parameter.DefaultValue.IntegerValue <= int.MaxValue && parameter.DefaultValue.IntegerValue >= int.MinValue)
+                        literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                                SyntaxKind.NumericLiteralExpression,
+                                                                SyntaxFactory.Literal((int)parameter.DefaultValue.IntegerValue));
+                    else
+                        literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                                SyntaxKind.NumericLiteralExpression,
+                                                                SyntaxFactory.Literal(parameter.DefaultValue.IntegerValue));
+                    break;
+                case PythonConstant.ConstantType.String:
+                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                            SyntaxKind.StringLiteralExpression,
+                                                            SyntaxFactory.Literal(parameter.DefaultValue.StringValue));
+                    break;
+                case PythonConstant.ConstantType.Float:
                     literalExpressionSyntax = SyntaxFactory.LiteralExpression(
                                                             SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal((int)parameter.DefaultValue.IntegerValue));
-                else
+                                                            SyntaxFactory.Literal(parameter.DefaultValue.FloatValue));
+                    break;
+                case PythonConstant.ConstantType.Bool:
+                    literalExpressionSyntax = parameter.DefaultValue.BoolValue
+                        ? SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)
+                        : SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression);
+                    break;
+                case PythonConstant.ConstantType.None:
+                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+                    break;
+                case PythonConstant.ConstantType.HexidecimalInteger:
+                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                            SyntaxKind.NumericLiteralExpression,
+                                                            SyntaxFactory.Literal(string.Format("{0:X}", parameter.DefaultValue.IntegerValue), parameter.DefaultValue.IntegerValue));
+                    break;
+                case PythonConstant.ConstantType.BinaryInteger:
                     literalExpressionSyntax = SyntaxFactory.LiteralExpression(
                                                             SyntaxKind.NumericLiteralExpression,
                                                             SyntaxFactory.Literal(parameter.DefaultValue.IntegerValue));
+                    break;
+                default:
+                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+                    break;
             }
-            else if (parameter.DefaultValue.IsString && parameter.DefaultValue.StringValue is not null)
-                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                            SyntaxKind.StringLiteralExpression,
-                                                            SyntaxFactory.Literal(parameter.DefaultValue.StringValue));
-            else if (parameter.DefaultValue.IsFloat)
-                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                            SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal(parameter.DefaultValue.FloatValue));
-            else if (parameter.DefaultValue.IsBool && parameter.DefaultValue.BoolValue == true)
-                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression);
-            else if (parameter.DefaultValue.IsBool && parameter.DefaultValue.BoolValue == false)
-                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression);
-            else if (parameter.DefaultValue.IsNone)
-                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
-            else
-                // TODO : Handle other types?
-                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+
+
             return SyntaxFactory
                 .Parameter(SyntaxFactory.Identifier(Keywords.ValidIdentifier(parameter.Name.ToLowerPascalCase())))
                 .WithType(reflectedType)

--- a/PythonSourceGenerator/Reflection/ArgumentReflection.cs
+++ b/PythonSourceGenerator/Reflection/ArgumentReflection.cs
@@ -69,7 +69,7 @@ public class ArgumentReflection
                 case PythonConstant.ConstantType.BinaryInteger:
                     literalExpressionSyntax = SyntaxFactory.LiteralExpression(
                                                             SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal(parameter.DefaultValue.IntegerValue));
+                                                            SyntaxFactory.Literal(string.Format("0b{0}", Convert.ToString(parameter.DefaultValue.IntegerValue, 2)), parameter.DefaultValue.IntegerValue));
                     break;
                 default:
                     literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);

--- a/PythonSourceGenerator/Reflection/ArgumentReflection.cs
+++ b/PythonSourceGenerator/Reflection/ArgumentReflection.cs
@@ -30,9 +30,17 @@ public class ArgumentReflection
         {
             LiteralExpressionSyntax literalExpressionSyntax;
             if (parameter.DefaultValue.IsInteger)
-                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+            {
+                // Downcast long to int if the value is small as the code is more readable without the L suffix
+                if (parameter.DefaultValue.IntegerValue <= int.MaxValue && parameter.DefaultValue.IntegerValue >= int.MinValue)
+                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                            SyntaxKind.NumericLiteralExpression,
+                                                            SyntaxFactory.Literal((int)parameter.DefaultValue.IntegerValue));
+                else
+                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
                                                             SyntaxKind.NumericLiteralExpression,
                                                             SyntaxFactory.Literal(parameter.DefaultValue.IntegerValue));
+            }
             else if (parameter.DefaultValue.IsString && parameter.DefaultValue.StringValue is not null)
                 literalExpressionSyntax = SyntaxFactory.LiteralExpression(
                                                             SyntaxKind.StringLiteralExpression,


### PR DESCRIPTION
Also changes the parser to emit `long` instead of `int` for literals.

Closes #39 

Doesn't include Octal literals as C# doesn't support those anyway.

The emitted literals are formatted in binary or hexidecimal if Python was that way.