### PR TITLE
Error tracking

### DIFF
--- a/PythonSourceGenerator.Tests/BasicSmokeTests.cs
+++ b/PythonSourceGenerator.Tests/BasicSmokeTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 using Python.Runtime;
 using PythonSourceGenerator.Parser;
 using PythonSourceGenerator.Reflection;
@@ -33,8 +34,10 @@ namespace PythonSourceGenerator.Tests
             var tempName = string.Format("{0}_{1:N}", "test", Guid.NewGuid().ToString("N"));
             File.WriteAllText(Path.Combine(testEnv.TempDir, $"{tempName}.py"), code);
 
+            SourceText sourceText = SourceText.From(code);
+
             // create a Python scope
-            PythonSignatureParser.TryParseFunctionDefinitions(code, out var functions, out var errors);
+            PythonSignatureParser.TryParseFunctionDefinitions(sourceText, out var functions, out var errors);
             Assert.Empty(errors);
             var module = ModuleReflection.MethodsFromFunctionDefinitions(functions, "test");
             var csharp = module.Select(m => m.Syntax).Compile();

--- a/PythonSourceGenerator/PythonStaticGenerator.cs
+++ b/PythonSourceGenerator/PythonStaticGenerator.cs
@@ -12,7 +12,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // System.Diagnostics.Debugger.Launch();
+        //System.Diagnostics.Debugger.Launch();
         var pythonFilesPipeline = context.AdditionalTextsProvider
             .Where(static text => Path.GetExtension(text.Path) == ".py")
             .Collect();
@@ -31,7 +31,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
 
                 IEnumerable<MethodDefinition> methods;
                 // Read the file
-                var code = File.ReadAllText(file.Path);
+                var code = file.GetText(sourceContext.CancellationToken);
 
                 // Parse the Python file
                 var result = PythonSignatureParser.TryParseFunctionDefinitions(code, out PythonFunctionDefinition[] functions, out GeneratorError[]? errors);

--- a/PythonSourceGenerator/PythonStaticGenerator.cs
+++ b/PythonSourceGenerator/PythonStaticGenerator.cs
@@ -33,6 +33,8 @@ public class PythonStaticGenerator : IIncrementalGenerator
                 // Read the file
                 var code = file.GetText(sourceContext.CancellationToken);
 
+                if (code == null) continue;
+
                 // Parse the Python file
                 var result = PythonSignatureParser.TryParseFunctionDefinitions(code, out PythonFunctionDefinition[] functions, out GeneratorError[]? errors);
 


### PR DESCRIPTION
Using the source generator to read the file in, which gives us lines and column (span) count.

This can help pin-point errors a little easier.

Fixes #40