### PR TITLE
Refactor the python environment builder

### DIFF
--- a/src/CSnakes.Runtime/Locators/PythonLocationMetadata.cs
+++ b/src/CSnakes.Runtime/Locators/PythonLocationMetadata.cs
@@ -1,9 +1,16 @@
 ﻿namespace CSnakes.Runtime.Locators;
+
 /// <summary>
 /// Metadata about the location of a Python installation.
 /// </summary>
 /// <param name="Folder">Path on disk where Python is to be loaded from.</param>
 /// <param name="Version">Version of Python being used from the location.</param>
 /// <param name="Debug">True if the Python installation is a debug build.</param>
-/// <param name="FreeThreaded"
-public sealed record PythonLocationMetadata(string Folder, Version Version, bool Debug = false, bool FreeThreaded = false);
+public sealed record PythonLocationMetadata(
+    string Folder,
+    Version Version,
+    string LibPythonPath,
+    string PythonPath,
+    string PythonBinaryPath,
+    bool Debug = false, 
+    bool FreeThreaded = false);

--- a/src/CSnakes.Runtime/Locators/PythonLocator.cs
+++ b/src/CSnakes.Runtime/Locators/PythonLocator.cs
@@ -24,7 +24,22 @@ public abstract class PythonLocator(Version version)
 
     protected string GetPythonExecutablePath(string folder)
     {
-        return Path.Combine(folder, "python.exe");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Path.Combine(folder, "python.exe");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Path.Combine(folder, "bin", "python");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return Path.Combine(folder, "bin", "python");
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Unsupported platform.");
+        }
     }
 
     protected string GetLibPythonPath(string folder, bool freeThreaded = false)

--- a/src/CSnakes.Runtime/Locators/PythonLocator.cs
+++ b/src/CSnakes.Runtime/Locators/PythonLocator.cs
@@ -1,4 +1,6 @@
-﻿namespace CSnakes.Runtime.Locators;
+﻿using System.Runtime.InteropServices;
+
+namespace CSnakes.Runtime.Locators;
 
 /// <summary>
 /// Abstract class for locating Python installations.
@@ -20,20 +22,74 @@ public abstract class PythonLocator(Version version)
     /// <returns>The metadata of the located Python installation.</returns>
     public abstract PythonLocationMetadata LocatePython();
 
+    protected string GetPythonExecutablePath(string folder)
+    {
+        return Path.Combine(folder, "python.exe");
+    }
+
+    protected string GetLibPythonPath(string folder, bool freeThreaded = false)
+    {
+        string suffix = freeThreaded ? "t" : "";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Path.Combine(folder, $"python{version.Major}{version.Minor}{suffix}.dll");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Path.Combine(folder, "lib", $"libpython{version.Major}.{version.Minor}{suffix}.dylib");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return Path.Combine(folder, "lib", $"libpython{version.Major}.{version.Minor}{suffix}.so");
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Unsupported platform.");
+        }
+    }
+
+    /// <summary>
+    /// Get the standard lib path for Python.
+    /// </summary>
+    /// <param name="folder">The base folder</param>
+    /// <returns></returns>
+    protected string GetPythonPath(string folder)
+    {
+        char sep = Path.PathSeparator;
+
+        // Add standard library to PYTHONPATH
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Path.Combine(folder, "Lib") + sep + Path.Combine(folder, "DLLs");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Path.Combine(folder, "lib", $"python{version.Major}.{version.Minor}") + sep + Path.Combine(folder, "lib", $"python{version.Major}.{version.Minor}", "lib-dynload");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return Path.Combine(folder, "lib", $"python{version.Major}.{version.Minor}") + sep + Path.Combine(folder, "lib", $"python{version.Major}.{version.Minor}", "lib-dynload");
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Unsupported platform.");
+        }
+    }
+
     /// <summary>
     /// Locates the Python installation internally.
     /// </summary>
     /// <param name="folder">The folder path to search for Python.</param>
     /// <returns>The metadata of the located Python installation.</returns>
     /// <exception cref="DirectoryNotFoundException">Python not found at the specified folder.</exception>
-    protected PythonLocationMetadata LocatePythonInternal(string folder)
+    protected PythonLocationMetadata LocatePythonInternal(string folder, bool freeThreaded = false)
     {
         if (!Directory.Exists(folder))
         {
             throw new DirectoryNotFoundException($"Python not found at {folder}.");
         }
 
-        return new PythonLocationMetadata(folder, Version);
+        return new PythonLocationMetadata(folder, Version, GetLibPythonPath(folder, freeThreaded), GetPythonPath(folder), GetPythonExecutablePath(folder));
     }
 
     /// <summary>

--- a/src/CSnakes.Runtime/Locators/SourceLocator.cs
+++ b/src/CSnakes.Runtime/Locators/SourceLocator.cs
@@ -13,11 +13,6 @@ internal class SourceLocator(string folder, Version version, bool debug = true, 
             throw new DirectoryNotFoundException($"Python {Version} not found in {buildFolder}.");
         }
 
-        return new PythonLocationMetadata(
-            buildFolder,
-            Version,
-            debug,
-            freeThreaded
-        );
+        return LocatePythonInternal(folder, freeThreaded);
     }
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -94,12 +94,12 @@ internal class PythonEnvironment : IPythonEnvironment
 
         if (!Directory.Exists(venvPath))
         {
-            Logger.LogInformation("Creating virtual environment at {VirtualEnvPath}", venvPath);
+            Logger.LogInformation("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", venvPath, pythonLocation.PythonBinaryPath);
 
             ProcessStartInfo startInfo = new()
             {
                 WorkingDirectory = pythonLocation.Folder,
-                FileName = "python",
+                FileName = pythonLocation.PythonBinaryPath,
                 Arguments = $"-m venv {venvPath}"
             };
             startInfo.RedirectStandardError = true;

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -3,7 +3,6 @@ using CSnakes.Runtime.Locators;
 using CSnakes.Runtime.PackageManagement;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime;
 
@@ -132,55 +131,8 @@ internal class PythonEnvironment : IPythonEnvironment
 
     private CPythonAPI SetupStandardLibrary(PythonLocationMetadata pythonLocationMetadata, char sep)
     {
-        string pythonDll = string.Empty;
-        string pythonPath = string.Empty;
-        string pythonLocation = pythonLocationMetadata.Folder;
-        var version = pythonLocationMetadata.Version;
-        string suffix = string.Empty;
-
-        if (pythonLocationMetadata.FreeThreaded)
-        {
-            suffix += "t";
-        }
-
-        // Add standard library to PYTHONPATH
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            suffix += pythonLocationMetadata.Debug ? "_d" : string.Empty;
-            pythonDll = Path.Combine(pythonLocation, $"python{version.Major}{version.Minor}{suffix}.dll");
-            if (pythonLocationMetadata.Debug)
-            {
-                // From source..
-                pythonPath = Path.Combine(pythonLocation, "..", "..", "Lib") + sep + pythonLocation;
-            }
-            else
-            {
-                pythonPath = Path.Combine(pythonLocation, "Lib") + sep + Path.Combine(pythonLocation, "DLLs");
-            }
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            suffix += pythonLocationMetadata.Debug ? "d" : string.Empty;
-            if (pythonLocationMetadata.Debug) // from source
-            {
-                pythonDll = Path.Combine(pythonLocation, $"libpython{version.Major}.{version.Minor}{suffix}.dylib");
-                pythonPath = Path.Combine(pythonLocation, "Lib"); // TODO : build/lib.macosx-13.6-x86_64-3.13-pydebug
-            }
-            else
-            {
-                pythonDll = Path.Combine(pythonLocation, "lib", $"libpython{version.Major}.{version.Minor}{suffix}.dylib");
-                pythonPath = Path.Combine(pythonLocation, "lib", $"python{version.Major}.{version.Minor}") + sep + Path.Combine(pythonLocation, "lib", $"python{version.Major}.{version.Minor}", "lib-dynload");
-            }
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            pythonDll = Path.Combine(pythonLocation, "lib", $"libpython{version.Major}.{version.Minor}{suffix}.so");
-            pythonPath = Path.Combine(pythonLocation, "lib", $"python{version.Major}.{version.Minor}") + sep + Path.Combine(pythonLocation, "lib", $"python{version.Major}.{version.Minor}", "lib-dynload");
-        }
-        else
-        {
-            throw new PlatformNotSupportedException("Unsupported platform.");
-        }
+        string pythonDll = pythonLocationMetadata.LibPythonPath;
+        string pythonPath = pythonLocationMetadata.PythonPath;
 
         Logger.LogInformation("Python DLL: {PythonDLL}", pythonDll);
         Logger.LogInformation("Python path: {PythonPath}", pythonPath);


### PR DESCRIPTION
Moves the locations of the components into overridable methods

- the path to libpython
- the path to the python stdlib (PYTHONPATH)
- the path to the binary `python` that is used by the pip installer