### PR TITLE
Capture Python stack traces and frame data for easier debugging

### DIFF
--- a/src/CSnakes.Runtime/CPython/Mapping.cs
+++ b/src/CSnakes.Runtime/CPython/Mapping.cs
@@ -1,0 +1,55 @@
+﻿using System.Runtime.InteropServices;
+
+namespace CSnakes.Runtime.CPython;
+
+internal unsafe partial class CPythonAPI
+{
+    public static bool IsPyMapping(nint p)
+    {
+        return PyMapping_Check(p) == 1;
+    }
+
+    /// <summary>
+    /// Return 1 if the object provides the mapping protocol or supports slicing, and 0 otherwise. 
+    /// Note that it returns 1 for Python classes with a __getitem__() method, since in general 
+    /// it is impossible to determine what type of keys the class supports. This function always succeeds.
+    /// </summary>
+    /// <param name="p"></param>
+    /// <returns></returns>
+    [LibraryImport(PythonLibraryName)]
+    internal static partial int PyMapping_Check(nint ob);
+
+    /// <summary>
+    /// Return the object from dictionary p which has a key `key`. 
+    /// </summary>
+    /// <param name="dict">Dictionary Object</param>
+    /// <param name="key">Key Object</param>
+    /// <exception cref="KeyNotFoundException">If the key is not found</exception>
+    /// <returns>New reference.</returns>
+    internal static nint PyMapping_GetItem(nint map, nint key)
+    { 
+        return PyObject_GetItem(map, key);
+    }
+
+    /// <summary>
+    /// Insert val into the dictionary p with a key of key. 
+    /// key must be hashable; if it isn’t, TypeError will be raised.  
+    /// This function adds a reference to val and key if successful.
+    /// </summary>
+    /// <param name="dict">PyDict object</param>
+    /// <param name="key">Key</param>
+    /// <param name="value">Value</param>
+    /// <returns>Return 0 on success or -1 on failure.</returns>
+    internal static bool PyMapping_SetItem(nint dict, nint key, nint value)
+    {
+        return PyObject_SetItem(dict, key, value) == 0;
+    }
+
+    /// <summary>
+    /// Get the items iterator for the mapping.
+    /// </summary>
+    /// <param name="dict">Object that implements the mapping protocol</param>
+    /// <returns>New reference to the items().</returns>
+    [LibraryImport(PythonLibraryName)]
+    internal static partial nint PyMapping_Items(nint dict);
+}

--- a/src/CSnakes.Runtime/CPython/Object.cs
+++ b/src/CSnakes.Runtime/CPython/Object.cs
@@ -104,4 +104,25 @@ internal unsafe partial class CPythonAPI
     /// <returns>A new reference to the string representation</returns>
     [LibraryImport(PythonLibraryName)]
     internal static partial nint PyObject_Str(nint ob);
+
+    /// <summary>
+    /// Implements ob[key]
+    /// </summary>
+    /// <param name="ob"></param>
+    /// <param name="key"></param>
+    /// <returns>A new reference to the object item if it exists, else NULL</returns>
+    [LibraryImport(PythonLibraryName)]
+    internal static partial nint PyObject_GetItem(nint ob, nint key);
+
+    /// <summary>
+    /// Set ob[key] = value
+    /// Returns -1 on error and sets exception.
+    /// Does not steal a reference to value on success.
+    /// </summary>
+    /// <param name="ob"></param>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    [LibraryImport(PythonLibraryName)]
+    internal static partial int PyObject_SetItem(nint ob, nint key, nint value);
 }

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.cs
@@ -72,14 +72,15 @@ internal class PyObjectTypeConverter : TypeConverter
                 return ConvertToDictionary(pyObject, destinationType, context, culture);
             }
 
-            if (destinationType.IsAssignableTo(typeof(IEnumerable)) && CPythonAPI.IsPyMapping(handle))
-            {
-                return ConvertToDictionary(pyObject, destinationType, context, culture, useMappingProtocol: true);
-            }
-
             if (destinationType.IsAssignableTo(typeof(IEnumerable)) && CPythonAPI.IsPyList(handle))
             {
                 return ConvertToList(pyObject, destinationType, context, culture);
+            }
+
+            // This needs to come after lists, because sequences are also maps
+            if (destinationType.IsAssignableTo(typeof(IEnumerable)) && CPythonAPI.IsPyMapping(handle))
+            {
+                return ConvertToDictionary(pyObject, destinationType, context, culture, useMappingProtocol: true);
             }
 
             if (destinationType.IsAssignableTo(typeof(ITuple)))

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -51,17 +51,22 @@ public class PyObject : SafeHandle
                 throw new InvalidDataException("An error occurred in Python, but no exception was set.");
             }
             CPythonAPI.PyErr_Fetch(out nint excType, out nint excValue, out nint excTraceback);
-            using var pyExceptionType = new PyObject(excType);
-            using var pyExceptionValue = new PyObject(excValue);
-            var pyExceptionTraceback = new PyObject(excTraceback);
-
-            if (pyExceptionType.IsInvalid || pyExceptionValue.IsInvalid || pyExceptionType.IsInvalid)
+            
+            if (excType == 0)
             {
-                CPythonAPI.PyErr_Clear();
-                throw new InvalidDataException("An error fetching the exceptions in Python.");
+                throw new InvalidDataException("An error occurred in Python, but no exception was set.");
             }
 
-            var pyExceptionStr = pyExceptionValue.ToString();
+            using var pyExceptionType = new PyObject(excType);
+            PyObject? pyExceptionTraceback = excTraceback == IntPtr.Zero ? null : new PyObject(excTraceback);
+
+            var pyExceptionStr = string.Empty;
+            if (excValue != IntPtr.Zero)
+            {
+                using PyObject pyExceptionValue = new PyObject(excValue);
+                pyExceptionStr = pyExceptionValue.ToString();
+            }
+             ;
             // TODO: Consider adding __qualname__ as well for module exceptions that aren't builtins
             var pyExceptionTypeStr = pyExceptionType.GetAttr("__name__").ToString();
             CPythonAPI.PyErr_Clear();

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -65,7 +65,7 @@ public class PyObject : SafeHandle
             // TODO: Consider adding __qualname__ as well for module exceptions that aren't builtins
             var pyExceptionTypeStr = pyExceptionType.GetAttr("__name__").ToString();
             CPythonAPI.PyErr_Clear();
-            throw new PythonException(pyExceptionTypeStr, pyExceptionStr, pyExceptionTraceback);
+            throw new PythonInvocationException(pyExceptionTypeStr, pyExceptionStr, pyExceptionTraceback);
         }
     }
 

--- a/src/CSnakes.Runtime/PythonInvocationException.cs
+++ b/src/CSnakes.Runtime/PythonInvocationException.cs
@@ -6,7 +6,7 @@ namespace CSnakes.Runtime;
 [DebuggerDisplay("Exception Type={PythonExceptionType,nq}, Message={Message,nq}")]
 public class PythonInvocationException : Exception
 {
-    public PythonInvocationException(string exceptionType, string message, PyObject pythonStackTrace) : base($"The Python runtime raised a {exceptionType} exception, see InnerException for details.", new PythonRuntimeException(message, pythonStackTrace))
+    public PythonInvocationException(string exceptionType, string message, PyObject? pythonStackTrace) : base($"The Python runtime raised a {exceptionType} exception, see InnerException for details.", new PythonRuntimeException(message, pythonStackTrace))
     {
         PythonExceptionType = exceptionType;
     }

--- a/src/CSnakes.Runtime/PythonInvocationException.cs
+++ b/src/CSnakes.Runtime/PythonInvocationException.cs
@@ -1,0 +1,15 @@
+﻿using CSnakes.Runtime.Python;
+using System.Diagnostics;
+
+namespace CSnakes.Runtime;
+
+[DebuggerDisplay("Exception Type={PythonExceptionType,nq}, Message={Message,nq}")]
+public class PythonInvocationException : Exception
+{
+    public PythonInvocationException(string exceptionType, string message, PyObject pythonStackTrace) : base($"The Python runtime raised a {exceptionType} exception, see InnerException for details.", new PythonRuntimeException(message, pythonStackTrace))
+    {
+        PythonExceptionType = exceptionType;
+    }
+
+    public string PythonExceptionType { get; }
+}

--- a/src/CSnakes.Runtime/PythonRuntimeException.cs
+++ b/src/CSnakes.Runtime/PythonRuntimeException.cs
@@ -3,12 +3,16 @@
 namespace CSnakes.Runtime;
 public class PythonRuntimeException : Exception
 {
-    private readonly PyObject pythonTracebackObject;
+    private readonly PyObject? pythonTracebackObject;
     private string[]? formattedStackTrace = null;
 
-    public PythonRuntimeException(string message, PyObject traceback): base(message)
+    public PythonRuntimeException(string message, PyObject? traceback): base(message)
     {
         pythonTracebackObject = traceback;
+        if (traceback is null)
+        {
+            return;
+        }
         Data["locals"] = traceback.GetAttr("tb_frame").GetAttr("f_locals").As<IReadOnlyDictionary<string, PyObject>>();
         Data["globals"] = traceback.GetAttr("tb_frame").GetAttr("f_globals").As<IReadOnlyDictionary<string, PyObject>>();
     }
@@ -17,6 +21,10 @@ public class PythonRuntimeException : Exception
     {
         get
         {
+            if (pythonTracebackObject is null)
+            {
+                return Array.Empty<string>();
+            }
             // This is lazy because it's expensive to format the stack trace.
             formattedStackTrace ??= FormatPythonStackTrace(pythonTracebackObject);
             return formattedStackTrace;

--- a/src/Integration.Tests/ExceptionTests.cs
+++ b/src/Integration.Tests/ExceptionTests.cs
@@ -1,6 +1,8 @@
+using CSnakes.Runtime.Python;
+
 namespace Integration.Tests;
 
-public class EndToEndTests : IntegrationTestBase
+public class ExceptionTests : IntegrationTestBase
 {
 
     [Fact]
@@ -8,10 +10,20 @@ public class EndToEndTests : IntegrationTestBase
     {
         var testExceptionsModule = Env.TestExceptions();
         // This should fail. The python function raises an exception.
-        var exception = Assert.Throws<PythonException>(testExceptionsModule.TestRaisePythonException);
-        Assert.Equal("This is a Python exception", exception.Message);
-        Assert.Equal("ValueError", exception.ExceptionType);
-        Assert.Single(exception.PythonStackTrace);
-        Assert.Contains("in test_raise_python_exception", exception.PythonStackTrace[0]);
+        var exception = Assert.Throws<PythonInvocationException>(testExceptionsModule.TestRaisePythonException);
+        Assert.NotNull(exception.InnerException);
+        Assert.Equal("This is a Python exception", exception.InnerException.Message);
+        Assert.Equal("ValueError", exception.PythonExceptionType);
+        var pythonRuntimeException = (PythonRuntimeException)exception.InnerException;
+        Assert.Single(pythonRuntimeException.PythonStackTrace);
+        Assert.Contains("in test_raise_python_exception", pythonRuntimeException.PythonStackTrace[0]);
+        // Get the frame locals from the inner exception
+        Assert.NotNull(pythonRuntimeException.Data["locals"]);
+        var topFrameLocals = (IReadOnlyDictionary<string, PyObject>) pythonRuntimeException.Data["locals"];
+        Assert.NotNull(topFrameLocals);
+        Assert.Equal(1, topFrameLocals["a"].As<long>());
+        Assert.Equal(2, topFrameLocals["b"].As<long>());
+        var topFrameGlobals = (IReadOnlyDictionary<string, PyObject>)pythonRuntimeException.Data["globals"];
+        Assert.Equal(topFrameGlobals["some_global"].ToString(), "1337");
     }
 }

--- a/src/Integration.Tests/python/test_exceptions.py
+++ b/src/Integration.Tests/python/test_exceptions.py
@@ -1,2 +1,6 @@
+some_global = 1337
+
 def test_raise_python_exception() -> str:
+    a = 1
+    b = 2
     raise ValueError("This is a Python exception")


### PR DESCRIPTION
`PythonException` is now `PythonInvocationException`.
It always has an innerexception of `PythonRuntimeException`.