### PR TITLE
Fixing how we generate packages with debug info

### DIFF
--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   DOTNET_VERSION: 8.0.x
+  DOTNET_CONFIGURATION: Release
 
 jobs:
   publish-github-packages:
@@ -30,15 +31,15 @@ jobs:
         run: dotnet restore
         working-directory: src
 
-      - name: Build release packages
-        run: dotnet build --no-restore -c Release
+      - name: Build ${{ env.DOTNET_CONFIGURATION }} packages
+        run: dotnet build --no-restore -c ${{ env.DOTNET_CONFIGURATION }}
         working-directory: src
 
       - name: Publish NuGet package CSnakes
-        run: dotnet pack src/CSnakes --no-build -c Release -o ./nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
+        run: dotnet pack src/CSnakes --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack src/CSnakes.Runtime --no-build -c Release -o ./nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
+        run: dotnet pack src/CSnakes.Runtime --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
 
       - name: Publish NuGet packages as artifacts
         uses: actions/upload-artifact@v4
@@ -48,6 +49,3 @@ jobs:
 
       - name: Publish to GitHub packages
         run: dotnet nuget push ./nuget/*.nupkg --source "https://nuget.pkg.github.com/tonybaloney/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to GitHub packages (symbols)
-        run: dotnet nuget push ./nuget/*.snupkg --source "https://nuget.pkg.github.com/tonybaloney/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   DOTNET_VERSION: 8.0.x
+  DOTNET_CONFIGURATION: Release
 
 jobs:
   publish-github-packages:
@@ -30,15 +31,15 @@ jobs:
         run: dotnet restore
         working-directory: src
 
-      - name: Build release packages
-        run: dotnet build --no-restore -c Release
+      - name: Build ${{ env.DOTNET_CONFIGURATION }} packages
+        run: dotnet build --no-restore -c ${{ env.DOTNET_CONFIGURATION }}
         working-directory: src
 
       - name: Publish NuGet package CSnakes
-        run: dotnet pack src/CSnakes --no-build -c Release -o ./nuget -p:VersionSuffix='beta.${{ github.run_number }}'
+        run: dotnet pack src/CSnakes --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='beta.${{ github.run_number }}'
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack src/CSnakes.Runtime --no-build -c Release -o ./nuget -p:VersionSuffix='beta.${{ github.run_number }}'
+        run: dotnet pack src/CSnakes.Runtime --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='beta.${{ github.run_number }}'
 
       - name: Publish NuGet packages as artifacts
         uses: actions/upload-artifact@v4
@@ -46,8 +47,5 @@ jobs:
           name: nuget-packages
           path: ./nuget
 
-      - name: Publish to GitHub packages
+      - name: Publish to NuGet
         run: dotnet nuget push ./nuget/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }}
-
-      - name: Publish to GitHub packages (Symbols)
-        run: dotnet nuget push ./nuget/*.snupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/dotnet-publish-release.yml
+++ b/.github/workflows/dotnet-publish-release.yml
@@ -50,15 +50,8 @@ jobs:
       - name: Publish to GitHub packages
         run: dotnet nuget push ./nuget/*.nupkg --source "https://nuget.pkg.github.com/tonybaloney/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to GitHub packages (Symbols)
-        run: dotnet nuget push ./nuget/*.snupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }}
-
-      - name: Publish to GitHub packages (Symbols)
-        run: dotnet nuget push ./nuget/*.snupkg --source "https://nuget.pkg.github.com/tonybaloney/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
-
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             ./nuget/*.nupkg
-            ./nuget/*.snupkg

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,9 +27,7 @@
 
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <IncludeSymbols>true</IncludeSymbols>
         <DebugType>embedded</DebugType>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
Since DebugType is embedded the PDBs aren't generated, instead the metadata for that is put into the DLL that the compiler generates. We then don't need to generate a snupkg since that won't contain anything (there's no PDB), so we don't need to publish that anywhere.
Also, IncludeSymbols isn't 'add symbols to the build output' but 'create a symbols NuGet package'. See https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#includesymbols
