### PR TITLE
Add methods to `PyObject` for `Is`, `Equals` and `NotEquals`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -63,6 +63,38 @@ if (obj.IsNone())
 }
 ```
 
+## Object comparisons
+
+The `PyObject` types can be compared with one another using the `is`, `==` and `!=` operators from Python. 
+
+The equivalent to the `x is y` operator in Python is :
+
+```csharp
+// Small numbers are the same object in Python (weird implementation detail)
+PyObject obj1 = PyObject.From(true);
+PyObject obj2 = PyObject.From(true);
+if (obj1!.Is(obj2))
+    Console.WriteLine("Objects are the same!");
+```
+
+Equality can be accessed from the `.Equals` method or using the `==` operators in C#:
+
+```csharp
+PyObject obj1 = PyObject.From(3.0);
+PyObject obj2 = PyObject.From(3);
+if (obj1 == obj2) 
+    Console.WriteLine("Objects are equal!");
+```
+
+Inequality can be accessed from the `.NotEquals` method or using the `!=` operators in C#:
+
+```csharp
+PyObject obj1 = PyObject.From(3.0);
+PyObject obj2 = PyObject.From(3);
+if (obj1 != obj2) 
+    Console.WriteLine("Objects are not equal!");
+```
+
 ## Python Locators
 
 CSnakes uses a `PythonLocator` to find the Python runtime on the host machine. The `PythonLocator` is a service that is registered with the dependency injection container and is used to find the Python runtime on the host machine.

--- a/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
@@ -82,5 +82,51 @@ public class PyObjectTests : RuntimeTestBase
         var obj5 = PyObject.From(42);
         var obj6 = PyObject.From(43);
         Assert.False(obj5!.Equals(obj6!));
+
+        var obj7 = PyObject.From(42123434);
+        var obj8 = PyObject.From(42123434);
+        Assert.True(obj7 == obj8);
+
+        var obj9 = PyObject.From("Hello");
+        var obj10 = PyObject.From<IEnumerable<string>>(["Hello"]);
+        Assert.False(obj9!.Equals(obj10!));
+
+        // Test rich comparisons of mixed types
+        var obj11 = PyObject.From(3.0);
+        var obj12 = PyObject.From(3);
+        Assert.True(obj11!.Equals(obj12!));
+        Assert.True(obj11 == obj12);
+    }
+
+    [Fact]
+    public void TestObjectNotEquals()
+    {
+        var obj1 = PyObject.None;
+        var obj2 = PyObject.None;
+        Assert.False(obj1.NotEquals(obj2));
+        Assert.False(obj1 != obj2);
+
+        var obj3 = PyObject.From(42);
+        var obj4 = PyObject.From(42);
+        Assert.False(obj3!.NotEquals(obj4!));
+        Assert.False(obj3 != obj4);
+
+        var obj5 = PyObject.From(42);
+        var obj6 = PyObject.From(43);
+        Assert.True(obj5!.NotEquals(obj6!));
+
+        var obj7 = PyObject.From(42123434);
+        var obj8 = PyObject.From(42123434);
+        Assert.False(obj7 != obj8);
+
+        var obj9 = PyObject.From("Hello");
+        var obj10 = PyObject.From<IEnumerable<string>>(["Hello"]);
+        Assert.True(obj9!.NotEquals(obj10!));
+
+        // Test rich comparisons of mixed types
+        var obj11 = PyObject.From(3.0);
+        var obj12 = PyObject.From(4);
+        Assert.True(obj11!.NotEquals(obj12!));
+        Assert.True(obj11 != obj12);
     }
 }

--- a/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
@@ -79,37 +79,39 @@ public class PyObjectTests : RuntimeTestBase
     {
         using var obj1 = PyObject.From(o1);
         using var obj2 = PyObject.From(o2);
-        Assert.True(obj1.Equals(obj2));
+        Assert.True(obj1!.Equals(obj2));
         Assert.True(obj1 == obj2);
     }
 
+    [Fact]
     public void TestObjectEqualsCollection()
     {
         using var obj1 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
         using var obj2 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
-        Assert.False(obj1.Equals(obj2));
-        Assert.False(obj1 == obj2);
+        Assert.True(obj1!.Equals(obj2));
+        Assert.True(obj1 == obj2);
     }
 
     [InlineData(null, true)]
     [InlineData(42, 44)]
     [InlineData(42123434, 421234)]
     [InlineData("Hello!", "Hello?")]
-    [InlineData(3, 3.0)]
+    [InlineData(3, 3.2)]
     [Theory]
     public void TestObjectNotEquals(object? o1, object? o2)
     {
         using var obj1 = PyObject.From(o1);
         using var obj2 = PyObject.From(o2);
-        Assert.False(obj1.NotEquals(obj2));
-        Assert.False(obj1 != obj2);
+        Assert.True(obj1!.NotEquals(obj2));
+        Assert.True(obj1 != obj2);
     }
 
+    [Fact]
     public void TestObjectNotEqualsCollection()
     {
         using var obj1 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
         using var obj2 = PyObject.From<IEnumerable<string>>(["Hello?", "World?"]);
-        Assert.False(obj1.NotEquals(obj2));
-        Assert.False(obj1 != obj2);
+        Assert.True(obj1!.NotEquals(obj2));
+        Assert.True(obj1 != obj2);
     }
 }

--- a/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
@@ -1,58 +1,44 @@
 ﻿using CSnakes.Runtime.Python;
-using System.ComponentModel;
 
 namespace CSnakes.Runtime.Tests.Python;
 public class PyObjectTests : RuntimeTestBase
 {
-    private TypeConverter td = TypeDescriptor.GetConverter(typeof(PyObject));
 
     [Fact]
     public void TestToString()
     {
-        using (GIL.Acquire())
-        {
-            using PyObject? pyObj = td.ConvertFromString("Hello, World!") as PyObject;
-            Assert.NotNull(pyObj);
-            Assert.Equal("Hello, World!", pyObj!.ToString());
-        }
+        using PyObject? pyObj = PyObject.From("Hello, World!");
+        Assert.NotNull(pyObj);
+        Assert.Equal("Hello, World!", pyObj!.ToString());
     }
 
     [Fact]
     public void TestObjectType()
     {
-        using (GIL.Acquire())
-        {
-            using PyObject? pyObj = td.ConvertFromString("Hello, World!") as PyObject;
-            Assert.NotNull(pyObj);
-            Assert.Equal("<class 'str'>", pyObj!.GetPythonType().ToString());
-        }
+        using PyObject? pyObj = PyObject.From("Hello, World!");
+        Assert.NotNull(pyObj);
+        Assert.Equal("<class 'str'>", pyObj!.GetPythonType().ToString());
     }
 
     [Fact]
     public void TestObjectGetAttr()
     {
-        using (GIL.Acquire())
-        {
-            using PyObject? pyObj = td.ConvertFromString("Hello, World!") as PyObject;
-            Assert.NotNull(pyObj);
-            Assert.True(pyObj!.HasAttr("__doc__"));
-            using PyObject? pyObjDoc = pyObj!.GetAttr("__doc__");
-            Assert.NotNull(pyObjDoc);
-            Assert.Contains("Create a new string ", pyObjDoc!.ToString());
-        }
+        using PyObject? pyObj = PyObject.From("Hello, World!");
+        Assert.NotNull(pyObj);
+        Assert.True(pyObj!.HasAttr("__doc__"));
+        using PyObject? pyObjDoc = pyObj!.GetAttr("__doc__");
+        Assert.NotNull(pyObjDoc);
+        Assert.Contains("Create a new string ", pyObjDoc!.ToString());
     }
 
     [Fact]
     public void TestObjectGetRepr()
     {
-        using (GIL.Acquire())
-        {
-            using PyObject? pyObj = td.ConvertFromString("hello") as PyObject;
-            Assert.NotNull(pyObj);
-            string pyObjDoc = pyObj!.GetRepr();
-            Assert.False(string.IsNullOrEmpty(pyObjDoc));
-            Assert.Contains("'hello'", pyObjDoc);
-        }
+        using PyObject? pyObj = PyObject.From("hello");
+        Assert.NotNull(pyObj);
+        string pyObjDoc = pyObj!.GetRepr();
+        Assert.False(string.IsNullOrEmpty(pyObjDoc));
+        Assert.Contains("'hello'", pyObjDoc);
     }
 
     [Fact]
@@ -60,10 +46,41 @@ public class PyObjectTests : RuntimeTestBase
     {
         using (GIL.Acquire())
         {
-            using PyObject? pyObj = td.ConvertFromString("hello") as PyObject;
+            using PyObject? pyObj = PyObject.From("hello");
             Assert.NotNull(pyObj);
             pyObj.Dispose();
             Assert.Throws<ObjectDisposedException>(() => pyObj!.ToString());
         }
+    }
+
+    [Fact]
+    public void TestObjectIs()
+    {
+        var obj1 = PyObject.None;
+        var obj2 = PyObject.None;
+        Assert.True(obj2.Is(obj2));
+
+        // Small numbers are the same object in Python
+        var obj3 = PyObject.From(42);
+        var obj4 = PyObject.From(42);
+        Assert.True(obj3!.Is(obj4!));
+    }
+
+    [Fact]
+    public void TestObjectEquals()
+    {
+        var obj1 = PyObject.None;
+        var obj2 = PyObject.None;
+        Assert.True(obj1.Equals(obj2));
+        Assert.True(obj1 == obj2);
+
+        var obj3 = PyObject.From(42);
+        var obj4 = PyObject.From(42);
+        Assert.True(obj3!.Equals(obj4!));
+        Assert.True(obj3 == obj4);
+
+        var obj5 = PyObject.From(42);
+        var obj6 = PyObject.From(43);
+        Assert.False(obj5!.Equals(obj6!));
     }
 }

--- a/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
@@ -54,79 +54,62 @@ public class PyObjectTests : RuntimeTestBase
     }
 
     [Fact]
-    public void TestObjectIs()
+    public void TestObjectIsNone()
     {
         var obj1 = PyObject.None;
         var obj2 = PyObject.None;
         Assert.True(obj2.Is(obj2));
-
-        // Small numbers are the same object in Python
-        var obj3 = PyObject.From(42);
-        var obj4 = PyObject.From(42);
-        Assert.True(obj3!.Is(obj4!));
     }
 
     [Fact]
-    public void TestObjectEquals()
+    public void TestObjectIsSmallIntegers() {
+        // Small numbers are the same object in Python, weird implementation detail. 
+        var obj1 = PyObject.From(42);
+        var obj2 = PyObject.From(42);
+        Assert.True(obj1!.Is(obj2!));
+    }
+
+    [InlineData(null, null)]
+    [InlineData(42, 42)]
+    [InlineData(42123434, 42123434)]
+    [InlineData("Hello!", "Hello!")]
+    [InlineData(3, 3.0)]
+    [Theory]
+    public void TestObjectEquals(object? o1, object? o2)
     {
-        var obj1 = PyObject.None;
-        var obj2 = PyObject.None;
+        using var obj1 = PyObject.From(o1);
+        using var obj2 = PyObject.From(o2);
         Assert.True(obj1.Equals(obj2));
         Assert.True(obj1 == obj2);
-
-        var obj3 = PyObject.From(42);
-        var obj4 = PyObject.From(42);
-        Assert.True(obj3!.Equals(obj4!));
-        Assert.True(obj3 == obj4);
-
-        var obj5 = PyObject.From(42);
-        var obj6 = PyObject.From(43);
-        Assert.False(obj5!.Equals(obj6!));
-
-        var obj7 = PyObject.From(42123434);
-        var obj8 = PyObject.From(42123434);
-        Assert.True(obj7 == obj8);
-
-        var obj9 = PyObject.From("Hello");
-        var obj10 = PyObject.From<IEnumerable<string>>(["Hello"]);
-        Assert.False(obj9!.Equals(obj10!));
-
-        // Test rich comparisons of mixed types
-        var obj11 = PyObject.From(3.0);
-        var obj12 = PyObject.From(3);
-        Assert.True(obj11!.Equals(obj12!));
-        Assert.True(obj11 == obj12);
     }
 
-    [Fact]
-    public void TestObjectNotEquals()
+    public void TestObjectEqualsCollection()
     {
-        var obj1 = PyObject.None;
-        var obj2 = PyObject.None;
+        using var obj1 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
+        using var obj2 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
+        Assert.False(obj1.Equals(obj2));
+        Assert.False(obj1 == obj2);
+    }
+
+    [InlineData(null, true)]
+    [InlineData(42, 44)]
+    [InlineData(42123434, 421234)]
+    [InlineData("Hello!", "Hello?")]
+    [InlineData(3, 3.0)]
+    [Theory]
+    public void TestObjectNotEquals(object? o1, object? o2)
+    {
+        using var obj1 = PyObject.From(o1);
+        using var obj2 = PyObject.From(o2);
         Assert.False(obj1.NotEquals(obj2));
         Assert.False(obj1 != obj2);
+    }
 
-        var obj3 = PyObject.From(42);
-        var obj4 = PyObject.From(42);
-        Assert.False(obj3!.NotEquals(obj4!));
-        Assert.False(obj3 != obj4);
-
-        var obj5 = PyObject.From(42);
-        var obj6 = PyObject.From(43);
-        Assert.True(obj5!.NotEquals(obj6!));
-
-        var obj7 = PyObject.From(42123434);
-        var obj8 = PyObject.From(42123434);
-        Assert.False(obj7 != obj8);
-
-        var obj9 = PyObject.From("Hello");
-        var obj10 = PyObject.From<IEnumerable<string>>(["Hello"]);
-        Assert.True(obj9!.NotEquals(obj10!));
-
-        // Test rich comparisons of mixed types
-        var obj11 = PyObject.From(3.0);
-        var obj12 = PyObject.From(4);
-        Assert.True(obj11!.NotEquals(obj12!));
-        Assert.True(obj11 != obj12);
+    public void TestObjectNotEqualsCollection()
+    {
+        using var obj1 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
+        using var obj2 = PyObject.From<IEnumerable<string>>(["Hello?", "World?"]);
+        Assert.False(obj1.NotEquals(obj2));
+        Assert.False(obj1 != obj2);
     }
 }

--- a/src/CSnakes.Runtime/CPython/Object.cs
+++ b/src/CSnakes.Runtime/CPython/Object.cs
@@ -154,4 +154,20 @@ internal unsafe partial class CPythonAPI
     /// <returns></returns>
     [LibraryImport(PythonLibraryName)]
     internal static partial int PyObject_SetItem(PyObject ob, PyObject key, PyObject value);
+
+    [LibraryImport(PythonLibraryName)]
+    internal static partial int PyObject_Hash(PyObject ob);
+
+    internal static bool PyObject_Equals(PyObject ob1, PyObject ob2)
+    {
+        int result = PyObject_RichCompareBool(ob1, ob2, 2);
+        if (result == -1)
+        {
+            PyObject.ThrowPythonExceptionAsClrException();
+        }
+        return result == 1;
+    }
+
+    [LibraryImport(PythonLibraryName)]
+    internal static partial int PyObject_RichCompareBool(PyObject ob1, PyObject ob2, int opid);
 }

--- a/src/CSnakes.Runtime/CPython/Object.cs
+++ b/src/CSnakes.Runtime/CPython/Object.cs
@@ -4,13 +4,15 @@ using System.Runtime.InteropServices;
 namespace CSnakes.Runtime.CPython;
 internal unsafe partial class CPythonAPI
 {
-    /* Rich comparison opcodes */
-    const int Py_LT = 0;
-    const int Py_LE = 1;
-    const int Py_EQ = 2;
-    const int Py_NE = 3;
-    const int Py_GT = 4;
-    const int Py_GE = 5;
+    internal enum RichComparisonType : int
+    {
+        LessThan = 0,
+        LessThanEqual = 1,
+        Equal = 2,
+        NotEqual = 3,
+        GreaterThan = 4,
+        GreaterThanEqual = 5
+    }
 
     [LibraryImport(PythonLibraryName)]
     internal static partial IntPtr PyObject_Repr(PyObject ob);
@@ -166,19 +168,9 @@ internal unsafe partial class CPythonAPI
     [LibraryImport(PythonLibraryName)]
     internal static partial int PyObject_Hash(PyObject ob);
 
-    internal static bool PyObject_Equals(PyObject ob1, PyObject ob2)
+    internal static bool PyObject_RichCompare(PyObject ob1, PyObject ob2, RichComparisonType comparisonType)
     {
-        int result = PyObject_RichCompareBool(ob1, ob2, Py_EQ);
-        if (result == -1)
-        {
-            PyObject.ThrowPythonExceptionAsClrException();
-        }
-        return result == 1;
-    }
-
-    internal static bool PyObject_NotEquals(PyObject ob1, PyObject ob2)
-    {
-        int result = PyObject_RichCompareBool(ob1, ob2, Py_NE);
+        int result = PyObject_RichCompareBool(ob1, ob2, comparisonType);
         if (result == -1)
         {
             PyObject.ThrowPythonExceptionAsClrException();
@@ -187,5 +179,5 @@ internal unsafe partial class CPythonAPI
     }
 
     [LibraryImport(PythonLibraryName)]
-    internal static partial int PyObject_RichCompareBool(PyObject ob1, PyObject ob2, int opid);
+    internal static partial int PyObject_RichCompareBool(PyObject ob1, PyObject ob2, RichComparisonType comparisonType);
 }

--- a/src/CSnakes.Runtime/CPython/Object.cs
+++ b/src/CSnakes.Runtime/CPython/Object.cs
@@ -4,6 +4,14 @@ using System.Runtime.InteropServices;
 namespace CSnakes.Runtime.CPython;
 internal unsafe partial class CPythonAPI
 {
+    /* Rich comparison opcodes */
+    const int Py_LT = 0;
+    const int Py_LE = 1;
+    const int Py_EQ = 2;
+    const int Py_NE = 3;
+    const int Py_GT = 4;
+    const int Py_GE = 5;
+
     [LibraryImport(PythonLibraryName)]
     internal static partial IntPtr PyObject_Repr(PyObject ob);
 
@@ -160,7 +168,17 @@ internal unsafe partial class CPythonAPI
 
     internal static bool PyObject_Equals(PyObject ob1, PyObject ob2)
     {
-        int result = PyObject_RichCompareBool(ob1, ob2, 2);
+        int result = PyObject_RichCompareBool(ob1, ob2, Py_EQ);
+        if (result == -1)
+        {
+            PyObject.ThrowPythonExceptionAsClrException();
+        }
+        return result == 1;
+    }
+
+    internal static bool PyObject_NotEquals(PyObject ob1, PyObject ob2)
+    {
+        int result = PyObject_RichCompareBool(ob1, ob2, Py_NE);
         if (result == -1)
         {
             PyObject.ThrowPythonExceptionAsClrException();

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -195,6 +195,34 @@ public class PyObject : SafeHandle
         return base.Equals(obj);
     }
 
+    public bool NotEquals(object? obj)
+    {
+        if (obj is PyObject pyObj1)
+        {
+            if (Is(pyObj1))
+                return false;
+
+            using (GIL.Acquire())
+            {
+                return CPythonAPI.PyObject_NotEquals(this, pyObj1);
+            }
+        }
+        return !base.Equals(obj);
+    }
+
+    public static bool operator ==(PyObject? left, PyObject? right)
+    {
+        if (left is null)
+            return right is null;
+        return left.Equals(right);
+    }
+    public static bool operator !=(PyObject? left, PyObject? right)
+    {
+        if (left is null)
+            return right is not null;
+        return left.NotEquals(right);
+    }
+
     public override int GetHashCode()
     {
         using (GIL.Acquire())

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -189,7 +189,7 @@ public class PyObject : SafeHandle
 
             using (GIL.Acquire())
             {
-                return CPythonAPI.PyObject_Equals(this, pyObj1);
+                return CPythonAPI.PyObject_RichCompare(this, pyObj1, CPythonAPI.RichComparisonType.Equal);
             }
         }
         return base.Equals(obj);
@@ -204,7 +204,7 @@ public class PyObject : SafeHandle
 
             using (GIL.Acquire())
             {
-                return CPythonAPI.PyObject_NotEquals(this, pyObj1);
+                return CPythonAPI.PyObject_RichCompare(this, pyObj1, CPythonAPI.RichComparisonType.NotEqual);
             }
         }
         return !base.Equals(obj);


### PR DESCRIPTION
Also adds operator overloads. 

This now works:

```csharp
// Test rich comparisons of mixed types
var obj11 = PyObject.From(3.0);
var obj12 = PyObject.From(3);
Assert.True(obj11!.Equals(obj12!));
Assert.True(obj11 == obj12);
```