### PR TITLE
Fix NuGet packages override path combination

### DIFF
--- a/src/CSnakes.Runtime/Locators/NuGetLocator.cs
+++ b/src/CSnakes.Runtime/Locators/NuGetLocator.cs
@@ -11,9 +11,9 @@ internal class NuGetLocator(Version version) : PythonLocator(version)
         {
             throw new DirectoryNotFoundException("Neither NUGET_PACKAGES or USERPROFILE environments variable were found, which are needed to locate the NuGet package cache.");
         }
-        string? globalNugetPackagesPath = string.IsNullOrEmpty(nugetPackagesOverride) ? userProfile : nugetPackagesOverride;
+        string? globalNugetPackagesPath = string.IsNullOrEmpty(nugetPackagesOverride) ? Path.Combine(userProfile, ".nuget", "packages") : nugetPackagesOverride;
         // TODO : Load optional path from nuget settings. https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders
-        string nugetPath = Path.Combine(globalNugetPackagesPath!, ".nuget", "packages", "python", $"{Version.Major}.{Version.Minor}.{Version.Build}", "tools");
+        string nugetPath = Path.Combine(globalNugetPackagesPath!, "python", $"{Version.Major}.{Version.Minor}.{Version.Build}", "tools");
         return LocatePythonInternal(nugetPath);
     }
 


### PR DESCRIPTION
This PR fixes the path that's combined in `NuGetLocator` when `NUGET_PACKAGES` _is_ defined.

On my machine, I have `NUGET_PACKAGES` defined as `C:\dev\packages\nuget` (because I have [package caches located on a Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/#storing-package-cache-on-dev-drive)). When I checked out `main`, which was at commit b39fc5e99f5a721b3db7f077727659d3fcf544df at the time, and ran the tests using:

    dotnet test src

all the runtime and integration tests failed due to the error:

	System.IO.DirectoryNotFoundException
	Python not found at C:\dev\packages\nuget\.nuget\packages\python\3.12.4\tools.

One full example of such an error with the stack trace from a test was:

	System.IO.DirectoryNotFoundException
	Python not found at C:\dev\packages\nuget\.nuget\packages\python\3.12.4\tools.
	   at CSnakes.Runtime.Locators.PythonLocator.LocatePythonInternal(String folder, Boolean freeThreaded) in A:\CSnakes\main\src\CSnakes.Runtime\Locators\PythonLocator.cs:line 104
	   at CSnakes.Runtime.Locators.NuGetLocator.LocatePython() in A:\CSnakes\main\src\CSnakes.Runtime\Locators\NuGetLocator.cs:line 17
	   at CSnakes.Runtime.PythonEnvironment.<>c.<.ctor>b__9_1(PythonLocator locator) in A:\CSnakes\main\src\CSnakes.Runtime\PythonEnvironment.cs:line 42
	   at System.Linq.Enumerable.WhereSelectArrayIterator`2.MoveNext()
	   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
	   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
	   at CSnakes.Runtime.PythonEnvironment..ctor(IEnumerable`1 locators, IEnumerable`1 packageInstallers, PythonEnvironmentOptions options, ILogger`1 logger) in A:\CSnakes\main\src\CSnakes.Runtime\PythonEnvironment.cs:line 40
	   at CSnakes.Runtime.PythonEnvironment.GetPythonEnvironment(IEnumerable`1 locators, IEnumerable`1 packageInstallers, PythonEnvironmentOptions options, ILogger`1 logger) in A:\CSnakes\main\src\CSnakes.Runtime\PythonEnvironment.cs:line 26
	   at CSnakes.Runtime.IServiceCollectionExtensions.<>c.<WithPython>b__0_0(IServiceProvider sp) in A:\CSnakes\main\src\CSnakes.Runtime\IServiceCollectionExtensions.cs:line 32
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite callSite, RuntimeResolverContext context)
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
	   at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
	   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
	   at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
	   at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType)
	   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
	   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
	   at CSnakes.Runtime.Tests.RuntimeTestBase..ctor() in A:\CSnakes\main\src\CSnakes.Runtime.Tests\RuntimeTestBase.cs:line 32
	   at CSnakes.Runtime.Tests.Converter.ConverterTestBase..ctor()
	   at CSnakes.Runtime.Tests.Converter.BigIntegerConverterTest..ctor()
	   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)

It seems that when `NUGET_PACKAGES` is defined, the packages are located directly under it whereas the code was appending `.nuget\packages` whether `NUGET_PACKAGES` was defined or not.

This PR fixes the problem by only appending `.nuget\packages` to the `USERPROFILE` case, when `NUGET_PACKAGES` is undefined.

After this fix, all tests passed.
