### PR TITLE
Fix path to read-me doc in VS solution file

### DIFF
--- a/src/CSnakes.sln
+++ b/src/CSnakes.sln
@@ -6,7 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{24D80700-8F01-41C7-B858-2C1B242C4EE0}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
-		README.md = README.md
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSnakes", "CSnakes\CSnakes.csproj", "{3912E0F4-493B-4B26-A44D-B095F6CF7538}"


### PR DESCRIPTION
This PR fixes the path to the read-me document in Visual Studio solution file otherwise trying to open the file from the Solution Explorer in Visual Studio would give the error: _The document cannot be opened. It has been renamed, deleted or moved._