### PR TITLE
Resolve reported paths

### DIFF
--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -11,7 +11,7 @@ internal class PipInstaller(ILogger<PipInstaller> logger) : IPythonPackageInstal
     public Task InstallPackages(string home, string? virtualEnvironmentLocation)
     {
         // TODO:Allow overriding of the requirements file name.
-        string requirementsPath = Path.Combine(home, requirementsFileName);
+        string requirementsPath = Path.GetFullPath(Path.Combine(home, requirementsFileName));
         if (File.Exists(requirementsPath))
         {
             logger.LogInformation("File {Requirements} was found.", requirementsPath);
@@ -36,6 +36,7 @@ internal class PipInstaller(ILogger<PipInstaller> logger) : IPythonPackageInstal
 
         if (virtualEnvironmentLocation is not null)
         {
+            virtualEnvironmentLocation = Path.GetFullPath(virtualEnvironmentLocation);
             logger.LogInformation("Using virtual environment at {VirtualEnvironmentLocation} to install packages with pip.", virtualEnvironmentLocation);
             string venvScriptPath = Path.Combine(virtualEnvironmentLocation, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Scripts" : "bin");
             // TODO: Check that the pip executable exists, and if not, raise an exception with actionable steps.

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -51,6 +51,7 @@ internal class PythonEnvironment : IPythonEnvironment
         string home = options.Home;
         string[] extraPaths = options.ExtraPaths;
 
+        home = Path.GetFullPath(home);
         if (!Directory.Exists(home))
         {
             logger.LogError("Python home directory does not exist: {Home}", home);
@@ -96,23 +97,24 @@ internal class PythonEnvironment : IPythonEnvironment
         api.Initialize();
     }
 
-    private void EnsureVirtualEnvironment(PythonLocationMetadata pythonLocation, string? venvPath)
+    private void EnsureVirtualEnvironment(PythonLocationMetadata pythonLocation, string? virtualEnvironmentLocation)
     {
-        if (venvPath is null)
+        if (virtualEnvironmentLocation is null)
         {
             Logger.LogError("Virtual environment location is not set but it was requested to be created.");
-            throw new ArgumentNullException(nameof(venvPath), "Virtual environment location is not set.");
+            throw new ArgumentNullException(nameof(virtualEnvironmentLocation), "Virtual environment location is not set.");
         }
 
-        if (!Directory.Exists(venvPath))
+        virtualEnvironmentLocation = Path.GetFullPath(virtualEnvironmentLocation);
+        if (!Directory.Exists(virtualEnvironmentLocation))
         {
-            Logger.LogInformation("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", venvPath, pythonLocation.PythonBinaryPath);
-            using Process process1 = ExecutePythonCommand(pythonLocation, venvPath, $"-VV");
-            using Process process2 = ExecutePythonCommand(pythonLocation, venvPath, $"-m venv {venvPath}");
+            Logger.LogInformation("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", virtualEnvironmentLocation, pythonLocation.PythonBinaryPath);
+            using Process process1 = ExecutePythonCommand(pythonLocation, virtualEnvironmentLocation, $"-VV");
+            using Process process2 = ExecutePythonCommand(pythonLocation, virtualEnvironmentLocation, $"-m venv {virtualEnvironmentLocation}");
         }
         else
         {
-            Logger.LogDebug("Virtual environment already exists at {VirtualEnvPath}", venvPath);
+            Logger.LogDebug("Virtual environment already exists at {VirtualEnvPath}", virtualEnvironmentLocation);
         }
 
         Process ExecutePythonCommand(PythonLocationMetadata pythonLocation, string? venvPath, string arguments)


### PR DESCRIPTION
* Before
```
info: CSnakes.Runtime.IPythonEnvironment[0]
      Setting up Python environment from C:\Users\user\.nuget\packages\python\3.12.4\tools using home of D:\Development\Hackathon-CSnakes\samples\simple\QuickConsoleTest\bin\Debug\net8.0\..\..\..\..\ExamplePythonDependency
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      File D:\Development\Hackathon-CSnakes\samples\simple\QuickConsoleTest\bin\Debug\net8.0\..\..\..\..\ExamplePythonDependency\requirements.txt was found.
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Using virtual environment at D:\Development\Hackathon-CSnakes\samples\simple\QuickConsoleTest\bin\Debug\net8.0\..\..\..\..\ExamplePythonDependency\.venv to install packages with pip.
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Requirement already satisfied: numpy in d:\development\hackathon-csnakes\samples\simple\examplepythondependency\.venv\lib\site-packages (from -r requirements.txt (line 1)) (2.1.1)
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Collecting scikit-learn (from -r requirements.txt (line 2))
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
        Using cached scikit_learn-1.5.2-cp312-cp312-win_amd64.whl.metadata (13 kB)
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Requirement already satisfied: wheel in d:\development\hackathon-csnakes\samples\simple\examplepythondependency\.venv\lib\site-packages (from -r requirements.txt (line 3)) (0.44.0)
```

* After
```
info: CSnakes.Runtime.IPythonEnvironment[0]
      Setting up Python environment from C:\Users\user\.nuget\packages\python\3.12.4\tools using home of D:\Development\Hackathon-CSnakes\samples\simple\ExamplePythonDependency
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      File D:\Development\Hackathon-CSnakes\samples\simple\ExamplePythonDependency\requirements.txt was found.
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Using virtual environment at D:\Development\Hackathon-CSnakes\samples\simple\ExamplePythonDependency\.venv to install packages with pip.
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Requirement already satisfied: numpy in d:\development\hackathon-csnakes\samples\simple\examplepythondependency\.venv\lib\site-packages (from -r requirements.txt (line 1)) (2.1.1)
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Collecting scikit-learn (from -r requirements.txt (line 2))
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
        Using cached scikit_learn-1.5.2-cp312-cp312-win_amd64.whl.metadata (13 kB)
info: CSnakes.Runtime.PackageManagement.PipInstaller[0]
      Requirement already satisfied: wheel in d:\development\hackathon-csnakes\samples\simple\examplepythondependency\.venv\lib\site-packages (from -r requirements.txt (line 3)) (0.44.0)
```