### PR TITLE
Fix broken links to examples in docs

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 ## Most Basic Example
 
-In the sample solution, the file [`hello_world.py`](https://github.com/tonybaloney/CSnakes/blob/main/samples/ExamplePythonDependency/hello_world.py) demonstrates the most basic example of embedding Python code into a .NET project.
+In the sample solution, the file [`hello_world.py`](https://github.com/tonybaloney/CSnakes/blob/main/samples/simple/ExamplePythonDependency/hello_world.py) demonstrates the most basic example of embedding Python code into a .NET project.
 
 The Python file contains a single function `hello_world` that takes a single argument `name` and returns a greeting message. It takes an optional `int` of the maximum length of the greeting message, which defaults to 50.
 
@@ -19,7 +19,7 @@ public string FormatName(string name, long maxLength = 50);
 
 ## KMeans Example
 
-A more complex example is the [`kmeans_example.py`](https://github.com/tonybaloney/CSnakes/blob/main/samples/ExamplePythonDependency/kmeans_example.py) file, which contains a function `calculate_kmeans_inertia` that calculates the inertia of a KMeans clustering algorithm using the `sklearn` library:
+A more complex example is the [`kmeans_example.py`](https://github.com/tonybaloney/CSnakes/blob/main/samples/simple/ExamplePythonDependency/kmeans_example.py) file, which contains a function `calculate_kmeans_inertia` that calculates the inertia of a KMeans clustering algorithm using the `sklearn` library:
 
 ```python
 from sklearn.cluster import k_means
@@ -44,12 +44,12 @@ public (IReadOnlyList<IReadOnlyList<double>>, double) CalculateKmeansInertia(IRe
 
 ## Phi-3 inference demo
 
-The [`phi3_demo.py`](https://github.com/tonybaloney/CSnakes/blob/main/samples/ExamplePythonDependency/phi3_demo.py) file contains a demo of using the `transformers` package from hugging face and pytorch to invoke a Small Language Model (Phi3) and complete an input string.
+The [`phi3_demo.py`](https://github.com/tonybaloney/CSnakes/blob/main/samples/simple/ExamplePythonDependency/phi3_demo.py) file contains a demo of using the `transformers` package from hugging face and pytorch to invoke a Small Language Model (Phi3) and complete an input string.
 
 This demo requires the `transformers` and `torch` packages to be installed in the Python environment. PyTorch has special requirements and should be installed per the instructions on the [PyTorch website](https://pytorch.org/get-started/locally/).
 
 ## Embedding Python in a .NET Web App
 
-The [`webapp`](https://github.com/tonybaloney/CSnakes/blob/main/samples/WebApp) project demonstrates how to embed Python code in a .NET web application. The `webapp` project is a simple web application that exposes some of the example Python functions via HTTP routes.
+The [`webapp`](https://github.com/tonybaloney/CSnakes/blob/main/samples/simple/WebApp) project demonstrates how to embed Python code in a .NET web application. The `webapp` project is a simple web application that exposes some of the example Python functions via HTTP routes.
 
-This demo also comes with a [JMeter load test.](https://github.com/tonybaloney/CSnakes/blob/main/samples/WebApp/loadtest.jmx)
+This demo also comes with a [JMeter load test.](https://github.com/tonybaloney/CSnakes/blob/main/samples/simple/WebApp/loadtest.jmx)


### PR DESCRIPTION
Found some broken links in [the examples documentation](https://tonybaloney.github.io/CSnakes/examples/) that this PR fixes.