### PR TITLE
Have direct integration example implement `IDisposable`

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -90,7 +90,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CSnakes.Runtime;
 
-public class ExampleDirectIntegration
+public sealed class ExampleDirectIntegration : IDisposable
 {
     private readonly PyObject module;
 


### PR DESCRIPTION
When reading through the [**Calling Python without the Source Generator**](https://tonybaloney.github.io/CSnakes/advanced/#calling-python-without-the-source-generator) section of the documentation, I found it confusing that `ExampleDirectIntegration` did not _technically_ implement `IDisposable`. This PR fixes that to avoid confusing future readers.