### PR TITLE
Make PyDictionary and PyList convertable back to PyObject without marshalling

### DIFF
--- a/src/CSnakes.Runtime/PyObjectTypeConverter.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.cs
@@ -1,8 +1,5 @@
 ﻿using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.Python;
-using System.Collections;
-using System.Runtime.CompilerServices;
-using System.Numerics;
 using System.Collections.Concurrent;
 using System.Reflection;
 

--- a/src/CSnakes.Runtime/Python/ICloneable.cs
+++ b/src/CSnakes.Runtime/Python/ICloneable.cs
@@ -1,0 +1,5 @@
+﻿namespace CSnakes.Runtime.Python;
+internal interface ICloneable
+{
+    internal PyObject Clone();
+}

--- a/src/CSnakes.Runtime/Python/PyDictionary.cs
+++ b/src/CSnakes.Runtime/Python/PyDictionary.cs
@@ -100,10 +100,6 @@ internal class PyDictionary<TKey, TValue>(PyObject dictionary) : IReadOnlyDictio
         return false;
     }
 
-    PyObject ICloneable.Clone()
-    {
-        return _dictionaryObject.Clone();
-    }
-
+    PyObject ICloneable.Clone() => dictionaryObject.Clone();
     IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 }

--- a/src/CSnakes.Runtime/Python/PyDictionary.cs
+++ b/src/CSnakes.Runtime/Python/PyDictionary.cs
@@ -100,6 +100,6 @@ internal class PyDictionary<TKey, TValue>(PyObject dictionary) : IReadOnlyDictio
         return false;
     }
 
-    PyObject ICloneable.Clone() => dictionaryObject.Clone();
+    PyObject ICloneable.Clone() => _dictionaryObject.Clone();
     IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 }

--- a/src/CSnakes.Runtime/Python/PyDictionary.cs
+++ b/src/CSnakes.Runtime/Python/PyDictionary.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace CSnakes.Runtime.Python;
 
-internal class PyDictionary<TKey, TValue>(PyObject dictionary) : IReadOnlyDictionary<TKey, TValue>, IDisposable
+internal class PyDictionary<TKey, TValue>(PyObject dictionary) : IReadOnlyDictionary<TKey, TValue>, IDisposable, ICloneable
     where TKey : notnull
 {
     private readonly Dictionary<TKey, TValue> _dictionary = [];
@@ -98,6 +98,11 @@ internal class PyDictionary<TKey, TValue>(PyObject dictionary) : IReadOnlyDictio
 
         value = default;
         return false;
+    }
+
+    PyObject ICloneable.Clone()
+    {
+        return _dictionaryObject.Clone();
     }
 
     IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();

--- a/src/CSnakes.Runtime/Python/PyList.cs
+++ b/src/CSnakes.Runtime/Python/PyList.cs
@@ -49,10 +49,6 @@ internal class PyList<TItem>(PyObject listObject) : IReadOnlyList<TItem>, IDispo
         }
     }
 
-    PyObject ICloneable.Clone()
-    {
-        return listObject.Clone();
-    }
-
+    PyObject ICloneable.Clone() => listObject.Clone();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/CSnakes.Runtime/Python/PyList.cs
+++ b/src/CSnakes.Runtime/Python/PyList.cs
@@ -3,14 +3,10 @@ using System.Collections;
 
 namespace CSnakes.Runtime.Python;
 
-internal class PyList<TItem> : IReadOnlyList<TItem>, IDisposable
+internal class PyList<TItem>(PyObject listObject) : IReadOnlyList<TItem>, IDisposable, ICloneable
 {
-    private readonly PyObject _listObject;
-
     // If someone fetches the same index multiple times, we cache the result to avoid multiple round trips to Python
-    private readonly Dictionary<long, TItem> _convertedItems = new();
-
-    public PyList(PyObject listObject) => _listObject = listObject;
+    private readonly Dictionary<long, TItem> _convertedItems = [];
 
     public TItem this[int index]
     {
@@ -23,7 +19,7 @@ internal class PyList<TItem> : IReadOnlyList<TItem>, IDisposable
 
             using (GIL.Acquire())
             {
-                using PyObject value = PyObject.Create(CPythonAPI.PySequence_GetItem(_listObject, index));
+                using PyObject value = PyObject.Create(CPythonAPI.PySequence_GetItem(listObject, index));
                 TItem result = value.As<TItem>();
                 _convertedItems[index] = result;
                 return result;
@@ -37,20 +33,25 @@ internal class PyList<TItem> : IReadOnlyList<TItem>, IDisposable
         {
             using (GIL.Acquire())
             {
-                return (int)CPythonAPI.PySequence_Size(_listObject);
+                return (int)CPythonAPI.PySequence_Size(listObject);
             }
         }
     }
 
-    public void Dispose() => _listObject.Dispose();
+    public void Dispose() => listObject.Dispose();
 
     public IEnumerator<TItem> GetEnumerator()
     {
         // TODO: If someone fetches the same index multiple times, we cache the result to avoid multiple round trips to Python
         using (GIL.Acquire())
         {
-            return new PyEnumerable<TItem>(_listObject);
+            return new PyEnumerable<TItem>(listObject);
         }
+    }
+
+    PyObject ICloneable.Clone()
+    {
+        return listObject.Clone();
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices.Marshalling;
 namespace CSnakes.Runtime.Python;
 
 [DebuggerDisplay("PyObject: repr={GetRepr()}, type={GetPythonType().ToString()}")]
-public class PyObject : SafeHandle
+public class PyObject : SafeHandle, ICloneable
 {
     protected PyObject(IntPtr pyObject, bool ownsHandle = true) : base(pyObject, ownsHandle)
     {
@@ -494,7 +494,7 @@ public class PyObject : SafeHandle
 
             return value switch
             {
-                PyObject pyObject => pyObject.Clone(),
+                ICloneable pyObject => pyObject.Clone(),
                 bool b => b ? True : False,
                 int i => Create(CPythonAPI.PyLong_FromLong(i)),
                 long l => Create(CPythonAPI.PyLong_FromLongLong(l)),
@@ -540,5 +540,10 @@ public class PyObject : SafeHandle
 
         combinedKwnames = [.. newKwnames];
         combinedKwvalues = [.. newKwvalues];
+    }
+
+    PyObject ICloneable.Clone()
+    {
+        return Clone();
     }
 }

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -542,8 +542,5 @@ public class PyObject : SafeHandle, ICloneable
         combinedKwvalues = [.. newKwvalues];
     }
 
-    PyObject ICloneable.Clone()
-    {
-        return Clone();
-    }
+    PyObject ICloneable.Clone() => Clone();
 }

--- a/src/Integration.Tests/DictsTests.cs
+++ b/src/Integration.Tests/DictsTests.cs
@@ -43,4 +43,17 @@ public class TestDicts : IntegrationTestBase
         Assert.Equal(1, result["dictkey1"]);
         Assert.Equal(2, result["dictkey2"]);
     }
+
+    [Fact]
+    public void TestDictionaryRoundTrip()
+    {
+        var testDicts = Env.TestDicts();
+
+        IReadOnlyDictionary<string, long> testDict = new Dictionary<string, long> { { "dictkey1", 1 }, { "dictkey2", 2 } };
+        var result = testDicts.TestDictStrInt(testDict);
+        Assert.Equal(1, result["dictkey1"]);
+
+        var roundTrip = testDicts.TestDictStrInt(result);
+        Assert.Equal(1, roundTrip["dictkey1"]);
+    }
 }


### PR DESCRIPTION
Fixes #199 