### PR TITLE
Fix CS8604 (possible null dereferencing) warnings

### DIFF
--- a/samples/Aspire/CSnakesAspire.ApiService/Program.cs
+++ b/samples/Aspire/CSnakesAspire.ApiService/Program.cs
@@ -62,7 +62,7 @@ app.MapGet("/weatherforecast", (
     [FromServices] IWeather weather,
     [FromServices] ILogger<Program> logger) =>
 {
-    var rawForecast = weather.GetWeatherForecast(Activity.Current?.TraceId.ToString(), Activity.Current.SpanId.ToString());
+    var rawForecast = weather.GetWeatherForecast(Activity.Current?.TraceId.ToString(), Activity.Current?.SpanId.ToString());
 
     logger.LogInformation("Raw forecast: {RawForecast}", rawForecast);
 


### PR DESCRIPTION
This PR addressed the following two [CS8604](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#possible-null-assigned-to-a-nonnullable-reference) warnings:

    A:\CSnakes\main\src\CSnakes.Runtime\Locators\NuGetLocator.cs(15,102): warning CS8604: Possible null reference argument for parameter 'path1' in 'string Path.Combine(string path1, string path2, string path3)'. [A:\CSnakes\main\src\CSnakes.Runtime\CSnakes.Runtime.csproj]
    A:\CSnakes\main\samples\Aspire\CSnakesAspire.ApiService\Program.cs(65,88): warning CS8602: Dereference of a possibly null reference. [A:\CSnakes\main\samples\Aspire\CSnakesAspire.ApiService\CSnakesAspire.ApiService.csproj]

that were being flagged during build and also adding a lot of GH Actions annotation noise in PR diffs:

<img width="334" alt="image" src="https://github.com/user-attachments/assets/9c868607-741c-47cb-ad4c-a2c484e5b1a6">
