### PR TITLE
Pre-allocate list based on source length

### DIFF
--- a/src/CSnakes.Runtime/CPython/List.cs
+++ b/src/CSnakes.Runtime/CPython/List.cs
@@ -49,8 +49,19 @@ internal unsafe partial class CPythonAPI
     [LibraryImport(PythonLibraryName, EntryPoint = "PyList_GetItem")]
     private static partial nint PyList_GetItem_(PyObject obj, nint pos);
 
-    [LibraryImport(PythonLibraryName)]
-    internal static partial int PyList_Append(PyObject obj, PyObject o);
+    internal static int PyList_SetItemRaw(nint ob, nint pos, nint o)
+    {
+        int result = PyList_SetItem_(ob, pos, o);
+        if (result != -1)
+        {
+            // Add reference to the new item as it belongs to list now.
+            Py_IncRefRaw(o);
+        }
+        return result;
+    }
+
+    [LibraryImport(PythonLibraryName, EntryPoint = "PyList_SetItem")]
+    internal static partial int PyList_SetItem_(nint obj, nint pos, nint o);
 
     internal static bool IsPyList(PyObject p)
     {

--- a/src/CSnakes.Runtime/CPython/Tuple.cs
+++ b/src/CSnakes.Runtime/CPython/Tuple.cs
@@ -7,6 +7,12 @@ internal unsafe partial class CPythonAPI
     private static nint PyTupleType = IntPtr.Zero;
     private static nint PyEmptyTuple = IntPtr.Zero;
 
+    public static nint GetPyEmptyTuple()
+    {
+        Py_IncRefRaw(PyEmptyTuple);
+        return PyEmptyTuple;
+    }
+
     /// <summary>
     /// Create a PyTuple from the PyObject pointers in `items`.
     /// Function handles the reference increments to items.
@@ -17,10 +23,7 @@ internal unsafe partial class CPythonAPI
     {
         // This is a shortcut to a CPython optimization. Keep an empty tuple and reuse it.
         if (items.Length == 0)
-        {
-            Py_IncRefRaw(PyEmptyTuple);
-            return PyEmptyTuple;
-        }
+            return GetPyEmptyTuple();
 
         nint tuple = PyTuple_New(items.Length);
         for (int i = 0; i < items.Length; i++)

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -17,13 +17,13 @@ internal static class Pack
     internal static PyObject CreateList(Span<PyObject> items) =>
         PyObject.Create(CreateListOrTuple<ListBuilder>(items));
 
-    public interface IListOrTupleBuilder
+    private interface IListOrTupleBuilder
     {
         static abstract nint New(nint size);
         static abstract int SetItemRaw(nint ob, nint pos, nint o);
     }
 
-    public sealed class ListBuilder : IListOrTupleBuilder
+    private sealed class ListBuilder : IListOrTupleBuilder
     {
         // As per Python/C API docs for `PyList_New`:
         //
@@ -38,13 +38,13 @@ internal static class Pack
         public static int SetItemRaw(IntPtr ob, IntPtr pos, IntPtr o) => CPythonAPI.PyList_SetItemRaw(ob, pos, o);
     }
 
-    public sealed class TupleBuilder : IListOrTupleBuilder
+    private sealed class TupleBuilder : IListOrTupleBuilder
     {
         public static IntPtr New(IntPtr size) => size == 0 ? CPythonAPI.GetPyEmptyTuple() : CPythonAPI.PyTuple_New(size);
         public static int SetItemRaw(IntPtr ob, IntPtr pos, IntPtr o) => CPythonAPI.PyTuple_SetItemRaw(ob, pos, o);
     }
 
-    public static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
+    private static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
         where TBuilder : IListOrTupleBuilder
     {
         nint obj = 0;

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -114,11 +114,11 @@ internal static class Pack
         try
         {
             obj = TBuilder.New(items.Length);
-            SetItems(spilledHandles, SetItems(initialHandles, 0));
+            SetItems(obj, spilledHandles, SetItems(obj, initialHandles, 0));
 
             return obj;
 
-            int SetItems(Span<nint> handles, int i)
+            static int SetItems(nint obj, Span<nint> handles, int i)
             {
                 foreach (var handle in handles)
                 {

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -25,6 +25,8 @@ internal static class Pack
 
     private sealed class ListBuilder : IListOrTupleBuilder
     {
+        private ListBuilder() { }
+
         // As per Python/C API docs for `PyList_New`:
         //
         // > If len is greater than zero, the returned list object's items are set to `NULL`. Thus
@@ -40,6 +42,7 @@ internal static class Pack
 
     private sealed class TupleBuilder : IListOrTupleBuilder
     {
+        private TupleBuilder() { }
         public static IntPtr New(IntPtr size) => size == 0 ? CPythonAPI.GetPyEmptyTuple() : CPythonAPI.PyTuple_New(size);
         public static int SetItemRaw(IntPtr ob, IntPtr pos, IntPtr o) => CPythonAPI.PyTuple_SetItemRaw(ob, pos, o);
     }

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -5,21 +5,47 @@ using System.Runtime.InteropServices.Marshalling;
 namespace CSnakes.Runtime.Python;
 
 /// <summary>
-/// These methods are used internally to create a PyObject where the Dispose() call will dispose all items in
+/// These methods are used internally to create a PyObject where the Dispose() call will dispose all items in 
 /// the collection inside the same call stack. This avoids the .NET GC Finalizer thread from disposing the items
 /// that were created and creating a GIL contention issue when other code is running.
 /// </summary>
 internal static class Pack
 {
-    internal static unsafe PyObject CreateTuple(Span<PyObject> items) =>
-        PyObject.Create(CreateListOrTuple(items, &CPythonAPI.PyTuple_New, &CPythonAPI.PyTuple_SetItemRaw));
+    internal static PyObject CreateTuple(Span<PyObject> items) =>
+        PyObject.Create(CreateListOrTuple<TupleBuilder>(items));
 
-    internal static unsafe PyObject CreateList(Span<PyObject> items) =>
-        PyObject.Create(CreateListOrTuple(items, &CPythonAPI.PyList_New, &CPythonAPI.PyList_SetItemRaw));
+    internal static PyObject CreateList(Span<PyObject> items) =>
+        PyObject.Create(CreateListOrTuple<ListBuilder>(items));
 
-    public static unsafe nint CreateListOrTuple(Span<PyObject> items,
-                                                delegate* <nint, nint> newObject,
-                                                delegate* <nint, nint, nint, int> setItemRaw)
+    public interface IListOrTupleBuilder
+    {
+        static abstract nint New(nint size);
+        static abstract int SetItemRaw(nint ob, nint pos, nint o);
+    }
+
+    public sealed class ListBuilder : IListOrTupleBuilder
+    {
+        // As per Python/C API docs for `PyList_New`:
+        //
+        // > If len is greater than zero, the returned list object's items are set to `NULL`. Thus
+        // > you cannot use abstract API functions such as `PySequence_SetItem()` or expose the
+        // > object to Python code before setting all items to a real object with
+        // > `PyList_SetItem()`.
+        //
+        // Source: https://docs.python.org/3/c-api/list.html#c.PyList_New
+
+        public static IntPtr New(IntPtr size) => CPythonAPI.PyList_New(size);
+        public static int SetItemRaw(IntPtr ob, IntPtr pos, IntPtr o) => CPythonAPI.PyList_SetItemRaw(ob, pos, o);
+    }
+
+    public sealed class TupleBuilder : IListOrTupleBuilder
+    {
+        public static IntPtr New(IntPtr size) => size == 0 ? CPythonAPI.GetPyEmptyTuple() : CPythonAPI.PyTuple_New(size);
+        public static int SetItemRaw(IntPtr ob, IntPtr pos, IntPtr o) => CPythonAPI.PyTuple_SetItemRaw(ob, pos, o);
+    }
+
+    public static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
+        where TBuilder : IListOrTupleBuilder
     {
         nint obj = 0;
 
@@ -44,12 +70,12 @@ internal static class Pack
 
             Debug.Assert(uninitializedHandles.Length == 0);
 
-            obj = newObject(items.Length);
+            obj = TBuilder.New(items.Length);
 
             var i = 0;
             foreach (var handle in handles)
             {
-                int result = setItemRaw(obj, i++, handle);
+                int result = TBuilder.SetItemRaw(obj, i++, handle);
                 if (result == -1)
                 {
                     throw PyObject.ThrowPythonExceptionAsClrException();

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -1,7 +1,5 @@
 ﻿using CSnakes.Runtime.CPython;
-using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using PyObjectMarshaller = System.Runtime.InteropServices.Marshalling.SafeHandleMarshaller<CSnakes.Runtime.Python.PyObject>;
@@ -59,107 +57,27 @@ internal static class Pack
         private T _;
     }
 
-    [DebuggerDisplay($"{{{nameof(DebuggerDisplay)}(),nq}}")]
-    struct RentalState
-    {
-        private bool returned;
-
-        /// <remarks>
-        /// This method should only be called from a state manager like <see
-        /// cref="RentedArray{T}"/>. It should not be called directly from user
-        /// code and thus is named "dangerous" to attract attention.
-        /// </remarks>
-        public void DangerousReturn() => returned = true;
-
-        public static implicit operator bool(RentalState b) => !b.returned;
-
-        private string DebuggerDisplay() => this ? "rented" : "returned";
-    }
-
-    [DebuggerDisplay($"{{{nameof(DebuggerDisplay)}(),nq}}")]
-    private ref struct RentedArray<T>
-    {
-        private readonly T[] array;
-        private ref RentalState rented;
-        private readonly ArrayPool<T> pool;
-        private readonly Span<T> span;
-
-        public RentedArray(ArrayPool<T> pool, int length, ref RentalState rental)
-        {
-            Debug.Assert(rental);
-            this.rented = ref rental;
-            this.pool = pool;
-            this.array = pool.Rent(length);
-            this.span = array.AsSpan(..length);
-        }
-
-        public int Length => Span.Length;
-
-        private Span<T> Span
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                if (!this.rented)
-                {
-                    ThrowObjectDisposedException();
-                }
-
-                return this.span;
-            }
-        }
-
-        public void Dispose()
-        {
-            if (!this.rented)
-                return;
-
-            this.rented.DangerousReturn();
-            this.pool.Return(this.array);
-        }
-
-        public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
-
-        public static implicit operator Span<T>(RentedArray<T> rented) => rented.Span;
-
-        private string DebuggerDisplay() =>
-            this.rented ? $"Length = {Length} (Capacity = {this.array.Length})" : "(returned)";
-
-        [DoesNotReturn]
-        private void ThrowObjectDisposedException() => throw new ObjectDisposedException(nameof(RentedArray<T>));
-    }
-
-    private static class ArrayPools
-    {
-        private const int MaxLength = 100;
-        private const int MaxPerBucket = 10;
-
-        private static readonly ArrayPool<nint> Handles = ArrayPool<nint>.Create(MaxLength, MaxPerBucket);
-        private static readonly ArrayPool<PyObjectMarshaller.ManagedToUnmanagedIn> Marshallers = ArrayPool<PyObjectMarshaller.ManagedToUnmanagedIn>.Create(MaxLength, MaxPerBucket);
-
-        public static RentedArray<nint> RentHandles(int length, ref RentalState rental) => new(Handles, length, ref rental);
-        public static RentedArray<PyObjectMarshaller.ManagedToUnmanagedIn> RentMarshallers(int length, ref RentalState returned) => new(Marshallers, length, ref returned);
-    }
-
     private static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
         where TBuilder : IListOrTupleBuilder
     {
         // Allocate initial space for the handles and marshallers on the stack.
         // If the number of items exceeds the stack space, allocate and spill
         // the rest into an array on the heap.
+        // TODO Consider using an array pool for the spilled handles and marshallers.
 
         const int stackSpillThreshold = FixedArrayLength;
         var spillLength = Math.Max(0, items.Length - stackSpillThreshold);
 
         Span<nint> initialHandles = stackalloc nint[Math.Min(stackSpillThreshold, items.Length)];
-        var spilledHandlesRental = new RentalState();
-        using var spilledHandles = ArrayPools.RentHandles(spillLength, ref spilledHandlesRental);
+        nint[]? spilledHandles = spillLength > 0 ? new nint[spillLength] : null;
 
         var initialMarshallers = new ArrayOf8<PyObjectMarshaller.ManagedToUnmanagedIn>();
-        var spilledMarshallersRental = new RentalState();
-        using var spilledMarshallers = ArrayPools.RentMarshallers(spillLength, ref spilledMarshallersRental);
+        PyObjectMarshaller.ManagedToUnmanagedIn[]? spilledMarshallers =
+            spillLength > 0
+            ? new PyObjectMarshaller.ManagedToUnmanagedIn[spillLength]
+            : null;
 
-        scoped var uninitializedMarshallers = MemoryMarshal.CreateSpan(ref Unsafe.As<ArrayOf8<PyObjectMarshaller.ManagedToUnmanagedIn>, PyObjectMarshaller.ManagedToUnmanagedIn>(ref initialMarshallers), stackSpillThreshold);
+        var uninitializedMarshallers = MemoryMarshal.CreateSpan(ref Unsafe.As<ArrayOf8<PyObjectMarshaller.ManagedToUnmanagedIn>, PyObjectMarshaller.ManagedToUnmanagedIn>(ref initialMarshallers), stackSpillThreshold);
         var uninitializedHandles = initialHandles;
 
         // The following loop initializes the marshallers and handles for each
@@ -172,17 +90,19 @@ internal static class Pack
             PyObjectMarshaller.ManagedToUnmanagedIn m = default;
             m.FromManaged(item);
 
-            if (uninitializedMarshallers.IsEmpty && spilledMarshallers is { Length: > 0 } sms)
+            if (uninitializedMarshallers.IsEmpty)
             {
-                uninitializedMarshallers = sms;
+                Debug.Assert(spilledMarshallers is not null);
+                uninitializedMarshallers = spilledMarshallers;
             }
 
             uninitializedMarshallers[0] = m;
             uninitializedMarshallers = uninitializedMarshallers[1..];
 
-            if (uninitializedHandles.IsEmpty && spilledHandles is { Length: > 0 } shs)
+            if (uninitializedHandles.IsEmpty)
             {
-                uninitializedHandles = shs;
+                Debug.Assert(spilledHandles is not null);
+                uninitializedHandles = spilledHandles;
             }
 
             uninitializedHandles[0] = m.ToUnmanaged();
@@ -223,7 +143,14 @@ internal static class Pack
         }
         finally
         {
-            if (spilledMarshallers.Length > 0)
+            if (spilledMarshallers is null)
+            {
+                foreach (var m in initialMarshallers[..items.Length])
+                {
+                    m.Free();
+                }
+            }
+            else
             {
                 foreach (var m in initialMarshallers)
                 {
@@ -231,13 +158,6 @@ internal static class Pack
                 }
 
                 foreach (var m in spilledMarshallers)
-                {
-                    m.Free();
-                }
-            }
-            else
-            {
-                foreach (var m in initialMarshallers[..items.Length])
                 {
                     m.Free();
                 }

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -1,5 +1,4 @@
 ﻿using CSnakes.Runtime.CPython;
-using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -5,47 +5,21 @@ using System.Runtime.InteropServices.Marshalling;
 namespace CSnakes.Runtime.Python;
 
 /// <summary>
-/// These methods are used internally to create a PyObject where the Dispose() call will dispose all items in 
+/// These methods are used internally to create a PyObject where the Dispose() call will dispose all items in
 /// the collection inside the same call stack. This avoids the .NET GC Finalizer thread from disposing the items
 /// that were created and creating a GIL contention issue when other code is running.
 /// </summary>
 internal static class Pack
 {
-    internal static PyObject CreateTuple(Span<PyObject> items) =>
-        PyObject.Create(CreateListOrTuple<TupleBuilder>(items));
+    internal static unsafe PyObject CreateTuple(Span<PyObject> items) =>
+        PyObject.Create(CreateListOrTuple(items, &CPythonAPI.PyTuple_New, &CPythonAPI.PyTuple_SetItemRaw));
 
-    internal static PyObject CreateList(Span<PyObject> items) =>
-        PyObject.Create(CreateListOrTuple<ListBuilder>(items));
+    internal static unsafe PyObject CreateList(Span<PyObject> items) =>
+        PyObject.Create(CreateListOrTuple(items, &CPythonAPI.PyList_New, &CPythonAPI.PyList_SetItemRaw));
 
-    public interface IListOrTupleBuilder
-    {
-        static abstract nint New(nint size);
-        static abstract int SetItemRaw(nint ob, nint pos, nint o);
-    }
-
-    public sealed class ListBuilder : IListOrTupleBuilder
-    {
-        // As per Python/C API docs for `PyList_New`:
-        //
-        // > If len is greater than zero, the returned list object's items are set to `NULL`. Thus
-        // > you cannot use abstract API functions such as `PySequence_SetItem()` or expose the
-        // > object to Python code before setting all items to a real object with
-        // > `PyList_SetItem()`.
-        //
-        // Source: https://docs.python.org/3/c-api/list.html#c.PyList_New
-
-        public static IntPtr New(IntPtr size) => CPythonAPI.PyList_New(size);
-        public static int SetItemRaw(IntPtr ob, IntPtr pos, IntPtr o) => CPythonAPI.PyList_SetItemRaw(ob, pos, o);
-    }
-
-    public sealed class TupleBuilder : IListOrTupleBuilder
-    {
-        public static IntPtr New(IntPtr size) => size == 0 ? CPythonAPI.GetPyEmptyTuple() : CPythonAPI.PyTuple_New(size);
-        public static int SetItemRaw(IntPtr ob, IntPtr pos, IntPtr o) => CPythonAPI.PyTuple_SetItemRaw(ob, pos, o);
-    }
-
-    public static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
-        where TBuilder : IListOrTupleBuilder
+    public static unsafe nint CreateListOrTuple(Span<PyObject> items,
+                                                delegate* <nint, nint> newObject,
+                                                delegate* <nint, nint, nint, int> setItemRaw)
     {
         nint obj = 0;
 
@@ -70,12 +44,12 @@ internal static class Pack
 
             Debug.Assert(uninitializedHandles.Length == 0);
 
-            obj = TBuilder.New(items.Length);
+            obj = newObject(items.Length);
 
             var i = 0;
             foreach (var handle in handles)
             {
-                int result = TBuilder.SetItemRaw(obj, i++, handle);
+                int result = setItemRaw(obj, i++, handle);
                 if (result == -1)
                 {
                     throw PyObject.ThrowPythonExceptionAsClrException();

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -59,86 +59,34 @@ internal static class Pack
         private T _;
     }
 
-    [DebuggerDisplay($"{{{nameof(DebuggerDisplay)}(),nq}}")]
-    struct RentalState
+    private class StockArray<T>(int length)
     {
-        private bool returned;
+        private T[]? array;
 
-        /// <remarks>
-        /// This method should only be called from a state manager like <see
-        /// cref="RentedArray{T}"/>. It should not be called directly from user
-        /// code and thus is named "dangerous" to attract attention.
-        /// </remarks>
-        public void DangerousReturn() => returned = true;
+        public Span<T> GetArray(int minimumLength)
+        {
+            if (minimumLength == 0)
+                return [];
 
-        public static implicit operator bool(RentalState b) => !b.returned;
+            if (minimumLength > length)
+                return new T[minimumLength];
 
-        private string DebuggerDisplay() => this ? "rented" : "returned";
+            return (this.array ??= new T[length])[..minimumLength];
+        }
     }
 
-    [DebuggerDisplay($"{{{nameof(DebuggerDisplay)}(),nq}}")]
-    private ref struct RentedArray<T>
+    static class ThreadStatics
     {
-        private readonly T[] array;
-        private ref RentalState rented;
-        private readonly ArrayPool<T> pool;
-        private readonly Span<T> span;
+        [ThreadStatic]
+        private static StockArray<nint>? spilledHandles;
 
-        public RentedArray(ArrayPool<T> pool, int length, ref RentalState rental)
-        {
-            Debug.Assert(rental);
-            this.rented = ref rental;
-            this.pool = pool;
-            this.array = pool.Rent(length);
-            this.span = array.AsSpan(..length);
-        }
+        [ThreadStatic]
+        private static StockArray<PyObjectMarshaller.ManagedToUnmanagedIn>? spilledMarshallers;
 
-        public int Length => Span.Length;
+        private const int StockArrayThresholdLength = 100;
 
-        private Span<T> Span
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                if (!this.rented)
-                {
-                    ThrowObjectDisposedException();
-                }
-
-                return this.span;
-            }
-        }
-
-        public void Dispose()
-        {
-            if (!this.rented)
-                return;
-
-            this.rented.DangerousReturn();
-            this.pool.Return(this.array);
-        }
-
-        public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
-
-        public static implicit operator Span<T>(RentedArray<T> rented) => rented.Span;
-
-        private string DebuggerDisplay() =>
-            this.rented ? $"Length = {Length} (Capacity = {this.array.Length})" : "(returned)";
-
-        [DoesNotReturn]
-        private void ThrowObjectDisposedException() => throw new ObjectDisposedException(nameof(RentedArray<T>));
-    }
-
-    private static class ArrayPools
-    {
-        private const int MaxLength = 100;
-        private const int MaxPerBucket = 10;
-
-        private static readonly ArrayPool<nint> Handles = ArrayPool<nint>.Create(MaxLength, MaxPerBucket);
-        private static readonly ArrayPool<PyObjectMarshaller.ManagedToUnmanagedIn> Marshallers = ArrayPool<PyObjectMarshaller.ManagedToUnmanagedIn>.Create(MaxLength, MaxPerBucket);
-
-        public static RentedArray<nint> RentHandles(int length, ref RentalState rental) => new(Handles, length, ref rental);
-        public static RentedArray<PyObjectMarshaller.ManagedToUnmanagedIn> RentMarshallers(int length, ref RentalState returned) => new(Marshallers, length, ref returned);
+        public static StockArray<nint> SpilledHandles => spilledHandles ??= new StockArray<nint>(StockArrayThresholdLength);
+        public static StockArray<PyObjectMarshaller.ManagedToUnmanagedIn> SpilledMarshallers => spilledMarshallers ??= new StockArray<PyObjectMarshaller.ManagedToUnmanagedIn>(StockArrayThresholdLength);
     }
 
     private static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
@@ -152,12 +100,10 @@ internal static class Pack
         var spillLength = Math.Max(0, items.Length - stackSpillThreshold);
 
         Span<nint> initialHandles = stackalloc nint[Math.Min(stackSpillThreshold, items.Length)];
-        var spilledHandlesRental = new RentalState();
-        using var spilledHandles = ArrayPools.RentHandles(spillLength, ref spilledHandlesRental);
+        var spilledHandles = ThreadStatics.SpilledHandles.GetArray(spillLength);
 
         var initialMarshallers = new ArrayOf8<PyObjectMarshaller.ManagedToUnmanagedIn>();
-        var spilledMarshallersRental = new RentalState();
-        using var spilledMarshallers = ArrayPools.RentMarshallers(spillLength, ref spilledMarshallersRental);
+        var spilledMarshallers = ThreadStatics.SpilledMarshallers.GetArray(spillLength);
 
         scoped var uninitializedMarshallers = MemoryMarshal.CreateSpan(ref Unsafe.As<ArrayOf8<PyObjectMarshaller.ManagedToUnmanagedIn>, PyObjectMarshaller.ManagedToUnmanagedIn>(ref initialMarshallers), stackSpillThreshold);
         var uninitializedHandles = initialHandles;

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -59,34 +59,86 @@ internal static class Pack
         private T _;
     }
 
-    private class StockArray<T>(int length)
+    [DebuggerDisplay($"{{{nameof(DebuggerDisplay)}(),nq}}")]
+    struct RentalState
     {
-        private T[]? array;
+        private bool returned;
 
-        public Span<T> GetArray(int minimumLength)
-        {
-            if (minimumLength == 0)
-                return [];
+        /// <remarks>
+        /// This method should only be called from a state manager like <see
+        /// cref="RentedArray{T}"/>. It should not be called directly from user
+        /// code and thus is named "dangerous" to attract attention.
+        /// </remarks>
+        public void DangerousReturn() => returned = true;
 
-            if (minimumLength > length)
-                return new T[minimumLength];
+        public static implicit operator bool(RentalState b) => !b.returned;
 
-            return (this.array ??= new T[length])[..minimumLength];
-        }
+        private string DebuggerDisplay() => this ? "rented" : "returned";
     }
 
-    static class ThreadStatics
+    [DebuggerDisplay($"{{{nameof(DebuggerDisplay)}(),nq}}")]
+    private ref struct RentedArray<T>
     {
-        [ThreadStatic]
-        private static StockArray<nint>? spilledHandles;
+        private readonly T[] array;
+        private ref RentalState rented;
+        private readonly ArrayPool<T> pool;
+        private readonly Span<T> span;
 
-        [ThreadStatic]
-        private static StockArray<PyObjectMarshaller.ManagedToUnmanagedIn>? spilledMarshallers;
+        public RentedArray(ArrayPool<T> pool, int length, ref RentalState rental)
+        {
+            Debug.Assert(rental);
+            this.rented = ref rental;
+            this.pool = pool;
+            this.array = pool.Rent(length);
+            this.span = array.AsSpan(..length);
+        }
 
-        private const int StockArrayThresholdLength = 100;
+        public int Length => Span.Length;
 
-        public static StockArray<nint> SpilledHandles => spilledHandles ??= new StockArray<nint>(StockArrayThresholdLength);
-        public static StockArray<PyObjectMarshaller.ManagedToUnmanagedIn> SpilledMarshallers => spilledMarshallers ??= new StockArray<PyObjectMarshaller.ManagedToUnmanagedIn>(StockArrayThresholdLength);
+        private Span<T> Span
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (!this.rented)
+                {
+                    ThrowObjectDisposedException();
+                }
+
+                return this.span;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!this.rented)
+                return;
+
+            this.rented.DangerousReturn();
+            this.pool.Return(this.array);
+        }
+
+        public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
+
+        public static implicit operator Span<T>(RentedArray<T> rented) => rented.Span;
+
+        private string DebuggerDisplay() =>
+            this.rented ? $"Length = {Length} (Capacity = {this.array.Length})" : "(returned)";
+
+        [DoesNotReturn]
+        private void ThrowObjectDisposedException() => throw new ObjectDisposedException(nameof(RentedArray<T>));
+    }
+
+    private static class ArrayPools
+    {
+        private const int MaxLength = 100;
+        private const int MaxPerBucket = 10;
+
+        private static readonly ArrayPool<nint> Handles = ArrayPool<nint>.Create(MaxLength, MaxPerBucket);
+        private static readonly ArrayPool<PyObjectMarshaller.ManagedToUnmanagedIn> Marshallers = ArrayPool<PyObjectMarshaller.ManagedToUnmanagedIn>.Create(MaxLength, MaxPerBucket);
+
+        public static RentedArray<nint> RentHandles(int length, ref RentalState rental) => new(Handles, length, ref rental);
+        public static RentedArray<PyObjectMarshaller.ManagedToUnmanagedIn> RentMarshallers(int length, ref RentalState returned) => new(Marshallers, length, ref returned);
     }
 
     private static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
@@ -100,10 +152,12 @@ internal static class Pack
         var spillLength = Math.Max(0, items.Length - stackSpillThreshold);
 
         Span<nint> initialHandles = stackalloc nint[Math.Min(stackSpillThreshold, items.Length)];
-        var spilledHandles = ThreadStatics.SpilledHandles.GetArray(spillLength);
+        var spilledHandlesRental = new RentalState();
+        using var spilledHandles = ArrayPools.RentHandles(spillLength, ref spilledHandlesRental);
 
         var initialMarshallers = new ArrayOf8<PyObjectMarshaller.ManagedToUnmanagedIn>();
-        var spilledMarshallers = ThreadStatics.SpilledMarshallers.GetArray(spillLength);
+        var spilledMarshallersRental = new RentalState();
+        using var spilledMarshallers = ArrayPools.RentMarshallers(spillLength, ref spilledMarshallersRental);
 
         scoped var uninitializedMarshallers = MemoryMarshal.CreateSpan(ref Unsafe.As<ArrayOf8<PyObjectMarshaller.ManagedToUnmanagedIn>, PyObjectMarshaller.ManagedToUnmanagedIn>(ref initialMarshallers), stackSpillThreshold);
         var uninitializedHandles = initialHandles;


### PR DESCRIPTION
This PR addresses issue #173.

It consolidates tuple and list construction since they shared the bulk of the implementation and both have the same semantics and signatures in CPython (and both, [`PyTuple_SetItem`](https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem) and [`PyList_SetItem`](https://docs.python.org/3/c-api/list.html#c.PyList_SetItem) _steal_ references). It uses a similar approach to the one applied in PR #204. That is, the C APIs for each type are abstracted behind a new interface (with static members only):

```c#
private interface IListOrTupleBuilder
{
    static abstract nint New(nint size);
    static abstract int SetItemRaw(nint ob, nint pos, nint o);
}
```

Then there's an implementation for tuples (`TupleBuilder`) and another for lists (`ListsBuilder`) that just delegate to the corresponding APIs. I also tried an approach with function pointers in d584188675c6c56c5dea392cfbc24fdcd8bddbba, but it didn't seem to bring any advantage and also read less clear for now (it was reverted with d45b2a0ff52f665aa6305b1d7c866fb9eab507de).

The `CreateTuple` and `CreateList` methods now just call `CreateListOrTuple` with the right builder type:

```c#
internal static class Pack
{
    internal static PyObject CreateTuple(Span<PyObject> items) =>
        PyObject.Create(CreateListOrTuple<TupleBuilder>(items));

    internal static PyObject CreateList(Span<PyObject> items) =>
        PyObject.Create(CreateListOrTuple<ListBuilder>(items));

    // ...

    private static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
        where TBuilder : IListOrTupleBuilder
    {
        // ...
    }
}
```

Internally, `CreateListOrTuple` optimises memory allocations by using the stack for tuples and lists with 8 items or less. For larger structures, it spills to an array allocated on the heap. This is done for handles (like before), but also for marshallers via fixed-length arrays that are inlined on the stack. Spilling means that for a list of 16 elements, 8 handles and marshallers go on the stack and 8 on heap-allocated arrays. Ideally, this could be further optimised by an [array pool](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1?view=net-8.0). For now, however, the situation is better than before when marshallers always ended up on the heap with a list + array:

https://github.com/tonybaloney/CSnakes/blob/3d94d1285bee9f980dd1133a69a6eb1bac3667f1/src/CSnakes.Runtime/Python/Pack.cs#L15

Since the majority of the code is shared, any improvements to the core approach will benefit lists and tuples without additional effort.

The one potential performance regression that this PR introduces is that `CreateTuple` allocated handles on the stack for tuples up to the max size of 17:

https://github.com/tonybaloney/CSnakes/blob/3d94d1285bee9f980dd1133a69a6eb1bac3667f1/src/CSnakes.Runtime/Python/Pack.cs#L18-L20

This PR uses 8 for tuples and lists. I think tuples with 9+ elements is going to be extremely rare so this could be a reasonable compromise, but if we want to maintain a different threshold between tuples and lists then this is something that could be addressed in the future.

---
Possible list of things to consider before publishing this draft (but which could also be deferred to a future PR as improvements):

- [x] Consolidate duplication with [`Pack.CreateTuple`](https://github.com/tonybaloney/CSnakes/blob/3cdbd44a02763c8bd9647305a91217e6cb4aa12c/src/CSnakes.Runtime/Python/Pack.cs#L13-L38)
- [x] Allocate marshallers (`SafeHandleMarshaller<PyObject>.ManagedToUnmanagedIn`) on the stack for small lists
