### PR TITLE
Supporting forks in CI better

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -108,24 +108,3 @@ jobs:
         working-directory: samples
         env:
           PYTHON_VERSION: ${{ steps.installpython.outputs.python-version }}
-
-  test-reporting:
-    permissions:
-      contents: read
-      actions: read
-      checks: write
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: ".NET Tests"
-          path: "*.trx"
-          reporter: dotnet-trx

--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET Publish (GitHub Packages)
+name: .NET Publish (CI)
 
 on:
   pull_request:
@@ -16,11 +16,6 @@ env:
 jobs:
   publish-github-packages:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
@@ -46,6 +41,3 @@ jobs:
         with:
           name: nuget-packages
           path: ./nuget
-
-      - name: Publish to GitHub packages
-        run: dotnet nuget push ./nuget/*.nupkg --source "https://nuget.pkg.github.com/tonybaloney/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-publish-gh-packages.yml
+++ b/.github/workflows/dotnet-publish-gh-packages.yml
@@ -1,0 +1,19 @@
+name: "Publish NuGet packages to GitHub Packages"
+on:
+  workflow_run:
+    workflows: [".NET Publish (CI)"]
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET Publish (NuGet)
+name: .NET Publish (main)
 
 on:
   push:

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -1,0 +1,16 @@
+name: "Test Report"
+on:
+  workflow_run:
+    workflows: [".NET CI"]
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: phoenix-actions/test-reporting@v15
+        id: test-report
+        with:
+          name: ".NET Tests"
+          path: "*.trx"
+          reporter: dotnet-trx

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: phoenix-actions/test-reporting@v15
         id: test-report
         with:
-          name: ".NET Tests"
           path: "*.trx"
           reporter: dotnet-trx
+          artifact: /test-results-(.*)/
+          name: ".NET Test report $1"


### PR DESCRIPTION
Some of our CI jobs require access to the `GITHUB_TOKEN`, but the problem is that when they are run from a fork, they don't have permission to do what we need done.

To address this, we need to split the jobs that need permissions out into a new workflow which is run once the triggered workflow completes, since that trigger will run in context of the repo and mean that we can use the `GITHUB_TOKEN`.

Fixes #208