### PR TITLE
Fix LD_PRELOAD workarounds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,6 +42,5 @@
 	"remoteUser": "root",
 	"remoteEnv": {
 		"Python3_ROOT_DIR": "/usr/local/python/current",
-		"LD_PRELOAD": "/usr/local/python/current/lib/libpython3.12.so.1.0"
 	}
 }

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -57,7 +57,6 @@ jobs:
         working-directory: src
         env:
           PYTHON_VERSION: ${{ steps.installpython.outputs.python-version }}
-          LD_PRELOAD: /opt/hostedtoolcache/Python/${{ steps.installpython.outputs.python-version }}/x64/lib/libpython3.so
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -35,11 +35,11 @@ internal unsafe partial class CPythonAPI : IDisposable
     private enum RTLD : int
     {
         LOCAL = 0,
-        LAZY  = 1,
+        LAZY = 1,
         NOW = 2,
-        NOLOAD=4,
-        DEEPBIND=8,
-        GLOBAL=0x00100
+        NOLOAD = 4,
+        DEEPBIND = 8,
+        GLOBAL = 0x00100
     }
 
 

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -45,7 +45,6 @@ internal unsafe partial class CPythonAPI : IDisposable
     [LibraryImport("libdl.so.2", StringMarshalling = StringMarshalling.Utf8)]
     private static partial nint dlopen(string path, int flags);
 
-
     private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
         if (libraryName == PythonLibraryName)

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -31,10 +31,24 @@ internal unsafe partial class CPythonAPI : IDisposable
         }
     }
 
+    const int RTLD_LAZY=0x1;
+    const int RTLD_NOW=0x2;
+    const int RTLD_LOCAL=0x4;
+    const int RTLD_GLOBAL=0x8;
+
+    [LibraryImport("/usr/lib/x86_64-linux-gnu/libdl.so.2", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint dlopen(string path, int flags);
+
+
     private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
         if (libraryName == PythonLibraryName)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){
+                // TODO: find how to load libdl.so without hardcoding the path
+                return dlopen(pythonLibraryPath!, RTLD_NOW | RTLD_GLOBAL);
+            }
+
             return NativeLibrary.Load(pythonLibraryPath!, assembly, null);
         }
         return NativeLibrary.Load(libraryName, assembly, searchPath);

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -36,7 +36,7 @@ internal unsafe partial class CPythonAPI : IDisposable
     const int RTLD_LOCAL=0x4;
     const int RTLD_GLOBAL=0x8;
 
-    [LibraryImport("/usr/lib/x86_64-linux-gnu/libdl.so.2", StringMarshalling = StringMarshalling.Utf8)]
+    [LibraryImport("libdl.so.2", StringMarshalling = StringMarshalling.Utf8)]
     private static partial nint dlopen(string path, int flags);
 
 

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -42,7 +42,6 @@ internal unsafe partial class CPythonAPI : IDisposable
         GLOBAL = 0x00100
     }
 
-
     [LibraryImport("libdl.so.2", StringMarshalling = StringMarshalling.Utf8)]
     private static partial nint dlopen(string path, int flags);
 

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -46,7 +46,7 @@ internal unsafe partial class CPythonAPI : IDisposable
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){
                 // TODO: find how to load libdl.so without hardcoding the path
-                return dlopen(pythonLibraryPath!, RTLD_NOW | RTLD_GLOBAL);
+                return dlopen(pythonLibraryPath!, RTLD_LAZY | RTLD_GLOBAL);
             }
 
             return NativeLibrary.Load(pythonLibraryPath!, assembly, null);

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -49,6 +49,8 @@ internal unsafe partial class CPythonAPI : IDisposable
     {
         if (libraryName == PythonLibraryName)
         {
+            // Override default dlopen flags on linux to allow global symbol resolution (required in extension modules)
+            // See https://github.com/tonybaloney/CSnakes/issues/112#issuecomment-2290643468
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){
                 return dlopen(pythonLibraryPath!, (int)(RTLD.LAZY | RTLD.GLOBAL));
             }

--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -31,10 +31,17 @@ internal unsafe partial class CPythonAPI : IDisposable
         }
     }
 
-    const int RTLD_LAZY=0x1;
-    const int RTLD_NOW=0x2;
-    const int RTLD_LOCAL=0x4;
-    const int RTLD_GLOBAL=0x8;
+    [Flags]
+    private enum RTLD : int
+    {
+        LOCAL = 0,
+        LAZY  = 1,
+        NOW = 2,
+        NOLOAD=4,
+        DEEPBIND=8,
+        GLOBAL=0x00100
+    }
+
 
     [LibraryImport("libdl.so.2", StringMarshalling = StringMarshalling.Utf8)]
     private static partial nint dlopen(string path, int flags);
@@ -45,8 +52,7 @@ internal unsafe partial class CPythonAPI : IDisposable
         if (libraryName == PythonLibraryName)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){
-                // TODO: find how to load libdl.so without hardcoding the path
-                return dlopen(pythonLibraryPath!, RTLD_LAZY | RTLD_GLOBAL);
+                return dlopen(pythonLibraryPath!, (int)(RTLD.LAZY | RTLD.GLOBAL));
             }
 
             return NativeLibrary.Load(pythonLibraryPath!, assembly, null);

--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -1,10 +1,12 @@
 ﻿using CSnakes.Runtime.Python;
+using Xunit;
 
 namespace Integration.Tests;
 
 public class BufferTests : IntegrationTestBase
 {
     [Fact]
+    [Trait("requires", "numpy")]
     public void TestBoolBuffer()
     {
         var testModule = Env.TestBuffer();

--- a/src/Integration.Tests/TestDependency.cs
+++ b/src/Integration.Tests/TestDependency.cs
@@ -7,9 +7,6 @@ public class TestDependency : IntegrationTestBase
     [Fact]
     public void VerifyInstalledPackage()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) // TODO: Fix virtual environments on Linux
-        {
-            Assert.True(Env.TestDependency().TestNothing());
-        }
+        Assert.True(Env.TestDependency().TestNothing());
     }
 }


### PR DESCRIPTION
.Net LoadLibrary doesn't offer a way of setting the RTLD flags for Linux.

Python needs global symbols so that further dynamically loaded libraries can resolve symbols from the Python API. 

Our current workaround is to LD_PRELOAD the `libpython` so in the devcontainer and the tests. But this isn't practical for all users.

Fixes #112 