### PR TITLE
Add Conda Environment Management and Locator Support

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -20,7 +20,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      - uses: conda-incubator/setup-miniconda@v3
+        id: setup-conda
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
       - name: Setup Python
         id: installpython
         uses: actions/setup-python@v5

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+      - name: cleanup conda-incubator/setup-miniconda
+        run: conda clean --all --yes
       - name: Setup Python
         id: installpython
         uses: actions/setup-python@v5

--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -34,7 +34,8 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack src/CSnakes.Runtime --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
+        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
+        working-directory: src
 
       - name: Publish NuGet packages as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
+        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ../nuget -p:VersionSuffix='alpha.${{ github.run_number }}'
         working-directory: src
 
       - name: Publish NuGet packages as artifacts

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -39,7 +39,8 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack src/CSnakes.Runtime --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='beta.${{ github.run_number }}'
+        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='beta.${{ github.run_number }}'
+        working-directory: src
 
       - name: Publish NuGet packages as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:VersionSuffix='beta.${{ github.run_number }}'
+        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ../nuget -p:VersionSuffix='beta.${{ github.run_number }}'
         working-directory: src
 
       - name: Publish NuGet packages as artifacts

--- a/.github/workflows/dotnet-publish-release.yml
+++ b/.github/workflows/dotnet-publish-release.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget
+        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ../nuget
         working-directory: src
 
       - name: Publish NuGet packages as artifacts

--- a/.github/workflows/dotnet-publish-release.yml
+++ b/.github/workflows/dotnet-publish-release.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "src/**"
 
+env:
+  DOTNET_CONFIGURATION: Release
+
 jobs:
   publish-github-packages:
     runs-on: ubuntu-latest
@@ -26,15 +29,16 @@ jobs:
             9.0.x
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore -c ${{ env.DOTNET_CONFIGURATION }}
         working-directory: src
 
-      - name: Build release packages
-        run: dotnet build --no-restore -c Release
+      - name: Build ${{ env.DOTNET_CONFIGURATION }} packages
+        run: dotnet build --no-restore -c ${{ env.DOTNET_CONFIGURATION }}
         working-directory: src
 
       - name: Publish NuGet package CSnakes.Runtime
-        run: dotnet pack src/CSnakes.Runtime --no-build -c Release -o ./nuget
+        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget
+        working-directory: src
 
       - name: Publish NuGet packages as artifacts
         uses: actions/upload-artifact@v4

--- a/src/CSnakes.Runtime.Tests/Locators/PythonLocatorTests.cs
+++ b/src/CSnakes.Runtime.Tests/Locators/PythonLocatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using CSnakes.Runtime.Locators;
 using Microsoft.TestUtilities;
+using System;
 using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.Tests.Locators;
@@ -174,12 +175,9 @@ public class PythonLocatorTests
         Assert.Equal(folder, result.Folder);
     }
 
-    private class MockPythonLocator : PythonLocator
+    private class MockPythonLocator(Version version) : PythonLocator
     {
-        public MockPythonLocator(Version version)
-            : base(version)
-        {
-        }
+        protected override Version Version { get; } = version;
 
         public string GetPythonExecutablePathReal(string folder) => base.GetPythonExecutablePath(folder);
 

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -1,22 +1,9 @@
 ﻿using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
-
 
 namespace CSnakes.Runtime.EnvironmentManagement;
-internal class CondaEnvironmentManagement : IEnvironmentManagement
+internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaLocator conda, string environmentSpecPath) : IEnvironmentManagement
 {
-    private readonly string name;
-    private readonly bool ensureExists;
-    private readonly CondaLocator conda;
-
-    internal CondaEnvironmentManagement(string name, bool ensureExists, CondaLocator conda)
-    {
-        this.name = name;
-        this.conda = conda;
-        this.ensureExists = ensureExists;
-    }
-
     public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation)
     {
         if (!ensureExists)
@@ -28,10 +15,10 @@ internal class CondaEnvironmentManagement : IEnvironmentManagement
         {
             logger.LogInformation("Creating conda environment at {fullPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
             // TODO: Shell escape the name
-            var (process, _) = conda.ExecuteCondaCommand($"env create -n {name}");
+            var (process, result) = conda.ExecuteCondaCommand($"env create -n {name} -f {environmentSpecPath}");
             if (process.ExitCode != 0)
             {
-                logger.LogError("Failed to create conda environment {Error}.", process.StandardError.ReadToEnd());
+                logger.LogError("Failed to create conda environment {Error}.", result);
                 throw new InvalidOperationException("Could not create conda environment.");
             }
         }

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.Logging;
 
 namespace CSnakes.Runtime.EnvironmentManagement;
-internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaLocator conda, string environmentSpecPath) : IEnvironmentManagement
+internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaLocator conda, string? environmentSpecPath) : IEnvironmentManagement
 {
     public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation)
     {
@@ -13,14 +13,14 @@ internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaL
         var fullPath = Path.GetFullPath(GetPath());
         if (!Directory.Exists(fullPath))
         {
-            logger.LogInformation("Creating conda environment at {fullPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
-            // TODO: Shell escape the name
-            var result = conda.ExecuteCondaShellCommand($"env create -n {name} -f {environmentSpecPath}");
-            if (!result)
-            {
-                logger.LogError("Failed to create conda environment.");
-                throw new InvalidOperationException("Could not create conda environment");
-            }
+            logger.LogError("Cannot find conda environment at {fullPath}.", fullPath);
+            // TODO: Automate the creation of the conda environments. 
+            //var result = conda.ExecuteCondaShellCommand($"env create -n {name} -f {environmentSpecPath}");
+            //if (!result)
+            //{
+            //    logger.LogError("Failed to create conda environment.");
+            //    throw new InvalidOperationException("Could not create conda environment");
+            //}
         }
         else
         {

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -27,6 +27,7 @@ internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaL
         else
         {
             logger.LogDebug("Conda environment already exists at {fullPath}", fullPath);
+            // TODO: Check if the environment is up to date
         }
     }
 

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -20,7 +20,7 @@ internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaL
             {
                 logger.LogError("Failed to create conda environment {Error}.", error);
                 process.Dispose();
-                throw new InvalidOperationException("Could not create conda environment.");
+                throw new InvalidOperationException($"Could not create conda environment : {error}");
             }
             process.Dispose();
         }

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -2,9 +2,13 @@
 using Microsoft.Extensions.Logging;
 
 namespace CSnakes.Runtime.EnvironmentManagement;
-internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaLocator conda, string? environmentSpecPath) : IEnvironmentManagement
+#pragma warning disable CS9113 // Parameter is unread. There for future use.
+internal class CondaEnvironmentManagement(ILogger logger, string name, bool ensureExists, CondaLocator conda, string? environmentSpecPath) : IEnvironmentManagement
+#pragma warning restore CS9113 // Parameter is unread.
 {
-    public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation)
+    ILogger IEnvironmentManagement.Logger => logger;
+
+    public void EnsureEnvironment(PythonLocationMetadata pythonLocation)
     {
         if (!ensureExists)
             return;

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -1,0 +1,78 @@
+﻿using CSnakes.Runtime.Locators;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using System.IO;
+
+
+namespace CSnakes.Runtime.EnvironmentManagement;
+internal class CondaEnvironmentManagement : IEnvironmentManagement
+{
+    private readonly string name;
+    private readonly bool ensureExists;
+    private CondaLocator conda;
+
+    internal CondaEnvironmentManagement(string name, bool ensureExists, CondaLocator conda)
+    {
+        this.name = name;
+        this.conda = conda;
+        this.ensureExists = ensureExists;
+    }
+
+    public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation)
+    {
+        if (!ensureExists)
+            return;
+
+
+        var fullPath = Path.GetFullPath(GetPath());
+        if (!Directory.Exists(fullPath))
+        {
+            logger.LogInformation("Creating conda environment at {fullPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
+            using Process process1 = ExecutePythonCommand(pythonLocation, fullPath, $"-VV");
+            using Process process2 = ExecutePythonCommand(pythonLocation, fullPath, $"-m conda env create -n {name}");
+        }
+        else
+        {
+            logger.LogDebug("Conda environment already exists at {fullPath}", fullPath);
+        }
+
+        Process ExecutePythonCommand(PythonLocationMetadata pythonLocation, string? venvPath, string arguments)
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                WorkingDirectory = pythonLocation.Folder,
+                FileName = pythonLocation.PythonBinaryPath,
+                Arguments = arguments,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+            Process process = new() { StartInfo = startInfo };
+            process.OutputDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    logger.LogInformation("{Data}", e.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    logger.LogError("{Data}", e.Data);
+                }
+            };
+
+            process.Start();
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+            return process;
+        }
+    }
+
+    public string GetPath()
+    {
+        return Path.Combine(conda.CondaHome, "envs", name);
+    }
+}

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -1,7 +1,6 @@
 ﻿using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
-using System.IO;
 
 
 namespace CSnakes.Runtime.EnvironmentManagement;
@@ -28,46 +27,12 @@ internal class CondaEnvironmentManagement : IEnvironmentManagement
         if (!Directory.Exists(fullPath))
         {
             logger.LogInformation("Creating conda environment at {fullPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
-            using Process process1 = ExecutePythonCommand(pythonLocation, fullPath, $"-VV");
-            using Process process2 = ExecutePythonCommand(pythonLocation, fullPath, $"-m conda env create -n {name}");
+            using Process process1 = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-VV");
+            using Process process2 = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-m conda env create -n {name}");
         }
         else
         {
             logger.LogDebug("Conda environment already exists at {fullPath}", fullPath);
-        }
-
-        Process ExecutePythonCommand(PythonLocationMetadata pythonLocation, string? venvPath, string arguments)
-        {
-            ProcessStartInfo startInfo = new()
-            {
-                WorkingDirectory = pythonLocation.Folder,
-                FileName = pythonLocation.PythonBinaryPath,
-                Arguments = arguments,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            };
-            Process process = new() { StartInfo = startInfo };
-            process.OutputDataReceived += (sender, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    logger.LogInformation("{Data}", e.Data);
-                }
-            };
-
-            process.ErrorDataReceived += (sender, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    logger.LogError("{Data}", e.Data);
-                }
-            };
-
-            process.Start();
-            process.BeginErrorReadLine();
-            process.BeginOutputReadLine();
-            process.WaitForExit();
-            return process;
         }
     }
 

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -15,12 +15,14 @@ internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaL
         {
             logger.LogInformation("Creating conda environment at {fullPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
             // TODO: Shell escape the name
-            var (process, result) = conda.ExecuteCondaCommand($"env create -n {name} -f {environmentSpecPath}");
+            var (process, _, error) = conda.ExecuteCondaCommand($"env create -n {name} -f {environmentSpecPath}");
             if (process.ExitCode != 0)
             {
-                logger.LogError("Failed to create conda environment {Error}.", result);
+                logger.LogError("Failed to create conda environment {Error}.", error);
+                process.Dispose();
                 throw new InvalidOperationException("Could not create conda environment.");
             }
+            process.Dispose();
         }
         else
         {

--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -15,14 +15,12 @@ internal class CondaEnvironmentManagement(string name, bool ensureExists, CondaL
         {
             logger.LogInformation("Creating conda environment at {fullPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
             // TODO: Shell escape the name
-            var (process, _, error) = conda.ExecuteCondaCommand($"env create -n {name} -f {environmentSpecPath}");
-            if (process.ExitCode != 0)
+            var result = conda.ExecuteCondaShellCommand($"env create -n {name} -f {environmentSpecPath}");
+            if (!result)
             {
-                logger.LogError("Failed to create conda environment {Error}.", error);
-                process.Dispose();
-                throw new InvalidOperationException($"Could not create conda environment : {error}");
+                logger.LogError("Failed to create conda environment.");
+                throw new InvalidOperationException("Could not create conda environment");
             }
-            process.Dispose();
         }
         else
         {

--- a/src/CSnakes.Runtime/EnvironmentManagement/IEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/IEnvironmentManagement.cs
@@ -5,8 +5,10 @@ using System.Runtime.InteropServices;
 namespace CSnakes.Runtime.EnvironmentManagement;
 public interface IEnvironmentManagement
 {
+    ILogger Logger { get; }
+
     public string GetPath();
-    public virtual string GetExtraPackagePath(ILogger logger, PythonLocationMetadata location) {
+    public virtual string GetExtraPackagePath(PythonLocationMetadata location) {
         var envLibPath = string.Empty;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             envLibPath = Path.Combine(GetPath(), "Lib", "site-packages");
@@ -15,9 +17,9 @@ public interface IEnvironmentManagement
             string suffix = location.FreeThreaded ? "t" : "";
             envLibPath = Path.Combine(GetPath(), "lib", $"python{location.Version.Major}.{location.Version.Minor}{suffix}", "site-packages");
         }
-        logger.LogDebug("Adding environment site-packages to extra paths: {VenvLibPath}", envLibPath);
+        Logger.LogDebug("Adding environment site-packages to extra paths: {VenvLibPath}", envLibPath);
         return envLibPath;
     }
-    public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation);
+    public void EnsureEnvironment(PythonLocationMetadata pythonLocation);
 
 }

--- a/src/CSnakes.Runtime/EnvironmentManagement/IEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/IEnvironmentManagement.cs
@@ -1,0 +1,23 @@
+﻿using CSnakes.Runtime.Locators;
+using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
+
+namespace CSnakes.Runtime.EnvironmentManagement;
+public interface IEnvironmentManagement
+{
+    public string GetPath();
+    public virtual string GetExtraPackagePath(ILogger logger, PythonLocationMetadata location) {
+        var envLibPath = string.Empty;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            envLibPath = Path.Combine(GetPath(), "Lib", "site-packages");
+        else
+        {
+            string suffix = location.FreeThreaded ? "t" : "";
+            envLibPath = Path.Combine(GetPath(), "lib", $"python{location.Version.Major}.{location.Version.Minor}{suffix}", "site-packages");
+        }
+        logger.LogDebug("Adding environment site-packages to extra paths: {VenvLibPath}", envLibPath);
+        return envLibPath;
+    }
+    public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation);
+
+}

--- a/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
@@ -28,46 +28,12 @@ internal class VenvEnvironmentManagement : IEnvironmentManagement
         if (!Directory.Exists(path))
         {
             logger.LogInformation("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
-            using Process process1 = ExecutePythonCommand(pythonLocation, fullPath, $"-VV");
-            using Process process2 = ExecutePythonCommand(pythonLocation, fullPath, $"-m venv {fullPath}");
+            using Process process1 = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-VV");
+            using Process process2 = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-m venv {fullPath}");
         }
         else
         {
             logger.LogDebug("Virtual environment already exists at {VirtualEnvPath}", fullPath);
-        }
-
-        Process ExecutePythonCommand(PythonLocationMetadata pythonLocation, string? venvPath, string arguments)
-        {
-            ProcessStartInfo startInfo = new()
-            {
-                WorkingDirectory = pythonLocation.Folder,
-                FileName = pythonLocation.PythonBinaryPath,
-                Arguments = arguments,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            };
-            Process process = new() { StartInfo = startInfo };
-            process.OutputDataReceived += (sender, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    logger.LogInformation("{Data}", e.Data);
-                }
-            };
-
-            process.ErrorDataReceived += (sender, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    logger.LogError("{Data}", e.Data);
-                }
-            };
-
-            process.Start();
-            process.BeginErrorReadLine();
-            process.BeginOutputReadLine();
-            process.WaitForExit();
-            return process;
         }
     }
 

--- a/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
@@ -1,0 +1,78 @@
+﻿using CSnakes.Runtime.Locators;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+namespace CSnakes.Runtime.EnvironmentManagement;
+internal class VenvEnvironmentManagement : IEnvironmentManagement
+{
+    private readonly string path;
+    private readonly bool ensureExists;
+
+    internal VenvEnvironmentManagement(string path, bool ensureExists)
+    {
+        this.path = path;
+        this.ensureExists = ensureExists;
+    }
+
+    public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation)
+    {
+        if (!ensureExists)
+            return;
+
+        if (string.IsNullOrEmpty(path))
+        {
+            logger.LogError("Virtual environment location is not set but it was requested to be created.");
+            throw new ArgumentNullException(nameof(path), "Virtual environment location is not set.");
+        }
+        var fullPath = Path.GetFullPath(path);
+        if (!Directory.Exists(path))
+        {
+            logger.LogInformation("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
+            using Process process1 = ExecutePythonCommand(pythonLocation, fullPath, $"-VV");
+            using Process process2 = ExecutePythonCommand(pythonLocation, fullPath, $"-m venv {fullPath}");
+        }
+        else
+        {
+            logger.LogDebug("Virtual environment already exists at {VirtualEnvPath}", fullPath);
+        }
+
+        Process ExecutePythonCommand(PythonLocationMetadata pythonLocation, string? venvPath, string arguments)
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                WorkingDirectory = pythonLocation.Folder,
+                FileName = pythonLocation.PythonBinaryPath,
+                Arguments = arguments,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+            Process process = new() { StartInfo = startInfo };
+            process.OutputDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    logger.LogInformation("{Data}", e.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    logger.LogError("{Data}", e.Data);
+                }
+            };
+
+            process.Start();
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+            return process;
+        }
+    }
+
+    public string GetPath()
+    {
+        return path;
+    }
+}

--- a/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
@@ -1,22 +1,12 @@
 ﻿using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.Logging;
-using System.ComponentModel;
-using System.Diagnostics;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace CSnakes.Runtime.EnvironmentManagement;
-internal class VenvEnvironmentManagement : IEnvironmentManagement
+internal class VenvEnvironmentManagement(ILogger logger, string path, bool ensureExists) : IEnvironmentManagement
 {
-    private readonly string path;
-    private readonly bool ensureExists;
+    ILogger IEnvironmentManagement.Logger => logger;
 
-    internal VenvEnvironmentManagement(string path, bool ensureExists)
-    {
-        this.path = path;
-        this.ensureExists = ensureExists;
-    }
-
-    public void EnsureEnvironment(ILogger logger, PythonLocationMetadata pythonLocation)
+    public void EnsureEnvironment(PythonLocationMetadata pythonLocation)
     {
         if (!ensureExists)
             return;

--- a/src/CSnakes.Runtime/IPythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/IPythonEnvironmentBuilder.cs
@@ -19,13 +19,14 @@ public interface IPythonEnvironmentBuilder
 
 
     /// <summary>
-    /// Sets the virtual environment path for the Python environment being built to a named conda environment.
+    /// Sets the virtual environment path for the Python environment to a named conda environment.
+    /// This requires Python to be installed via Conda and usage of the <see cref="ServiceCollectionExtensions.FromConda(IPythonEnvironmentBuilder, string)"/> locator. 
     /// </summary>
-    /// <param name="name">The name of the conda environment.</param>
-    /// <param name="environmentSpecPath">The path to the conda environment specification file (environment.yml).</param>
-    /// <param name="ensureEnvironment">Indicates whether to ensure the conda environment exists.</param>
+    /// <param name="name">The name of the conda environment to use.</param>
+    /// <param name="environmentSpecPath">The path to the conda environment specification file (environment.yml), used if ensureEnvironment = true.</param>
+    /// <param name="ensureEnvironment">Indicates whether to create the conda environment if it doesn't exist (not yet supported).</param>
     /// <returns>The current instance of the <see cref="IPythonEnvironmentBuilder"/>.</returns>
-    IPythonEnvironmentBuilder WithCondaEnvironment(string name, string environmentSpecPath, bool ensureEnvironment = true);
+    IPythonEnvironmentBuilder WithCondaEnvironment(string name, string? environmentSpecPath = null, bool ensureEnvironment = false);
 
     /// <summary>
     /// Sets the home directory for the Python environment being built.

--- a/src/CSnakes.Runtime/IPythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/IPythonEnvironmentBuilder.cs
@@ -22,9 +22,10 @@ public interface IPythonEnvironmentBuilder
     /// Sets the virtual environment path for the Python environment being built to a named conda environment.
     /// </summary>
     /// <param name="name">The name of the conda environment.</param>
+    /// <param name="environmentSpecPath">The path to the conda environment specification file (environment.yml).</param>
     /// <param name="ensureEnvironment">Indicates whether to ensure the conda environment exists.</param>
     /// <returns>The current instance of the <see cref="IPythonEnvironmentBuilder"/>.</returns>
-    IPythonEnvironmentBuilder WithCondaEnvironment(string name, bool ensureEnvironment = true);
+    IPythonEnvironmentBuilder WithCondaEnvironment(string name, string environmentSpecPath, bool ensureEnvironment = true);
 
     /// <summary>
     /// Sets the home directory for the Python environment being built.

--- a/src/CSnakes.Runtime/IPythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/IPythonEnvironmentBuilder.cs
@@ -13,9 +13,18 @@ public interface IPythonEnvironmentBuilder
     /// Sets the virtual environment path for the Python environment being built.
     /// </summary>
     /// <param name="path">The path to the virtual environment.</param>
-    /// <param name="ensureVirtualEnvironment">Indicates whether to ensure the virtual environment exists.</param>
+    /// <param name="ensureEnvironment">Indicates whether to ensure the virtual environment exists.</param>
     /// <returns>The current instance of the <see cref="IPythonEnvironmentBuilder"/>.</returns>
-    IPythonEnvironmentBuilder WithVirtualEnvironment(string path, bool ensureVirtualEnvironment = true);
+    IPythonEnvironmentBuilder WithVirtualEnvironment(string path, bool ensureEnvironment = true);
+
+
+    /// <summary>
+    /// Sets the virtual environment path for the Python environment being built to a named conda environment.
+    /// </summary>
+    /// <param name="name">The name of the conda environment.</param>
+    /// <param name="ensureEnvironment">Indicates whether to ensure the conda environment exists.</param>
+    /// <returns>The current instance of the <see cref="IPythonEnvironmentBuilder"/>.</returns>
+    IPythonEnvironmentBuilder WithCondaEnvironment(string name, bool ensureEnvironment = true);
 
     /// <summary>
     /// Sets the home directory for the Python environment being built.

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -20,7 +20,7 @@ internal class CondaLocator : PythonLocator
         var (process, result) = ExecuteCondaCommand($"info --json");
         if (process.ExitCode != 0)
         {
-            logger.LogError("Failed to determine Python version from Conda {Error}.", process.StandardError.ReadToEnd());
+            logger.LogError("Failed to determine Python version from Conda {Error}.", result);
             throw new InvalidOperationException("Could not determine Python version from Conda.");
         }
 

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -48,6 +48,11 @@ internal class CondaLocator : PythonLocator
         return ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
     }
 
+    internal bool ExecuteCondaShellCommand(string arguments)
+    {
+        return ProcessUtils.ExecuteShellCommand(logger, condaBinaryPath, arguments);
+    }
+
     public override PythonLocationMetadata LocatePython() =>
         LocatePythonInternal(folder);
 

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -1,0 +1,9 @@
+﻿namespace CSnakes.Runtime.Locators;
+
+internal class CondaLocator(string folder, Version version) : PythonLocator(version)
+{
+    public override PythonLocationMetadata LocatePython() =>
+        LocatePythonInternal(folder);
+
+    public string CondaHome { get { return folder; } }
+}

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -45,8 +45,7 @@ internal class CondaLocator : PythonLocator
 
     internal (Process process, string? output, string? errors) ExecuteCondaCommand(string arguments) => ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
 
-    internal bool ExecuteCondaShellCommand(string arguments) => return ProcessUtils.ExecuteShellCommand(logger, 
-    }
+    internal bool ExecuteCondaShellCommand(string arguments) => ProcessUtils.ExecuteShellCommand(logger, condaBinaryPath, arguments);
 
     public override PythonLocationMetadata LocatePython() =>
         LocatePythonInternal(folder);

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -17,13 +17,13 @@ internal class CondaLocator : PythonLocator
     {
         this.logger = logger;
         this.condaBinaryPath = condaBinaryPath;
-        var (process, result) = ExecuteCondaCommand($"info --json");
+        var (process, result, errors) = ExecuteCondaCommand($"info --json");
         if (process.ExitCode != 0)
         {
-            logger.LogError("Failed to determine Python version from Conda {Error}.", result);
+            logger.LogError("Failed to determine Python version from Conda {Error}.", errors);
             throw new InvalidOperationException("Could not determine Python version from Conda.");
         }
-
+        process.Dispose();
         // Parse JSON output to get the version
         var json = JsonNode.Parse(result ?? "")!;
         var versionAttribute = json["python_version"]?.GetValue<string>() ?? string.Empty;
@@ -43,7 +43,7 @@ internal class CondaLocator : PythonLocator
         folder = basePrefix;
     }
 
-    internal (Process, string?) ExecuteCondaCommand(string arguments)
+    internal (Process process, string? output, string? errors) ExecuteCondaCommand(string arguments)
     {
         return ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
     }

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -1,7 +1,53 @@
-﻿namespace CSnakes.Runtime.Locators;
+﻿using Microsoft.Extensions.Logging;
+using System.Text.Json.Nodes;
+using System.Diagnostics;
 
-internal class CondaLocator(string folder, Version version) : PythonLocator(version)
+namespace CSnakes.Runtime.Locators;
+
+internal class CondaLocator : PythonLocator
 {
+    private readonly string folder;
+    private readonly Version version;
+    private readonly ILogger logger;
+    private readonly string condaBinaryPath;
+
+    protected override Version Version { get { return version; } }
+
+    internal CondaLocator(ILogger logger, string condaBinaryPath)
+    {
+        this.logger = logger;
+        this.condaBinaryPath = condaBinaryPath;
+        var (process, result) = ExecuteCondaCommand($"info --json");
+        if (process.ExitCode != 0)
+        {
+            logger.LogError("Failed to determine Python version from Conda {Error}.", process.StandardError.ReadToEnd());
+            throw new InvalidOperationException("Could not determine Python version from Conda.");
+        }
+
+        // Parse JSON output to get the version
+        var json = JsonNode.Parse(result ?? "")!;
+        var versionAttribute = json["python_version"]?.GetValue<string>() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(versionAttribute))
+        {
+            throw new InvalidOperationException("Could not determine Python version from Conda.");
+        }
+
+        var basePrefix = json["root_prefix"]?.GetValue<string>() ?? string.Empty;
+        if (string.IsNullOrEmpty(basePrefix))
+        {
+            throw new InvalidOperationException("Could not determine Conda home.");
+        }
+
+        version = ServiceCollectionExtensions.ParsePythonVersion(versionAttribute);
+        folder = basePrefix;
+    }
+
+    internal (Process, string?) ExecuteCondaCommand(string arguments)
+    {
+        return ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
+    }
+
     public override PythonLocationMetadata LocatePython() =>
         LocatePythonInternal(folder);
 

--- a/src/CSnakes.Runtime/Locators/EnvironmentVariableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/EnvironmentVariableLocator.cs
@@ -1,7 +1,9 @@
 ﻿namespace CSnakes.Runtime.Locators;
 
-internal class EnvironmentVariableLocator(string variable, Version version) : PythonLocator(version)
+internal class EnvironmentVariableLocator(string variable, Version version) : PythonLocator
 {
+    protected override Version Version { get; } = version;
+
     public override PythonLocationMetadata LocatePython()
     {
         var envValue = Environment.GetEnvironmentVariable(variable);

--- a/src/CSnakes.Runtime/Locators/FolderLocator.cs
+++ b/src/CSnakes.Runtime/Locators/FolderLocator.cs
@@ -1,6 +1,8 @@
 ﻿namespace CSnakes.Runtime.Locators;
-internal class FolderLocator(string folder, Version version) : PythonLocator(version)
+internal class FolderLocator(string folder, Version version) : PythonLocator
 {
+    protected override Version Version { get; } = version;
+
     public override PythonLocationMetadata LocatePython() =>
         LocatePythonInternal(folder);
 }

--- a/src/CSnakes.Runtime/Locators/MacOSInstallerLocator.cs
+++ b/src/CSnakes.Runtime/Locators/MacOSInstallerLocator.cs
@@ -1,8 +1,10 @@
 ﻿using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.Locators;
-internal class MacOSInstallerLocator(Version version, bool freeThreaded = false) : PythonLocator(version)
+internal class MacOSInstallerLocator(Version version, bool freeThreaded = false) : PythonLocator
 {
+    protected override Version Version { get; } = version;
+
     public override PythonLocationMetadata LocatePython()
     {
         string framework = freeThreaded ? "PythonT.framework" : "Python.framework";

--- a/src/CSnakes.Runtime/Locators/NuGetLocator.cs
+++ b/src/CSnakes.Runtime/Locators/NuGetLocator.cs
@@ -2,8 +2,10 @@
 
 namespace CSnakes.Runtime.Locators;
 
-internal class NuGetLocator(string nugetVersion, Version version) : PythonLocator(version)
+internal class NuGetLocator(string nugetVersion, Version version) : PythonLocator
 {
+    protected override Version Version { get; } = version;
+
     public override PythonLocationMetadata LocatePython()
     {
         var globalNugetPackagesPath = (NuGetPackages: Environment.GetEnvironmentVariable("NUGET_PACKAGES"),

--- a/src/CSnakes.Runtime/Locators/PythonLocator.cs
+++ b/src/CSnakes.Runtime/Locators/PythonLocator.cs
@@ -9,12 +9,12 @@ namespace CSnakes.Runtime.Locators;
 /// Initializes a new instance of the <see cref="PythonLocator"/> class.
 /// </remarks>
 /// <param name="version">The version of Python.</param>
-public abstract class PythonLocator(Version version)
+public abstract class PythonLocator
 {
     /// <summary>
     /// Gets the version of Python.
     /// </summary>
-    protected Version Version { get ; } = version;
+    protected abstract Version Version { get; }
 
     /// <summary>
     /// Locates the Python installation.

--- a/src/CSnakes.Runtime/Locators/SourceLocator.cs
+++ b/src/CSnakes.Runtime/Locators/SourceLocator.cs
@@ -2,8 +2,10 @@
 
 namespace CSnakes.Runtime.Locators;
 
-internal class SourceLocator(string folder, Version version, bool debug = true, bool freeThreaded = false) : PythonLocator(version)
+internal class SourceLocator(string folder, Version version, bool debug = true, bool freeThreaded = false) : PythonLocator
 {
+    protected override Version Version { get; } = version;
+
     protected bool Debug => debug;
 
     protected override string GetLibPythonPath(string folder, bool freeThreaded = false)

--- a/src/CSnakes.Runtime/Locators/WindowsInstallerLocator.cs
+++ b/src/CSnakes.Runtime/Locators/WindowsInstallerLocator.cs
@@ -1,8 +1,10 @@
 ﻿using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.Locators;
-internal class WindowsInstallerLocator(Version version) : PythonLocator(version)
+internal class WindowsInstallerLocator(Version version) : PythonLocator
 {
+    protected override Version Version { get; } = version;
+
     readonly string programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
     public override PythonLocationMetadata LocatePython()

--- a/src/CSnakes.Runtime/Locators/WindowsStoreLocator.cs
+++ b/src/CSnakes.Runtime/Locators/WindowsStoreLocator.cs
@@ -1,8 +1,10 @@
 ﻿using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.Locators;
-internal class WindowsStoreLocator(Version version) : PythonLocator(version)
+internal class WindowsStoreLocator(Version version) : PythonLocator
 {
+    protected override Version Version { get; } = version;
+
     public override PythonLocationMetadata LocatePython()
     {
         var windowsStorePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", "Python", $"Python{Version.Major}.{Version.Minor}");

--- a/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
@@ -1,4 +1,6 @@
-﻿namespace CSnakes.Runtime.PackageManagement;
+﻿using CSnakes.Runtime.EnvironmentManagement;
+
+namespace CSnakes.Runtime.PackageManagement;
 
 /// <summary>
 /// Represents an interface for installing Python packages.
@@ -11,5 +13,5 @@ public interface IPythonPackageInstaller
     /// <param name="home">The home directory.</param>
     /// <param name="virtualEnvironmentLocation">The location of the virtual environment (optional).</param>
     /// <returns>A task representing the asynchronous package installation operation.</returns>
-    Task InstallPackages(string home, string? virtualEnvironmentLocation);
+    Task InstallPackages(string home, IEnvironmentManagement? environmentManager);
 }

--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -5,10 +5,9 @@ using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.PackageManagement;
 
-internal class PipInstaller(ILogger<PipInstaller> logger) : IPythonPackageInstaller
+internal class PipInstaller(ILogger<PipInstaller> logger, string requirementsFileName) : IPythonPackageInstaller
 {
     static readonly string pipBinaryName = $"pip{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
-    static readonly string requirementsFileName = "requirements.txt";
 
     public Task InstallPackages(string home, IEnvironmentManagement? environmentManager)
     {

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -1,0 +1,43 @@
+﻿using CSnakes.Runtime.Locators;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+namespace CSnakes.Runtime
+{
+    internal static class ProcessUtils
+    {
+        internal static Process ExecutePythonCommand(ILogger logger, PythonLocationMetadata pythonLocation, string arguments)
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                WorkingDirectory = pythonLocation.Folder,
+                FileName = pythonLocation.PythonBinaryPath,
+                Arguments = arguments,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+            Process process = new() { StartInfo = startInfo };
+            process.OutputDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    logger.LogInformation("{Data}", e.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    logger.LogError("{Data}", e.Data);
+                }
+            };
+
+            process.Start();
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+            return process;
+        }
+    }
+}

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -6,7 +6,7 @@ namespace CSnakes.Runtime
 {
     internal static class ProcessUtils
     {
-        internal static Process ExecutePythonCommand(ILogger logger, PythonLocationMetadata pythonLocation, string arguments)
+        internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger logger, PythonLocationMetadata pythonLocation, string arguments)
         {
             ProcessStartInfo startInfo = new()
             {
@@ -16,11 +16,10 @@ namespace CSnakes.Runtime
                 RedirectStandardError = true,
                 RedirectStandardOutput = true
             };
-            var (process, _) = ExecuteCommand(logger, startInfo);
-            return process;
+            return ExecuteCommand(logger, startInfo);
         }
 
-        internal static (Process proc, string? result) ExecuteCommand(ILogger logger, string fileName, string arguments)
+        internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, string fileName, string arguments)
         {
             ProcessStartInfo startInfo = new()
             {
@@ -32,9 +31,10 @@ namespace CSnakes.Runtime
             return ExecuteCommand(logger, startInfo);
         }
 
-        private static (Process proc, string? result) ExecuteCommand(ILogger logger, ProcessStartInfo startInfo) { 
+        private static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, ProcessStartInfo startInfo) { 
             Process process = new() { StartInfo = startInfo };
             string? result = null;
+            string? errors = null;
             process.OutputDataReceived += (sender, e) =>
             {
                 if (!string.IsNullOrEmpty(e.Data))
@@ -48,6 +48,7 @@ namespace CSnakes.Runtime
             {
                 if (!string.IsNullOrEmpty(e.Data))
                 {
+                    errors += e.Data;
                     logger.LogError("{Data}", e.Data);
                 }
             };
@@ -56,7 +57,7 @@ namespace CSnakes.Runtime
             process.BeginErrorReadLine();
             process.BeginOutputReadLine();
             process.WaitForExit();
-            return (process, result);
+            return (process, result, errors);
         }
     }
 }

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -1,80 +1,78 @@
 ﻿using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
-namespace CSnakes.Runtime
+namespace CSnakes.Runtime;
+
+internal static class ProcessUtils
 {
-    internal static class ProcessUtils
+    internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger logger, PythonLocationMetadata pythonLocation, string arguments)
     {
-        internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger logger, PythonLocationMetadata pythonLocation, string arguments)
+        ProcessStartInfo startInfo = new()
         {
-            ProcessStartInfo startInfo = new()
-            {
-                WorkingDirectory = pythonLocation.Folder,
-                FileName = pythonLocation.PythonBinaryPath,
-                Arguments = arguments,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            };
-            return ExecuteCommand(logger, startInfo);
-        }
+            WorkingDirectory = pythonLocation.Folder,
+            FileName = pythonLocation.PythonBinaryPath,
+            Arguments = arguments,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        return ExecuteCommand(logger, startInfo);
+    }
 
-        internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, string fileName, string arguments)
+    internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, string fileName, string arguments)
+    {
+        ProcessStartInfo startInfo = new()
         {
-            ProcessStartInfo startInfo = new()
-            {
-                FileName = fileName,
-                Arguments = arguments,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            };
-            return ExecuteCommand(logger, startInfo);
-        }
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        return ExecuteCommand(logger, startInfo);
+    }
 
-        internal static bool ExecuteShellCommand(ILogger logger, string fileName, string arguments)
+    internal static bool ExecuteShellCommand(ILogger logger, string fileName, string arguments)
+    {
+        logger.LogInformation("Executing shell command {FileName} {Arguments}", fileName, arguments);
+        ProcessStartInfo startInfo = new()
         {
-            logger.LogInformation("Executing shell command {FileName} {Arguments}", fileName, arguments);
-            ProcessStartInfo startInfo = new()
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = true,
+        };
+        Process process = new() { StartInfo = startInfo };
+        process.Start();
+        process.WaitForExit();
+        return process.ExitCode == 0;
+    }
+
+
+    private static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, ProcessStartInfo startInfo) { 
+        Process process = new() { StartInfo = startInfo };
+        string? result = null;
+        string? errors = null;
+        process.OutputDataReceived += (sender, e) =>
+        {
+            if (!string.IsNullOrEmpty(e.Data))
             {
-                FileName = fileName,
-                Arguments = arguments,
-                UseShellExecute = true,
-            };
-            Process process = new() { StartInfo = startInfo };
-            process.Start();
-            process.WaitForExit();
-            return process.ExitCode == 0;
-        }
+                result += e.Data;
+                logger.LogInformation("{Data}", e.Data);
+            }
+        };
 
-
-        private static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, ProcessStartInfo startInfo) { 
-            Process process = new() { StartInfo = startInfo };
-            string? result = null;
-            string? errors = null;
-            process.OutputDataReceived += (sender, e) =>
+        process.ErrorDataReceived += (sender, e) =>
+        {
+            if (!string.IsNullOrEmpty(e.Data))
             {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    result += e.Data;
-                    logger.LogInformation("{Data}", e.Data);
-                }
-            };
+                errors += e.Data;
+                logger.LogError("{Data}", e.Data);
+            }
+        };
 
-            process.ErrorDataReceived += (sender, e) =>
-            {
-                if (!string.IsNullOrEmpty(e.Data))
-                {
-                    errors += e.Data;
-                    logger.LogError("{Data}", e.Data);
-                }
-            };
-
-            process.Start();
-            process.BeginErrorReadLine();
-            process.BeginOutputReadLine();
-            process.WaitForExit();
-            return (process, result, errors);
-        }
+        process.Start();
+        process.BeginErrorReadLine();
+        process.BeginOutputReadLine();
+        process.WaitForExit();
+        return (process, result, errors);
     }
 }

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -1,6 +1,7 @@
 ﻿using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace CSnakes.Runtime
 {
@@ -30,6 +31,22 @@ namespace CSnakes.Runtime
             };
             return ExecuteCommand(logger, startInfo);
         }
+
+        internal static bool ExecuteShellCommand(ILogger logger, string fileName, string arguments)
+        {
+            logger.LogInformation("Executing shell command {FileName} {Arguments}", fileName, arguments);
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = true,
+            };
+            Process process = new() { StartInfo = startInfo };
+            process.Start();
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+
 
         private static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, ProcessStartInfo startInfo) { 
             Process process = new() { StartInfo = startInfo };

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -16,11 +16,30 @@ namespace CSnakes.Runtime
                 RedirectStandardError = true,
                 RedirectStandardOutput = true
             };
+            var (process, _) = ExecuteCommand(logger, startInfo);
+            return process;
+        }
+
+        internal static (Process proc, string? result) ExecuteCommand(ILogger logger, string fileName, string arguments)
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+            return ExecuteCommand(logger, startInfo);
+        }
+
+        private static (Process proc, string? result) ExecuteCommand(ILogger logger, ProcessStartInfo startInfo) { 
             Process process = new() { StartInfo = startInfo };
+            string? result = null;
             process.OutputDataReceived += (sender, e) =>
             {
                 if (!string.IsNullOrEmpty(e.Data))
                 {
+                    result += e.Data;
                     logger.LogInformation("{Data}", e.Data);
                 }
             };
@@ -37,7 +56,7 @@ namespace CSnakes.Runtime
             process.BeginErrorReadLine();
             process.BeginOutputReadLine();
             process.WaitForExit();
-            return process;
+            return (process, result);
         }
     }
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -60,9 +60,9 @@ internal class PythonEnvironment : IPythonEnvironment
 
         if (environmentManager is not null) {
             
-            extraPaths = [.. options.ExtraPaths, environmentManager.GetExtraPackagePath(logger, location!)];
+            extraPaths = [.. options.ExtraPaths, environmentManager.GetExtraPackagePath(location!)];
 
-            environmentManager.EnsureEnvironment(logger, location);
+            environmentManager.EnsureEnvironment(location);
         }
 
         logger.LogInformation("Setting up Python environment from {PythonLocation} using home of {Home}", location.Folder, home);

--- a/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
@@ -17,7 +17,7 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
         Services.AddSingleton<IEnvironmentManagement>(
             sp =>
             {
-                var logger = sp.GetRequiredService<ILogger>();
+                var logger = sp.GetRequiredService<ILogger<VenvEnvironmentManagement>>();
                 return new VenvEnvironmentManagement(logger, path, ensureExists);
             });
         return this;
@@ -33,7 +33,7 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
                 try
                 {
                     var condaLocator = sp.GetRequiredService<CondaLocator>();
-                    var logger = sp.GetRequiredService<ILogger>();
+                    var logger = sp.GetRequiredService<ILogger<CondaEnvironmentManagement>>();
                     var condaEnvManager = new CondaEnvironmentManagement(logger, name, ensureEnvironment, condaLocator, environmentSpecPath);
                     return condaEnvManager;
                 }

--- a/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
@@ -17,14 +17,14 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
         return this;
     }
 
-    public IPythonEnvironmentBuilder WithCondaEnvironment(string name, bool ensureExists = true)
+    public IPythonEnvironmentBuilder WithCondaEnvironment(string name, string environmentSpecPath, bool ensureExists = true)
     {
         Services.AddSingleton<IEnvironmentManagement>(
             sp => {
                 try
                 {
                     var condaLocator = sp.GetRequiredService<CondaLocator>();
-                    var condaEnvManager = new CondaEnvironmentManagement(name, ensureExists, condaLocator);
+                    var condaEnvManager = new CondaEnvironmentManagement(name, ensureExists, condaLocator, environmentSpecPath);
                     return condaEnvManager;
                 }
                 catch (InvalidOperationException)

--- a/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
@@ -1,20 +1,30 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using CSnakes.Runtime.EnvironmentManagement;
+using CSnakes.Runtime.Locators;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace CSnakes.Runtime;
 
 internal partial class PythonEnvironmentBuilder(IServiceCollection services) : IPythonEnvironmentBuilder
 {
-    private bool ensureVirtualEnvironment = false;
-    private string? virtualEnvironmentLocation;
     private readonly string[] extraPaths = [];
     private string home = Environment.CurrentDirectory;
 
     public IServiceCollection Services { get; } = services;
 
-    public IPythonEnvironmentBuilder WithVirtualEnvironment(string path, bool ensureVirtualEnvironment = true)
+    public IPythonEnvironmentBuilder WithVirtualEnvironment(string path, bool ensureExists = true)
     {
-        this.ensureVirtualEnvironment = ensureVirtualEnvironment;
-        virtualEnvironmentLocation = path;
+        Services.AddSingleton<IEnvironmentManagement>(new VenvEnvironmentManagement(path, ensureExists));
+        return this;
+    }
+
+    public IPythonEnvironmentBuilder WithCondaEnvironment(string name, bool ensureExists = true)
+    {
+        Services.AddSingleton<IEnvironmentManagement>(
+            sp => {
+            var condaLocator = sp.GetRequiredService<CondaLocator>();
+            var condaEnvManager = new CondaEnvironmentManagement(name, ensureExists, condaLocator);
+                return condaEnvManager;
+            });
         return this;
     }
 
@@ -25,5 +35,5 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
     }
 
     public PythonEnvironmentOptions GetOptions() =>
-        new(home, virtualEnvironmentLocation, ensureVirtualEnvironment, extraPaths);
+        new(home, extraPaths);
 }

--- a/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
@@ -21,9 +21,16 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
     {
         Services.AddSingleton<IEnvironmentManagement>(
             sp => {
-            var condaLocator = sp.GetRequiredService<CondaLocator>();
-            var condaEnvManager = new CondaEnvironmentManagement(name, ensureExists, condaLocator);
-                return condaEnvManager;
+                try
+                {
+                    var condaLocator = sp.GetRequiredService<CondaLocator>();
+                    var condaEnvManager = new CondaEnvironmentManagement(name, ensureExists, condaLocator);
+                    return condaEnvManager;
+                }
+                catch (InvalidOperationException)
+                {
+                    throw new InvalidOperationException("Conda environments much be used with Conda Locator.");
+                }
             });
         return this;
     }

--- a/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
@@ -17,14 +17,17 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
         return this;
     }
 
-    public IPythonEnvironmentBuilder WithCondaEnvironment(string name, string environmentSpecPath, bool ensureExists = true)
+    public IPythonEnvironmentBuilder WithCondaEnvironment(string name, string? environmentSpecPath = null, bool ensureEnvironment = false)
     {
+        if (ensureEnvironment)
+            throw new InvalidOperationException("Automated Conda environment creation not yet supported. Conda environments must be created manually.");
+
         Services.AddSingleton<IEnvironmentManagement>(
             sp => {
                 try
                 {
                     var condaLocator = sp.GetRequiredService<CondaLocator>();
-                    var condaEnvManager = new CondaEnvironmentManagement(name, ensureExists, condaLocator, environmentSpecPath);
+                    var condaEnvManager = new CondaEnvironmentManagement(name, ensureEnvironment, condaLocator, environmentSpecPath);
                     return condaEnvManager;
                 }
                 catch (InvalidOperationException)

--- a/src/CSnakes.Runtime/PythonEnvironmentOptions.cs
+++ b/src/CSnakes.Runtime/PythonEnvironmentOptions.cs
@@ -1,2 +1,2 @@
 ﻿namespace CSnakes.Runtime;
-public record PythonEnvironmentOptions(string Home, string? VirtualEnvironmentPath, bool EnsureVirtualEnvironment, string[] ExtraPaths);
+public record PythonEnvironmentOptions(string Home, string[] ExtraPaths);

--- a/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
+++ b/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
@@ -183,10 +183,17 @@ public static partial class ServiceCollectionExtensions
     /// Adds a pip package installer to the service collection.
     /// </summary>
     /// <param name="builder">The <see cref="IPythonEnvironmentBuilder"/> to add the installer to.</param>
+    /// <param name="requirementsPath">The path to the requirements file.</param>
     /// <returns>The modified <see cref="IPythonEnvironmentBuilder"/>.</returns>
-    public static IPythonEnvironmentBuilder WithPipInstaller(this IPythonEnvironmentBuilder builder)
+    public static IPythonEnvironmentBuilder WithPipInstaller(this IPythonEnvironmentBuilder builder, string requirementsPath = "requirements.txt")
     {
-        builder.Services.AddSingleton<IPythonPackageInstaller, PipInstaller>();
+        builder.Services.AddSingleton<IPythonPackageInstaller>(
+            sp =>
+            {
+                var logger = sp.GetRequiredService<ILogger<PipInstaller>>();
+                return new PipInstaller(logger, requirementsPath);
+            }
+        );
         return builder;
     }
 

--- a/src/CSnakes.sln
+++ b/src/CSnakes.sln
@@ -28,6 +28,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E52DC71C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "TestUtilities\TestUtilities.csproj", "{641C9CD0-8529-4666-8F27-ECEB7F72043C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Conda.Tests", "Conda.Tests\Conda.Tests.csproj", "{38604D9B-2C01-4B82-AFA1-A00E184BAE03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{641C9CD0-8529-4666-8F27-ECEB7F72043C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{641C9CD0-8529-4666-8F27-ECEB7F72043C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{641C9CD0-8529-4666-8F27-ECEB7F72043C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38604D9B-2C01-4B82-AFA1-A00E184BAE03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38604D9B-2C01-4B82-AFA1-A00E184BAE03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38604D9B-2C01-4B82-AFA1-A00E184BAE03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38604D9B-2C01-4B82-AFA1-A00E184BAE03}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -74,6 +80,7 @@ Global
 		{CB00C1F5-8C01-4FE7-82AD-7F9B4398E3F8} = {E52DC71C-FB58-4E57-9CCA-8A78EAA49123}
 		{93264FC1-2880-4959-9576-50D260039BC2} = {E52DC71C-FB58-4E57-9CCA-8A78EAA49123}
 		{641C9CD0-8529-4666-8F27-ECEB7F72043C} = {E52DC71C-FB58-4E57-9CCA-8A78EAA49123}
+		{38604D9B-2C01-4B82-AFA1-A00E184BAE03} = {E52DC71C-FB58-4E57-9CCA-8A78EAA49123}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4ACC77F9-1BB8-42DE-B647-01C458922F49}

--- a/src/Conda.Tests/BasicTests.cs
+++ b/src/Conda.Tests/BasicTests.cs
@@ -1,0 +1,12 @@
+namespace Conda.Tests;
+
+public class BasicTests : CondaTestBase
+{
+    [Fact]
+    public void TestSimpleImport()
+    {
+        var testModule = Env.TestSimple();
+        Assert.NotNull(testModule);
+        testModule.TestNothing();
+    }
+}

--- a/src/Conda.Tests/Conda.Tests.csproj
+++ b/src/Conda.Tests/Conda.Tests.csproj
@@ -1,0 +1,40 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.RegularExpressions" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="python" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="CSnakes.Runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CSnakes.Runtime\CSnakes.Runtime.csproj" />
+    <ProjectReference Include="..\CSnakes.SourceGeneration\CSnakes.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="python\*.py">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </AdditionalFiles>
+    <None Remove="python\test_simple.py" />
+    <Content Include="python\environment.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -21,7 +21,7 @@ public class CondaTestBase : IDisposable
 
         }
         var condaBinPath = OperatingSystem.IsWindows() ? Path.Join(condaEnv, "Scripts", "conda.exe") : Path.Join("bin", "conda");
-
+        var environmentSpecPath = Path.Join(Environment.CurrentDirectory, "python", "environment.yml");
         app = Host.CreateDefaultBuilder()
             .ConfigureServices((context, services) =>
             {
@@ -29,7 +29,7 @@ public class CondaTestBase : IDisposable
                 pb.WithHome(Path.Join(Environment.CurrentDirectory, "python"));
 
                 pb.FromConda(condaBinPath)
-                  .WithCondaEnvironment("test", true);
+                  .WithCondaEnvironment("csnakes_test", environmentSpecPath);
 
                 services.AddLogging(builder => builder.AddXUnit());
             })

--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Conda.Tests;
+public class CondaTestBase : IDisposable
+{
+    private readonly IPythonEnvironment env;
+    private readonly IHost app;
+
+    public CondaTestBase()
+    {
+        string pythonVersion = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12";
+        string condaEnv = string.Empty;
+        if (OperatingSystem.IsWindows())
+            condaEnv = Environment.GetEnvironmentVariable("LOCALAPPDATA") ?? "";
+        condaEnv = Path.Join(condaEnv, "anaconda3");
+
+        app = Host.CreateDefaultBuilder()
+            .ConfigureServices((context, services) =>
+            {
+                var pb = services.WithPython();
+                pb.WithHome(Path.Join(Environment.CurrentDirectory, "python"));
+
+                pb.FromConda(condaEnv ?? "", pythonVersion)
+                  .WithCondaEnvironment("test", true);
+
+                services.AddLogging(builder => builder.AddXUnit());
+            })
+            .Build();
+
+        env = app.Services.GetRequiredService<IPythonEnvironment>();
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        GC.Collect();
+    }
+
+    public IPythonEnvironment Env => env;
+}

--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -11,10 +11,15 @@ public class CondaTestBase : IDisposable
     public CondaTestBase()
     {
         string pythonVersion = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12";
-        string condaEnv = string.Empty;
-        if (OperatingSystem.IsWindows())
-            condaEnv = Environment.GetEnvironmentVariable("LOCALAPPDATA") ?? "";
-        condaEnv = Path.Join(condaEnv, "anaconda3");
+        string condaEnv = Environment.GetEnvironmentVariable("CONDA_HOME") ?? string.Empty;
+
+        if (string.IsNullOrEmpty(condaEnv))
+        {
+            if (OperatingSystem.IsWindows())
+                condaEnv = Environment.GetEnvironmentVariable("LOCALAPPDATA") ?? "";
+            condaEnv = Path.Join(condaEnv, "anaconda3");
+
+        }
 
         app = Host.CreateDefaultBuilder()
             .ConfigureServices((context, services) =>

--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -11,7 +11,7 @@ public class CondaTestBase : IDisposable
     public CondaTestBase()
     {
         string pythonVersion = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12";
-        string condaEnv = Environment.GetEnvironmentVariable("CONDA_HOME") ?? string.Empty;
+        string condaEnv = Environment.GetEnvironmentVariable("CONDA") ?? string.Empty;
 
         if (string.IsNullOrEmpty(condaEnv))
         {

--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -10,7 +10,6 @@ public class CondaTestBase : IDisposable
 
     public CondaTestBase()
     {
-        string pythonVersion = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12";
         string condaEnv = Environment.GetEnvironmentVariable("CONDA") ?? string.Empty;
 
         if (string.IsNullOrEmpty(condaEnv))
@@ -20,7 +19,7 @@ public class CondaTestBase : IDisposable
             condaEnv = Path.Join(condaEnv, "anaconda3");
 
         }
-        var condaBinPath = OperatingSystem.IsWindows() ? Path.Join(condaEnv, "Scripts", "conda.exe") : Path.Join("bin", "conda");
+        var condaBinPath = OperatingSystem.IsWindows() ? Path.Join(condaEnv, "Scripts", "conda.exe") : Path.Join(condaEnv, "bin", "conda");
         var environmentSpecPath = Path.Join(Environment.CurrentDirectory, "python", "environment.yml");
         app = Host.CreateDefaultBuilder()
             .ConfigureServices((context, services) =>

--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -20,6 +20,7 @@ public class CondaTestBase : IDisposable
             condaEnv = Path.Join(condaEnv, "anaconda3");
 
         }
+        var condaBinPath = OperatingSystem.IsWindows() ? Path.Join(condaEnv, "Scripts", "conda.exe") : Path.Join("bin", "conda");
 
         app = Host.CreateDefaultBuilder()
             .ConfigureServices((context, services) =>
@@ -27,7 +28,7 @@ public class CondaTestBase : IDisposable
                 var pb = services.WithPython();
                 pb.WithHome(Path.Join(Environment.CurrentDirectory, "python"));
 
-                pb.FromConda(condaEnv ?? "", pythonVersion)
+                pb.FromConda(condaBinPath)
                   .WithCondaEnvironment("test", true);
 
                 services.AddLogging(builder => builder.AddXUnit());

--- a/src/Conda.Tests/python/environment.yml
+++ b/src/Conda.Tests/python/environment.yml
@@ -1,4 +1,3 @@
 name: csnakes_test
 dependencies:
-  - numpy
   - httpx

--- a/src/Conda.Tests/python/environment.yml
+++ b/src/Conda.Tests/python/environment.yml
@@ -1,0 +1,4 @@
+name: csnakes_test
+dependencies:
+  - numpy
+  - httpx

--- a/src/Conda.Tests/python/test_simple.py
+++ b/src/Conda.Tests/python/test_simple.py
@@ -1,0 +1,5 @@
+import httpx
+
+
+def test_nothing() -> None:
+    pass

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,9 @@
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
 
     <IsPackable>false</IsPackable>
-    <EnableLocalPackaging>true</EnableLocalPackaging>
+    <EnableLocalPackaging>false</EnableLocalPackaging>
+    <!-- Forcably disable local packaging during CI to avoid extra packages being generated -->
+    <EnableLocalPackaging Condition="'$(ContinuousIntegrationBuild)' == 'true'">false</EnableLocalPackaging>
   </PropertyGroup>
 
   <Import Project="Packaging.props" />


### PR DESCRIPTION
- abstracts environment management (as we might want to add `uv` in future as well)
- moves venv logic into a standalone class
- refactors python builder to locate environment management class
- implements a conda locator for the python provided by conda (effectively a folder locator for now)
- implements a `WithCondaEnvironment` for adding a named environment
- implements a conda installer for installing conda packages from a `environment.yml` file

Implements #183 