### PR TITLE
Refactor `PythonConstant` types into a true union

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
@@ -44,59 +44,59 @@ public static partial class PythonParser
         from close in Character.EqualTo('\'')
         select Unit.Value;
 
-    public static TokenListParser<PythonToken, PythonConstant> DoubleQuotedStringConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.String> DoubleQuotedStringConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.DoubleQuotedString)
         .Apply(ConstantParsers.DoubleQuotedString)
-        .Select(s => new PythonConstant(s))
+        .Select(s => new PythonConstant.String(s))
         .Named("Double Quoted String Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant> SingleQuotedStringConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.String> SingleQuotedStringConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.SingleQuotedString)
         .Apply(ConstantParsers.SingleQuotedString)
-        .Select(s => new PythonConstant(s))
+        .Select(s => new PythonConstant.String(s))
         .Named("Single Quoted String Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant> DecimalConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.Float> DecimalConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.Decimal)
-        .Select(token => new PythonConstant(double.Parse(token.ToStringValue().Replace("_", ""), NumberStyles.Float, CultureInfo.InvariantCulture)))
+        .Select(token => new PythonConstant.Float(double.Parse(token.ToStringValue().Replace("_", ""), NumberStyles.Float, CultureInfo.InvariantCulture)))
         .Named("Decimal Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant> IntegerConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.Integer> IntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.Integer)
-        .Select(d => new PythonConstant(long.Parse(d.ToStringValue().Replace("_", ""), NumberStyles.Integer)))
+        .Select(d => new PythonConstant.Integer(long.Parse(d.ToStringValue().Replace("_", ""), NumberStyles.Integer)))
         .Named("Integer Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant> HexidecimalIntegerConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.HexidecimalInteger> HexidecimalIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.HexidecimalInteger)
-        .Select(d => new PythonConstant { Type = PythonConstant.ConstantType.HexidecimalInteger, IntegerValue = long.Parse(d.ToStringValue().Substring(2).Replace("_", ""), NumberStyles.HexNumber) })
+        .Select(d =>  new PythonConstant.HexidecimalInteger(long.Parse(d.ToStringValue().Substring(2).Replace("_", ""), NumberStyles.HexNumber)))
         .Named("Hexidecimal Integer Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant> BinaryIntegerConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.BinaryInteger> BinaryIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.BinaryInteger)
         // TODO: Consider Binary Format specifier introduced in .NET 8 https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#binary-format-specifier-b
-        .Select(d => new PythonConstant { Type = PythonConstant.ConstantType.BinaryInteger, IntegerValue = (long)Convert.ToUInt64(d.ToStringValue().Substring(2).Replace("_", ""), 2) })
+        .Select(d => new PythonConstant.BinaryInteger((long)Convert.ToUInt64(d.ToStringValue().Substring(2).Replace("_", ""), 2)))
         .Named("Binary Integer Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant> BoolConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.Bool> BoolConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.True).Or(Token.EqualTo(PythonToken.False))
-        .Select(d => new PythonConstant(d.Kind == PythonToken.True))
+        .Select(d => (d.Kind == PythonToken.True ? PythonConstant.Bool.True : PythonConstant.Bool.False))
         .Named("Bool Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant> NoneConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.None> NoneConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.None)
-        .Select(d => PythonConstant.FromNone())
+        .Select(d => PythonConstant.None.Value)
         .Named("None Constant");
 
     // Any constant value
     public static TokenListParser<PythonToken, PythonConstant?> ConstantValueTokenizer { get; } =
-        DecimalConstantTokenizer.AsNullable()
-        .Or(IntegerConstantTokenizer.AsNullable())
-        .Or(HexidecimalIntegerConstantTokenizer.AsNullable())
-        .Or(BinaryIntegerConstantTokenizer.AsNullable())
-        .Or(BoolConstantTokenizer.AsNullable())
-        .Or(NoneConstantTokenizer.AsNullable())
-        .Or(DoubleQuotedStringConstantTokenizer.AsNullable())
-        .Or(SingleQuotedStringConstantTokenizer.AsNullable())
+        DecimalConstantTokenizer.AsBase().AsNullable()
+        .Or(IntegerConstantTokenizer.AsBase().AsNullable())
+        .Or(HexidecimalIntegerConstantTokenizer.AsBase().AsNullable())
+        .Or(BinaryIntegerConstantTokenizer.AsBase().AsNullable())
+        .Or(BoolConstantTokenizer.AsBase().AsNullable())
+        .Or(NoneConstantTokenizer.AsBase().AsNullable())
+        .Or(DoubleQuotedStringConstantTokenizer.AsBase().AsNullable())
+        .Or(SingleQuotedStringConstantTokenizer.AsBase().AsNullable())
         .Named("Constant");
 
     static class ConstantParsers
@@ -125,4 +125,11 @@ public static partial class PythonParser
             from close in Character.EqualTo('\'')
             select new string(chars);
     }
+}
+
+file static class Extensions
+{
+    public static TokenListParser<TKind, PythonConstant> AsBase<TKind, T>(this TokenListParser<TKind, T> parser)
+        where T : PythonConstant =>
+        parser.Cast<TKind, T, PythonConstant>();
 }

--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonConstant.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonConstant.cs
@@ -1,77 +1,55 @@
 ﻿namespace CSnakes.Parser.Types;
 
-public class PythonConstant
+public abstract class PythonConstant
 {
-    public enum ConstantType
+    public abstract override string ToString();
+
+    public class Integer(long value) : PythonConstant
     {
-        Integer,
-        HexidecimalInteger,
-        BinaryInteger,
-        Float,
-        String,
-        Bool,
-        None,
+        public long Value { get; } = value;
+        public override string ToString() => Value.ToString();
     }
 
-    public PythonConstant() { }
-
-    public PythonConstant(long value)
+    public sealed class HexidecimalInteger(long value) : Integer(value)
     {
-        Type = ConstantType.Integer;
-        IntegerValue = value;
+        public override string ToString() => $"0x{Value:X}";
     }
 
-    public PythonConstant(double value)
+    public sealed class BinaryInteger(long value) : Integer(value)
     {
-        Type = ConstantType.Float;
-        FloatValue = value;
+        public override string ToString() => $"0b{Value:X}";
     }
 
-    public PythonConstant(string value)
+    public sealed class Float(double value) : PythonConstant
     {
-        Type = ConstantType.String;
-        StringValue = value;
+        public double Value { get; } = value;
+        public override string ToString() => Value.ToString();
     }
 
-    public PythonConstant(bool value)
+    public sealed class String(string value) : PythonConstant
     {
-        Type = ConstantType.Bool;
-        BoolValue = value;
+        public string Value { get; } = value;
+        public override string ToString() => Value;
     }
 
-    public static PythonConstant FromNone() => new PythonConstant { Type = ConstantType.None };
-    public ConstantType Type { get; set; }
-
-    public long IntegerValue { get; set; }
-
-    public string? StringValue { get; set; }
-
-    public double FloatValue { get; set; }
-
-    public bool BoolValue { get; set; }
-
-    public bool IsInteger { get => Type == ConstantType.Integer || Type == ConstantType.BinaryInteger || Type == ConstantType.HexidecimalInteger; }
-
-    public override string ToString()
+    public sealed class Bool : PythonConstant
     {
-        switch (Type)
-        {
-            case ConstantType.Integer:
-                return IntegerValue.ToString();
-            case ConstantType.HexidecimalInteger:
-                return $"0x{IntegerValue:X}";
-            case ConstantType.BinaryInteger:
-                return $"0b{IntegerValue:X}";
-            case ConstantType.Float:
-                return FloatValue.ToString();
-            case ConstantType.Bool:
-                return BoolValue.ToString();
-            case ConstantType.String:
-                return StringValue ?? throw new ArgumentNullException(nameof(StringValue));
-            case ConstantType.None:
-                return "None";
-            default:
-                return "unknown";
-        }
+        public static readonly Bool True = new(true);
+        public static readonly Bool False = new(false);
+
+        private Bool(bool value) => Value = value;
+
+        public bool Value { get; }
+
+        public override string ToString() => Value.ToString();
+    }
+
+    public sealed class None : PythonConstant
+    {
+        public static readonly None Value = new();
+
+        private None() { }
+
+        public override string ToString() => "None";
     }
 }

--- a/src/CSnakes.Tests/TokenizerTests.cs
+++ b/src/CSnakes.Tests/TokenizerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using CSnakes.Parser;
+using CSnakes.Parser.Types;
 using Superpower;
 
 namespace CSnakes.Tests;
@@ -490,8 +491,9 @@ if __name__ == '__main__':
 
         Assert.True(result.HasValue);
         Assert.NotNull(result.Value);
-        Assert.True(result.Value?.IsInteger);
-        Assert.Equal(expectedValue, result.Value?.IntegerValue);
+        var value = result.Value as PythonConstant.Integer;
+        Assert.NotNull(value);
+        Assert.Equal(expectedValue, value.Value);
     }
 
     [Theory]
@@ -517,8 +519,9 @@ if __name__ == '__main__':
         var result = PythonParser.DecimalConstantTokenizer.TryParse(tokens);
 
         Assert.True(result.HasValue);
-        Assert.NotNull(result.Value);
-        Assert.Equal(expectedValue, result.Value?.FloatValue);
+        var value = result.Value as PythonConstant.Float;
+        Assert.NotNull(value);
+        Assert.Equal(expectedValue, value.Value);
     }
 }
 


### PR DESCRIPTION
This PR proposes to refactor `PythonConstant` types into a true union via a class hierarchy where `PythonConstant` becomes an abstract base class and the various types its nested subclasses. This has the following benefits:

- Each subclass has its own clear, simpler and overriding implementation of `ToString` instead of a switch-case previously.
- Each subclass holds its own strong-typed value, e.g. `Value` on `PythonConstant.Integer` is typed as `long` whereas `Value` on `PythonConstant.String` is typed as `string`.
- Each subclass only requires the storage space for its value instead of the sum of all possible values.
- Subclasses like `Bool` and `None` have statically initialised values, which avoids unnecessary allocations.
- `PythonConstant.ConstantType` is no longer needed.
- Subclasses enable simpler, stronger and more robust pattern-matching (see updates in `ArgumentReflection.ArgumentSyntax`).
