### PR TITLE
Use a union struct for an optimal `PythonConstant`

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
@@ -68,13 +68,13 @@ public static partial class PythonParser
 
     public static TokenListParser<PythonToken, PythonConstant> HexidecimalIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.HexidecimalInteger)
-        .Select(d => new PythonConstant { Type = PythonConstant.ConstantType.HexidecimalInteger, IntegerValue = long.Parse(d.ToStringValue().Substring(2).Replace("_", ""), NumberStyles.HexNumber) })
+        .Select(d => PythonConstant.HexadecimalInteger(long.Parse(d.ToStringValue().Substring(2).Replace("_", ""), NumberStyles.HexNumber)))
         .Named("Hexidecimal Integer Constant");
 
     public static TokenListParser<PythonToken, PythonConstant> BinaryIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.BinaryInteger)
         // TODO: Consider Binary Format specifier introduced in .NET 8 https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#binary-format-specifier-b
-        .Select(d => new PythonConstant { Type = PythonConstant.ConstantType.BinaryInteger, IntegerValue = (long)Convert.ToUInt64(d.ToStringValue().Substring(2).Replace("_", ""), 2) })
+        .Select(d => PythonConstant.BinaryInteger((long)Convert.ToUInt64(d.ToStringValue().Substring(2).Replace("_", ""), 2)))
         .Named("Binary Integer Constant");
 
     public static TokenListParser<PythonToken, PythonConstant> BoolConstantTokenizer { get; } =
@@ -84,19 +84,19 @@ public static partial class PythonParser
 
     public static TokenListParser<PythonToken, PythonConstant> NoneConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.None)
-        .Select(d => PythonConstant.FromNone())
+        .Select(d => PythonConstant.None)
         .Named("None Constant");
 
     // Any constant value
-    public static TokenListParser<PythonToken, PythonConstant?> ConstantValueTokenizer { get; } =
-        DecimalConstantTokenizer.AsNullable()
-        .Or(IntegerConstantTokenizer.AsNullable())
-        .Or(HexidecimalIntegerConstantTokenizer.AsNullable())
-        .Or(BinaryIntegerConstantTokenizer.AsNullable())
-        .Or(BoolConstantTokenizer.AsNullable())
-        .Or(NoneConstantTokenizer.AsNullable())
-        .Or(DoubleQuotedStringConstantTokenizer.AsNullable())
-        .Or(SingleQuotedStringConstantTokenizer.AsNullable())
+    public static TokenListParser<PythonToken, PythonConstant> ConstantValueTokenizer { get; } =
+        DecimalConstantTokenizer
+        .Or(IntegerConstantTokenizer)
+        .Or(HexidecimalIntegerConstantTokenizer)
+        .Or(BinaryIntegerConstantTokenizer)
+        .Or(BoolConstantTokenizer)
+        .Or(NoneConstantTokenizer)
+        .Or(DoubleQuotedStringConstantTokenizer)
+        .Or(SingleQuotedStringConstantTokenizer)
         .Named("Constant");
 
     static class ConstantParsers

--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Parameters.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Parameters.cs
@@ -16,7 +16,7 @@ public static partial class PythonParser
                 _ => PythonTypeDefinitionTokenizer.AssumeNotNull().OptionalOrDefault()
              )
          from defaultValue in Token.EqualTo(PythonToken.Equal).Optional().Then(
-                 _ => ConstantValueTokenizer.AssumeNotNull().OptionalOrDefault()
+                 _ => ConstantValueTokenizer.Optional()
              )
          select new PythonFunctionParameter(arg.Name, type, defaultValue, arg.ParameterType))
         .Named("Parameter");

--- a/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
@@ -11,7 +11,7 @@ public class ArgumentReflection
 
     public static ParameterSyntax? ArgumentSyntax(PythonFunctionParameter parameter)
     {
-        // The parameter / is a special syntax, not a parameter. 
+        // The parameter / is a special syntax, not a parameter.
         if (parameter.ParameterType == PythonFunctionParameterType.Slash)
         {
             return null;
@@ -33,80 +33,69 @@ public class ArgumentReflection
             parameter.DefaultValue is null)
 
         {
-            parameter.DefaultValue = PythonConstant.FromNone();
+            parameter.DefaultValue = PythonConstant.None;
         }
 
         bool isNullableType = false;
 
-        if (parameter.DefaultValue is null)
+        LiteralExpressionSyntax? literalExpressionSyntax;
+
+        switch (parameter.DefaultValue)
         {
-            return SyntaxFactory
-                .Parameter(SyntaxFactory.Identifier(Keywords.ValidIdentifier(parameter.Name.ToLowerPascalCase())))
-                .WithType(reflectedType);
+            case null:
+                literalExpressionSyntax = null;
+                break;
+            case { HexidecimalIntegerValue: { } v }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                        SyntaxKind.NumericLiteralExpression,
+                                                        SyntaxFactory.Literal($"0x{v:X}", v));
+                break;
+            case { BinaryIntegerValue: { } v }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                        SyntaxKind.NumericLiteralExpression,
+                                                        SyntaxFactory.Literal($"0b{Convert.ToString(v, 2)}", v));
+                break;
+            case { IntegerValue: { } v and >= int.MinValue and <= int.MaxValue }:
+                // Downcast long to int if the value is small as the code is more readable without the L suffix
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                        SyntaxKind.NumericLiteralExpression,
+                                                        SyntaxFactory.Literal((int)v));
+                break;
+            case { IntegerValue: { } v }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                        SyntaxKind.NumericLiteralExpression,
+                                                        SyntaxFactory.Literal(v));
+                break;
+            case { StringValue: { } v }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                        SyntaxKind.StringLiteralExpression,
+                                                        SyntaxFactory.Literal(v));
+                break;
+            case { FloatValue: { } v }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(
+                                                        SyntaxKind.NumericLiteralExpression,
+                                                        SyntaxFactory.Literal(v));
+                break;
+            case { BoolValue: true }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression);
+                break;
+            case { BoolValue: false }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression);
+                break;
+            case { IsNone: true }:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+                isNullableType = true;
+                break;
+            default:
+                literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+                isNullableType = true;
+                break;
         }
-        else
-        {
-            LiteralExpressionSyntax literalExpressionSyntax;
 
-            switch (parameter.DefaultValue.Type)
-            {
-                case PythonConstant.ConstantType.Integer:
-                    // Downcast long to int if the value is small as the code is more readable without the L suffix
-                    if (parameter.DefaultValue.IntegerValue <= int.MaxValue && parameter.DefaultValue.IntegerValue >= int.MinValue)
-                        literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                                SyntaxKind.NumericLiteralExpression,
-                                                                SyntaxFactory.Literal((int)parameter.DefaultValue.IntegerValue));
-                    else
-                        literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                                SyntaxKind.NumericLiteralExpression,
-                                                                SyntaxFactory.Literal(parameter.DefaultValue.IntegerValue));
-                    break;
-                case PythonConstant.ConstantType.String:
-                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                            SyntaxKind.StringLiteralExpression,
-                                                            SyntaxFactory.Literal(parameter.DefaultValue.StringValue ?? String.Empty));
-                    break;
-                case PythonConstant.ConstantType.Float:
-                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                            SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal(parameter.DefaultValue.FloatValue));
-                    break;
-                case PythonConstant.ConstantType.Bool:
-                    literalExpressionSyntax = parameter.DefaultValue.BoolValue
-                        ? SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)
-                        : SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression);
-                    break;
-                case PythonConstant.ConstantType.None:
-                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
-                    isNullableType = true;
-                    break;
-                case PythonConstant.ConstantType.HexidecimalInteger:
-                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                            SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal(string.Format("0x{0:X}", parameter.DefaultValue.IntegerValue), parameter.DefaultValue.IntegerValue));
-                    break;
-                case PythonConstant.ConstantType.BinaryInteger:
-                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(
-                                                            SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal(string.Format("0b{0}", Convert.ToString(parameter.DefaultValue.IntegerValue, 2)), parameter.DefaultValue.IntegerValue));
-                    break;
-                default:
-                    literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
-                    isNullableType = true;
-                    break;
-            }
-
-            if (isNullableType)
-            {
-                reflectedType = SyntaxFactory.NullableType(reflectedType);
-            }
-
-            return SyntaxFactory
-                .Parameter(SyntaxFactory.Identifier(Keywords.ValidIdentifier(parameter.Name.ToLowerPascalCase())))
-                .WithType(reflectedType)
-                .WithDefault(SyntaxFactory.EqualsValueClause(literalExpressionSyntax));
-
-        }
+        return SyntaxFactory
+            .Parameter(SyntaxFactory.Identifier(Keywords.ValidIdentifier(parameter.Name.ToLowerPascalCase())))
+            .WithType(isNullableType ? SyntaxFactory.NullableType(reflectedType) : reflectedType)
+            .WithDefault(literalExpressionSyntax is not null ? SyntaxFactory.EqualsValueClause(literalExpressionSyntax) : null);
     }
 
     public static List<(PythonFunctionParameter, ParameterSyntax)> FunctionParametersAsParameterSyntaxPairs(PythonFunctionParameter[] parameters)

--- a/src/CSnakes.Tests/TokenizerTests.cs
+++ b/src/CSnakes.Tests/TokenizerTests.cs
@@ -489,9 +489,8 @@ if __name__ == '__main__':
         var result = PythonParser.ConstantValueTokenizer.TryParse(tokens);
 
         Assert.True(result.HasValue);
-        Assert.NotNull(result.Value);
-        Assert.True(result.Value?.IsInteger);
-        Assert.Equal(expectedValue, result.Value?.IntegerValue);
+        Assert.True(result.Value.IsInteger);
+        Assert.Equal(expectedValue, result.Value.IntegerValue);
     }
 
     [Theory]
@@ -517,8 +516,7 @@ if __name__ == '__main__':
         var result = PythonParser.DecimalConstantTokenizer.TryParse(tokens);
 
         Assert.True(result.HasValue);
-        Assert.NotNull(result.Value);
-        Assert.Equal(expectedValue, result.Value?.FloatValue);
+        Assert.Equal(expectedValue, result.Value.FloatValue);
     }
 }
 


### PR DESCRIPTION
This PR is an alternative design to the refactoring proposed in PR #234. Only one of the two should be merged.

In contrast to PR #234, which uses a type hierarchy of subclasses to represent a union of all `PythonConstant` types, this uses a single `struct` as a union. It has the following benefits with respect to the current implementation and the one proposed in PR #234:

- It uses a single storage for all scalar value types (`bool`, `long` and `double`) and another for strings, instead of the sum of storage needed for all value types.
- Being a value type, it requires no additional heap allocations itself.
- In its default state (`default(PythonConstant)`), it represents `None`.
- Various properties provide strong-typed access to the underlying value (union of scalars or string) and designed to be friendly for pattern-matching (see `ArgumentReflection.ArgumentSyntax` for application). In fact, `PythonConstant.ConstantType` can even be made private since it's no longer used outside of `PythonConstant`.

The main motivation for accepting this design over PR #234 is zero heap footprint.
