### PR TITLE
Fix GIL acquisition during Python runtime finalization

### DIFF
--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -138,6 +138,15 @@ internal unsafe partial class CPythonAPI : IDisposable
                         return;
 
                     Debug.WriteLine("Calling Py_Finalize()");
+
+                    // Acquire the GIL only to dispose it immediately because `PyGILState_Release`
+                    // is not available after `Py_Finalize` is called. This is done primarily to
+                    // trigger the disposal of handles that have been queued before the Python
+                    // runtime is finalized.
+
+                    GIL.Acquire().Dispose();
+
+                    PyGILState_Ensure();
                     Py_Finalize();
                 }
             }

--- a/src/Integration.Tests/ArgsTests.cs
+++ b/src/Integration.Tests/ArgsTests.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 
 namespace Integration.Tests;
-public class ArgsTests : IntegrationTestBase
+public class ArgsTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void PositionalOnly()

--- a/src/Integration.Tests/BasicTests.cs
+++ b/src/Integration.Tests/BasicTests.cs
@@ -1,6 +1,6 @@
 namespace Integration.Tests;
 
-public class BasicTests : IntegrationTestBase
+public class BasicTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void TestBasic_TestIntFloat()

--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Integration.Tests;
 
-public class BufferTests : IntegrationTestBase
+public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     [Trait("requires", "numpy")]

--- a/src/Integration.Tests/DefaultsTests.cs
+++ b/src/Integration.Tests/DefaultsTests.cs
@@ -1,5 +1,5 @@
 ﻿namespace Integration.Tests;
-public class DefaultsTests : IntegrationTestBase
+public class DefaultsTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void TestDefault_StrArg()

--- a/src/Integration.Tests/DictsTests.cs
+++ b/src/Integration.Tests/DictsTests.cs
@@ -1,5 +1,5 @@
 ﻿namespace Integration.Tests;
-public class TestDicts : IntegrationTestBase
+public class TestDicts(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void TestDicts_TestDictStrInt()

--- a/src/Integration.Tests/ExceptionTests.cs
+++ b/src/Integration.Tests/ExceptionTests.cs
@@ -2,7 +2,7 @@ using CSnakes.Runtime.Python;
 
 namespace Integration.Tests;
 
-public class ExceptionTests : IntegrationTestBase
+public class ExceptionTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void TestExceptions_TestRaisePythonException()

--- a/src/Integration.Tests/FalseReturns.cs
+++ b/src/Integration.Tests/FalseReturns.cs
@@ -1,6 +1,6 @@
 ﻿namespace Integration.Tests;
 
-public class FalseReturns : IntegrationTestBase
+public class FalseReturns(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void TestFalseReturn_StringNotInt()

--- a/src/Integration.Tests/GeneratorTests.cs
+++ b/src/Integration.Tests/GeneratorTests.cs
@@ -1,5 +1,5 @@
 ﻿namespace Integration.Tests;
-public class GeneratorTests : IntegrationTestBase
+public class GeneratorTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void TestGenerator()

--- a/src/Integration.Tests/IntegrationTestBase.cs
+++ b/src/Integration.Tests/IntegrationTestBase.cs
@@ -3,12 +3,21 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Integration.Tests;
-public class IntegrationTestBase : IDisposable
+
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+[CollectionDefinition(Name)]
+public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvironmentFixture>
+{
+    public const string Name = "PythonEnvironment";
+}
+
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+public sealed class PythonEnvironmentFixture : IDisposable
 {
     private readonly IPythonEnvironment env;
     private readonly IHost app;
 
-    public IntegrationTestBase()
+    public PythonEnvironmentFixture()
     {
         string pythonVersionWindows = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.4";
         string pythonVersionMacOS = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12";
@@ -37,9 +46,17 @@ public class IntegrationTestBase : IDisposable
 
     public void Dispose()
     {
+        env.Dispose();
+        app.Dispose();
         GC.SuppressFinalize(this);
         GC.Collect();
     }
 
     public IPythonEnvironment Env => env;
+}
+
+[Collection(PythonEnvironmentCollection.Name)]
+public abstract class IntegrationTestBase(PythonEnvironmentFixture fixture)
+{
+    public IPythonEnvironment Env { get; } = fixture.Env;
 }

--- a/src/Integration.Tests/NoneTests.cs
+++ b/src/Integration.Tests/NoneTests.cs
@@ -1,7 +1,7 @@
 ﻿using CSnakes.Runtime.Python;
 
 namespace Integration.Tests;
-public class NoneTests : IntegrationTestBase
+public class NoneTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void TestReturnsNoneIsNone()

--- a/src/Integration.Tests/TestDependency.cs
+++ b/src/Integration.Tests/TestDependency.cs
@@ -2,7 +2,7 @@
 
 namespace Integration.Tests;
 
-public class TestDependency : IntegrationTestBase
+public class TestDependency(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     [Fact]
     public void VerifyInstalledPackage()

--- a/src/Integration.Tests/TupleTests.cs
+++ b/src/Integration.Tests/TupleTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace Integration.Tests;
 
-public class TupleTests : IntegrationTestBase
+public class TupleTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {
     ITestTuples TestTuples => Env.TestTuples();
 


### PR DESCRIPTION
This PR fixes #237.

[Apparently](https://stackoverflow.com/a/27225020/6682):

> …calling `Py_Finalize` without holding the global interpreter lock. This is not allowed: the lock must be held for every Python API call, with the single exception of the call that acquires the GIL itself.

This PR acquires the lock prior to calling `Py_Finalize` (but doesn't release it afterwards). Prior to that, it acquires the lock and releases it immediately for the sole purpose of disposing any queued handles before the runtime is finalized:

https://github.com/tonybaloney/CSnakes/blob/c21d30d7e9400d02399d6ba38c1a2787449fe29a/src/CSnakes.Runtime/Python/GIL.cs#L59-L64

The [documentation says](https://tonybaloney.github.io/CSnakes/getting-started/#constructing-a-python-environment-from-c):

> Python environments created by CSnakes are designed to be process-level singletons. This means that you can create a Python environment once and use it throughout the lifetime of the process.

However, the integration tests were written such that the environment is created (though not destroyed until this PR) for each test class/collection and conflicts with the policy of being a process-level singleton. This PR therefore also adjusts the tests to use a _single environment_ via a [shared test collection fixture](https://xunit.net/docs/shared-context.html#collection-fixture). Unfortunately, without this, the process continues to crash due to other bugs that interfere with the process-level singleton environment policy. I'm not sure if the _singletons_ mentioned in plural form in the documentation was intended or not.

A major side-effect of this change is that all integration tests now run one-by-one since they belong to the same test collection. The environment is set-up and torn down once.
