### PR TITLE
Have generated module interfaces inherit from `IDisposable`

### DIFF
--- a/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
+++ b/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
@@ -117,7 +117,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
                     {{methods.Select(m => m.Syntax).Compile()}}
                 }
             }
-            public interface I{{pascalFileName}}
+            public interface I{{pascalFileName}} : IDisposable
             {
                 {{string.Join(Environment.NewLine, methods.Select(m => m.Syntax).Select(m => $"{m.ReturnType.NormalizeWhitespace()} {m.Identifier.Text}{m.ParameterList.NormalizeWhitespace()};"))}}
             }


### PR DESCRIPTION
The source generate implements the `Dispose` method on the implementation of the generated module interfaces:

https://github.com/tonybaloney/CSnakes/blob/bdabf2359e64e81e6069f03a317fd2ab6eb79ac6/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs#L110-L115

Since it doesn't advertise that, the implementation is publicly unreachable and therefore it's impossible to dispose a module and free its memory. This PR fixes that be having module interfaces inherit from `IDisposable`.