### PR TITLE
Fixing how the assemblies are referenced in NuGet

### DIFF
--- a/src/CSnakes.Runtime/Packaging.targets
+++ b/src/CSnakes.Runtime/Packaging.targets
@@ -7,7 +7,6 @@
     <!-- warning NU5128: Add lib or ref assemblies for the netstandard2.0 target framework -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
 
-    <DevelopmentDependency>true</DevelopmentDependency>
     <GeneratePackageOnBuild>$(EnableLocalPackaging)</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Packaging.props
+++ b/src/Packaging.props
@@ -5,7 +5,7 @@
     <PackageIcon>logo.jpeg</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/tonybaloney/CSnakes</RepositoryUrl>
-    <VersionPrefix>1.0.18</VersionPrefix>
+    <VersionPrefix>1.0.19</VersionPrefix>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Setting the DevelopmentDependency property will cause the nuspec to have a developmentDependency node in the metadata, which influences how the package is referenced in the consuming projects (see https://github.com/NuGet/NuGet.Client/blob/a41fd92fbbd65fb430e96b11c3277e2c96184474/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets#L236 for the task entrypoint).

This property would make sense if we were shipping something only for development in the nupkg (like just a source generator or analyzer) but since we're not, we're also shipping a runtime, we don't want the package considered a developmentDependency as that will influence the IncludeAssets and PrivateAssets properties of the package reference.

https://learn.microsoft.com/nuget/reference/nuspec#developmentdependency is the nuspec reference with more details here: https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference

Fixes #238