### PR TITLE
Make type name patterns explicit where `typing.` qualification is optional

### DIFF
--- a/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
@@ -20,19 +20,18 @@ public static class TypeReflection
         if (pythonType.HasArguments())
         {
             // Get last occurrence of ] in pythonType
-            return pythonType.Name.Replace("typing.", "") switch
+            return pythonType.Name switch
             {
                 "list" => CreateListType(pythonType.Arguments[0], direction),
-                "List" => CreateListType(pythonType.Arguments[0], direction),
-                "Tuple" => CreateTupleType(pythonType.Arguments, direction),
                 "tuple" => CreateTupleType(pythonType.Arguments, direction),
                 "dict" => CreateDictionaryType(pythonType.Arguments[0], pythonType.Arguments[1], direction),
-                "Dict" => CreateDictionaryType(pythonType.Arguments[0], pythonType.Arguments[1], direction),
-                "Mapping" => CreateDictionaryType(pythonType.Arguments[0], pythonType.Arguments[1], direction),
-                "Sequence" => CreateListType(pythonType.Arguments[0], direction),
-                "Optional" => AsPredefinedType(pythonType.Arguments[0], direction),
-                "Generator" => CreateGeneratorType(pythonType.Arguments[0], pythonType.Arguments[1], pythonType.Arguments[2], direction),
-                
+                "typing.List" or "List" => CreateListType(pythonType.Arguments[0], direction),
+                "typing.Tuple" or "Tuple" => CreateTupleType(pythonType.Arguments, direction),
+                "typing.Dict" or "Dict" => CreateDictionaryType(pythonType.Arguments[0], pythonType.Arguments[1], direction),
+                "typing.Mapping" or "Mapping" => CreateDictionaryType(pythonType.Arguments[0], pythonType.Arguments[1], direction),
+                "typing.Sequence" or "Sequence" => CreateListType(pythonType.Arguments[0], direction),
+                "typing.Optional" or "Optional" => AsPredefinedType(pythonType.Arguments[0], direction),
+                "typing.Generator" or "Generator" => CreateGeneratorType(pythonType.Arguments[0], pythonType.Arguments[1], pythonType.Arguments[2], direction),
                 // Todo more types... see https://docs.python.org/3/library/stdtypes.html#standard-generic-classes
                 _ => SyntaxFactory.ParseTypeName("PyObject"),
             };

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -22,6 +22,7 @@ public class GeneratedSignatureTests(TestEnvironment testEnv) : IClassFixture<Te
     [InlineData("def hello_world(name: str, age: int) -> str:\n    ...\n", "string HelloWorld(string name, long age)")]
     [InlineData("def hello_world(numbers: list[float]) -> list[int]:\n    ...\n", "IReadOnlyList<long> HelloWorld(IReadOnlyList<double> numbers)")]
     [InlineData("def hello_world(numbers: List[float]) -> List[int]:\n    ...\n", "IReadOnlyList<long> HelloWorld(IReadOnlyList<double> numbers)")]
+    [InlineData("def hello_world(numbers: Sequence[float]) -> typing.Sequence[int]:\n    ...\n", "IReadOnlyList<long> HelloWorld(IReadOnlyList<double> numbers)")]
     [InlineData("def hello_world(value: tuple[int]) -> None:\n    ...\n", "void HelloWorld(ValueTuple<long> value)")]
     [InlineData("def hello_world(a: bool, b: str, c: list[tuple[int, float]]) -> bool: \n ...\n", "bool HelloWorld(bool a, string b, IReadOnlyList<(long, double)> c)")]
     [InlineData("def hello_world(a: bool = True, b: str = None) -> bool: \n ...\n", "bool HelloWorld(bool a = true, string? b = null)")]
@@ -34,8 +35,12 @@ public class GeneratedSignatureTests(TestEnvironment testEnv) : IClassFixture<Te
     [InlineData("def hello(a: int = 0xdeadbeef) -> None:\n ...\n", "void Hello(long a = 0xDEADBEEF)")]
     [InlineData("def hello(a: int = 0b10101010) -> None:\n ...\n", "void Hello(long a = 0b10101010)")]
     [InlineData("def hello(a: int = 2147483648) -> None:\n ...\n", "void Hello(long a = 2147483648L)")]
-    [InlineData("def hello(a: Optional[int] = None) -> None:\n ...\n", "void Hello(long? a = null)")]
+    [InlineData("def hello(a: Optional[int] = None, b: typing.Optional[int] = None) -> None:\n ...\n", "void Hello(long? a = null, long? b = null)")]
     [InlineData("def hello(a: typing.List[int], b: typing.Dict[str, int]) -> typing.Tuple[str, int]:\n ...\n", "public (string, long) Hello(IReadOnlyList<long> a, IReadOnlyDictionary<string, long> b)")]
+    [InlineData("def hello(a: Dict[int, str]) -> typing.Dict[str, int]:\n ...\n", "IReadOnlyDictionary<string, long> Hello(IReadOnlyDictionary<long, string> a)")]
+    [InlineData("def hello(a: Mapping[int, str]) -> typing.Mapping[str, int]:\n ...\n", "IReadOnlyDictionary<string, long> Hello(IReadOnlyDictionary<long, string> a)")]
+    [InlineData("def hello() -> Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
+    [InlineData("def hello() -> typing.Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> Buffer:\n ...\n", "IPyBuffer Hello()")]
     public void TestGeneratedSignature(string code, string expected)
     {


### PR DESCRIPTION
This was a little hard to parse, somewhat fragile and potentially allocates:

https://github.com/tonybaloney/CSnakes/blob/efd03f84eb3bac396d1bcd5408cdfc31b5b04333/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs#L23

This PR proposes to use explicit `or` patterns instead for the following benefits (in order of importance):

- Clear and explicit cases of what's accepted, e.g. `"typing.Dict" or "Dict"`
- `typing.` isn't just removed anywhere in the name (always a prefix) to avoid accidental matches
- No new string allocation in case `Replace` the effect of removing the string

I added tests for cases that were previously uncovered to make sure nothing was broken by this PR (unless I got the intent wrong).
