### PR TITLE
Enable F5 debugging of source generator in Visual Studio

### DIFF
--- a/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj
+++ b/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1035</NoWarn>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CSnakes.SourceGeneration/Properties/launchSettings.json
+++ b/src/CSnakes.SourceGeneration/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Integration.Tests": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\Integration.Tests\\Integration.Tests.csproj"
+    }
+  }
+}


### PR DESCRIPTION
This PR enables [<kbd>F5</kbd> debugging of the source generator in Visual Studio](https://github.com/dotnet/roslyn-sdk/issues/850) against the integration tests.
