### PR TITLE
Use `ReadOnlySpan` where writing isn't needed

### DIFF
--- a/src/CSnakes.Runtime/CPython/Bytes.cs
+++ b/src/CSnakes.Runtime/CPython/Bytes.cs
@@ -11,7 +11,7 @@ internal unsafe partial class CPythonAPI
         return PyObject_IsInstance(p, PyBytesType);
     }
 
-    internal static nint PyBytes_FromByteSpan(Span<byte> bytes)
+    internal static nint PyBytes_FromByteSpan(ReadOnlySpan<byte> bytes)
     {
         fixed (byte* b = bytes)
         {

--- a/src/CSnakes.Runtime/CPython/Call.cs
+++ b/src/CSnakes.Runtime/CPython/Call.cs
@@ -5,7 +5,7 @@ namespace CSnakes.Runtime.CPython;
 
 internal unsafe partial class CPythonAPI
 {
-    internal static IntPtr Call(PyObject callable, Span<IntPtr> args)
+    internal static IntPtr Call(PyObject callable, ReadOnlySpan<IntPtr> args)
     {
         // These options are used for efficiency. Don't create a tuple if its not required. 
         if (args.Length == 0)
@@ -32,7 +32,7 @@ internal unsafe partial class CPythonAPI
         }
     }
 
-    internal static IntPtr Call(PyObject callable, Span<IntPtr> args, Span<string> kwnames, Span<IntPtr> kwvalues)
+    internal static IntPtr Call(PyObject callable, ReadOnlySpan<IntPtr> args, ReadOnlySpan<string> kwnames, ReadOnlySpan<IntPtr> kwvalues)
     {
         // These options are used for efficiency. Don't create a tuple if its not required. 
         if (false /* TODO: Implement vectorcall for kwargs*/ && 

--- a/src/CSnakes.Runtime/CPython/Dict.cs
+++ b/src/CSnakes.Runtime/CPython/Dict.cs
@@ -19,7 +19,7 @@ internal unsafe partial class CPythonAPI
         return PyObject_IsInstance(p, PyDictType);
     }
 
-    internal static nint PackDict(Span<string> kwnames, Span<IntPtr> kwvalues)
+    internal static nint PackDict(ReadOnlySpan<string> kwnames, ReadOnlySpan<IntPtr> kwvalues)
     {
         var dict = PyDict_New();
         for (int i = 0; i < kwnames.Length; i ++)

--- a/src/CSnakes.Runtime/CPython/Tuple.cs
+++ b/src/CSnakes.Runtime/CPython/Tuple.cs
@@ -19,7 +19,7 @@ internal unsafe partial class CPythonAPI
     /// </summary>
     /// <param name="items">An array of pointers to PyObject</param>
     /// <returns>A new reference to the resulting tuple object.</returns>
-    internal static nint PackTuple(Span<IntPtr> items)
+    internal static nint PackTuple(ReadOnlySpan<IntPtr> items)
     {
         // This is a shortcut to a CPython optimization. Keep an empty tuple and reuse it.
         if (items.Length == 0)

--- a/src/CSnakes.Runtime/Python/Pack.cs
+++ b/src/CSnakes.Runtime/Python/Pack.cs
@@ -7,16 +7,16 @@ using PyObjectMarshaller = System.Runtime.InteropServices.Marshalling.SafeHandle
 namespace CSnakes.Runtime.Python;
 
 /// <summary>
-/// These methods are used internally to create a PyObject where the Dispose() call will dispose all items in 
+/// These methods are used internally to create a PyObject where the Dispose() call will dispose all items in
 /// the collection inside the same call stack. This avoids the .NET GC Finalizer thread from disposing the items
 /// that were created and creating a GIL contention issue when other code is running.
 /// </summary>
 internal static class Pack
 {
-    internal static PyObject CreateTuple(Span<PyObject> items) =>
+    internal static PyObject CreateTuple(ReadOnlySpan<PyObject> items) =>
         PyObject.Create(CreateListOrTuple<TupleBuilder>(items));
 
-    internal static PyObject CreateList(Span<PyObject> items) =>
+    internal static PyObject CreateList(ReadOnlySpan<PyObject> items) =>
         PyObject.Create(CreateListOrTuple<ListBuilder>(items));
 
     private interface IListOrTupleBuilder
@@ -57,7 +57,7 @@ internal static class Pack
         private T _;
     }
 
-    private static nint CreateListOrTuple<TBuilder>(Span<PyObject> items)
+    private static nint CreateListOrTuple<TBuilder>(ReadOnlySpan<PyObject> items)
         where TBuilder : IListOrTupleBuilder
     {
         // Allocate initial space for the handles and marshallers on the stack.


### PR DESCRIPTION
This PR replaces `Span<>` with `ReadOnlySpan<>` where writing isn't needed to keep the signatures more open and honest.