### PR TITLE
Set variance of `IGeneratorIterator<,,>` type parameters

### DIFF
--- a/src/CSnakes.Runtime/Python/IGeneratorIterator.cs
+++ b/src/CSnakes.Runtime/Python/IGeneratorIterator.cs
@@ -1,6 +1,6 @@
 ﻿namespace CSnakes.Runtime.Python;
 
-public interface IGeneratorIterator<TYield, TSend, TReturn>: IEnumerator<TYield>, IEnumerable<TYield>, IGeneratorIterator
+public interface IGeneratorIterator<out TYield, in TSend, out TReturn>: IEnumerator<TYield>, IEnumerable<TYield>, IGeneratorIterator
 {
     TYield Send(TSend value);
 }


### PR DESCRIPTION
This PR sets the variance of `IGeneratorIterator<,,>` type parameters, especially for `TYield` to be aligned with `T` of `IEnumerator<out T>`.