### PR TITLE
Get error cause once

### DIFF
--- a/src/CSnakes.Runtime/PythonRuntimeException.cs
+++ b/src/CSnakes.Runtime/PythonRuntimeException.cs
@@ -19,18 +19,13 @@ public class PythonRuntimeException : Exception
         Data["globals"] = traceback.GetAttr("tb_frame").GetAttr("f_globals").As<IReadOnlyDictionary<string, PyObject>>();
     }
 
-    private static PythonRuntimeException? GetPythonInnerException(PyObject? exception)
-    {
-        if (exception is null)
-        {
-            return null;
-        }
-        if (exception.HasAttr("__cause__") && !exception.GetAttr("__cause__").IsNone())
-        {
-            return new PythonRuntimeException(exception.GetAttr("__cause__"), null);
-        }
-        return null;
-    }
+    private static PythonRuntimeException? GetPythonInnerException(PyObject? exception) =>
+        exception is { } someException
+        && someException.HasAttr("__cause__")
+        && someException.GetAttr("__cause__") is var cause
+        && !cause.IsNone()
+            ? new PythonRuntimeException(cause, null)
+            : null;
 
     public string[] PythonStackTrace
     {


### PR DESCRIPTION
This PR replaces two calls to get the `__cause__` attribute's value (`exception.GetAttr("__cause__")`) with a single one in order to avoid two hops across the marshalling boundary as well as allocations of the name.