### PR TITLE
Add missing reference to Superpower in test project

### DIFF
--- a/src/CSnakes.Tests/CSnakes.Tests.csproj
+++ b/src/CSnakes.Tests/CSnakes.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="Superpower" />
     <PackageReference Include="System.Net.Http" />
     <PackageReference Include="System.Text.RegularExpressions" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
The test project uses types from [Superpower](https://www.nuget.org/packages/Superpower) _directly_ (see [`src/CSnakes.Tests/TokenizerTests.cs`](https://github.com/tonybaloney/CSnakes/blob/048e011b5d70849edb1d0c26fa9b985f8a48f6dc/src/CSnakes.Tests/TokenizerTests.cs#L5) and [`src/CSnakes.Tests/TypeReflectionTests.cs`](https://github.com/tonybaloney/CSnakes/blob/048e011b5d70849edb1d0c26fa9b985f8a48f6dc/src/CSnakes.Tests/TypeReflectionTests.cs#L3)), but doesn't reference it from the test project file. This can throw off some test runners or show up distracting error squiggles in the IDE. This PR adds the missing reference.