### PR TITLE
Fix pythonpath (again)

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/AttributeTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/AttributeTests.cs
@@ -1,0 +1,25 @@
+﻿using CSnakes.Runtime.Python;
+namespace CSnakes.Runtime.Tests.Python;
+public class AttributeTests : RuntimeTestBase
+{
+    [Fact]
+    public void TestHasAttrFile()
+    {
+        using (GIL.Acquire())
+        {
+            using PyObject sys = Import.ImportModule("os");
+            Assert.NotNull(sys);
+            Assert.True(sys.HasAttr("__file__"));
+        }
+    }
+    [Fact]
+    public void TestHasAttrName()
+    {
+        using (GIL.Acquire())
+        {
+            using PyObject sys = Import.ImportModule("os");
+            Assert.NotNull(sys);
+            Assert.True(sys.HasAttr("__name__"));
+        }
+    }
+}

--- a/src/CSnakes.Runtime/CPython/List.cs
+++ b/src/CSnakes.Runtime/CPython/List.cs
@@ -23,6 +23,9 @@ internal unsafe partial class CPythonAPI
     [LibraryImport(PythonLibraryName)]
     internal static partial nint PyList_Size(PyObject obj);
 
+    [LibraryImport(PythonLibraryName, EntryPoint= "PyList_Size")]
+    internal static partial nint PyList_SizeRaw(nint obj);
+
     /// <summary>
     /// Get a reference to the item at `pos` in the list
     /// </summary>
@@ -49,6 +52,9 @@ internal unsafe partial class CPythonAPI
     [LibraryImport(PythonLibraryName, EntryPoint = "PyList_GetItem")]
     private static partial nint PyList_GetItem_(PyObject obj, nint pos);
 
+    [LibraryImport(PythonLibraryName, EntryPoint = "PyList_GetItem")]
+    private static partial nint PyList_GetItemRaw(nint obj, nint pos);
+
     internal static int PyList_SetItemRaw(nint ob, nint pos, nint o)
     {
         int result = PyList_SetItem_(ob, pos, o);
@@ -67,4 +73,9 @@ internal unsafe partial class CPythonAPI
     {
         return PyObject_IsInstance(p, PyListType);
     }
+
+
+    [LibraryImport(PythonLibraryName, EntryPoint = "PyList_Append")]
+    internal static partial int PyList_AppendRaw(nint obj, nint o);
+
 }

--- a/src/CSnakes.Runtime/CPython/Object.cs
+++ b/src/CSnakes.Runtime/CPython/Object.cs
@@ -180,4 +180,7 @@ internal unsafe partial class CPythonAPI
 
     [LibraryImport(PythonLibraryName)]
     internal static partial int PyObject_RichCompareBool(PyObject ob1, PyObject ob2, RichComparisonType comparisonType);
+
+    [LibraryImport(PythonLibraryName, EntryPoint= "PyObject_RichCompareBool")]
+    internal static partial int PyObject_RichCompareBoolRaw(nint ob1, nint ob2, RichComparisonType comparisonType);
 }


### PR DESCRIPTION
This time it should work...

- added test for __file__ and __name__ attribute on os module (first commit, so should fail without the patch)

- removed PySet_Path usage and DLL definitions
- added a AppendMissingPathsToSysPath() to CPythonAPI, called within GIL before initializing the types
- AppendMissingPathsToSysPath does as it says: it checks if a path is already in sys.path, if not it will be appended
- PythonPath is splitted "as is", its up to the setter of PythonPath to provide absolute paths