### PR TITLE
Reuse computed installation lock file path

### DIFF
--- a/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
@@ -44,8 +44,7 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, in
             return LocatePythonInternal(installPath);
         }
 
-
-        if (File.Exists(Path.Join(downloadPath, "install.lock"))) // Someone else is installing, wait to finish
+        if (File.Exists(lockfile)) // Someone else is installing, wait to finish
         {
             // Wait until it's finished
             var loopCount = 0;


### PR DESCRIPTION
The installation lock file path was being computed twice. This PR reuses the previously computed path in `lockfile`.