### PR TITLE
Fix `RedistributableLocator` install when special folder is missing

### DIFF
--- a/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
@@ -34,7 +34,8 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, in
 
     public override PythonLocationMetadata LocatePython()
     {
-        var downloadPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "CSnakes", $"python{Version.Major}.{Version.Minor}.{Version.Build}");
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create);
+        var downloadPath = Path.Join(appDataPath, "CSnakes", $"python{Version.Major}.{Version.Minor}.{Version.Build}");
         var installPath = Path.Join(downloadPath, "python", "install");
         var lockfile = Path.Join(downloadPath, "install.lock");
 


### PR DESCRIPTION
`RedistributableLocator` currently installs to [`Environment.SpecialFolder.ApplicationData`][SpecialFolder:fields], but [`Environment.GetFolderPath`] can return an empty string for this on some systems and therefore the installation fails. For example, testing `RedistributablePython.Tests` on the .NET SDK 9 docker image:

```sh
docker run --rm mcr.microsoft.com/dotnet/sdk:9.0 bash -ec '
    cat /etc/os-release
    git clone --depth 1 --branch v1.0.23 https://github.com/tonybaloney/CSnakes.git csnakes
    cd csnakes
    dotnet test -f net9.0 --tl:off src/RedistributablePython.Tests'
```

fails:

    PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
    NAME="Debian GNU/Linux"
    VERSION_ID="12"
    VERSION="12 (bookworm)"
    VERSION_CODENAME=bookworm
    ID=debian
    HOME_URL="https://www.debian.org/"
    SUPPORT_URL="https://www.debian.org/support"
    BUG_REPORT_URL="https://bugs.debian.org/"
    Cloning into 'csnakes'...
    Note: switching to 'd3ae49b2760277ee72355819d26938fee8d55042'.
    
    You are in 'detached HEAD' state. You can look around, make experimental
    changes and commit them, and you can discard any commits you make in this
    state without impacting any branches by switching back to a branch.
    
    If you want to create a new branch to retain commits you create, you may
    do so (now or later) by using -c with the switch command. Example:
    
      git switch -c <new-branch-name>
    
    Or undo this operation with:
    
      git switch -
    
    Turn off this advice by setting config variable advice.detachedHead to false
    
      Determining projects to restore...
      Restored /csnakes/src/CSnakes.Runtime/CSnakes.Runtime.csproj (in 5.55 sec).
      Restored /csnakes/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj (in 6.15 sec).
      Restored /csnakes/src/RedistributablePython.Tests/RedistributablePython.Tests.csproj (in 6.15 sec).
      CSnakes.SourceGeneration -> /csnakes/src/CSnakes.SourceGeneration/bin/Debug/netstandard2.0/CSnakes.SourceGeneration.dll
      CSnakes.Runtime -> /csnakes/src/CSnakes.Runtime/bin/Debug/net9.0/CSnakes.Runtime.dll
      RedistributablePython.Tests -> /csnakes/src/RedistributablePython.Tests/bin/Debug/net9.0/RedistributablePython.Tests.dll
    Test run for /csnakes/src/RedistributablePython.Tests/bin/Debug/net9.0/RedistributablePython.Tests.dll (.NETCoreApp,Version=v9.0)
    VSTest version 17.12.0 (x64)
    
    Starting test execution, please wait...
    A total of 1 test files matched the specified pattern.
    [xUnit.net 00:00:07.01]     RedistributablePython.Tests.BasicTests.TestSimpleImport [FAIL]
      Failed RedistributablePython.Tests.BasicTests.TestSimpleImport [1 ms]
      Error Message:
       System.InvalidOperationException : Could not create virtual environment. Error: [Errno 2] No such file or directory: '/csnakes/src/RedistributablePython.Tests/bin/Debug/net9.0/python/.venv/bin/python3.12'
      Stack Trace:
         at CSnakes.Runtime.EnvironmentManagement.VenvEnvironmentManagement.EnsureEnvironment(PythonLocationMetadata pythonLocation) in /csnakes/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs:line 31
       at CSnakes.Runtime.PythonEnvironment..ctor(IEnumerable`1 locators, IEnumerable`1 packageInstallers, PythonEnvironmentOptions options, ILogger`1 logger, IEnvironmentManagement environmentManager) in /csnakes/src/CSnakes.Runtime/PythonEnvironment.cs:line 72
       at CSnakes.Runtime.PythonEnvironment.GetPythonEnvironment(IEnumerable`1 locators, IEnumerable`1 packageInstallers, PythonEnvironmentOptions options, ILogger`1 logger, IEnvironmentManagement environmentManager) in /csnakes/src/CSnakes.Runtime/PythonEnvironment.cs:line 32
       at CSnakes.Runtime.ServiceCollectionExtensions.<>c.<WithPython>b__0_0(IServiceProvider sp) in /csnakes/src/CSnakes.Runtime/ServiceCollectionExtensions.cs:line 35
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite callSite, RuntimeResolverContext context)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
       at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
       at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
       at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
       at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType)
       at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
       at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
       at RedistributablePython.Tests.RedistributablePythonTestBase..ctor() in /csnakes/src/RedistributablePython.Tests/RedistributablePythonTestBase.cs:line 28
       at RedistributablePython.Tests.BasicTests..ctor()
       at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
    
    Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1, Duration: 1 ms - RedistributablePython.Tests.dll (net9.0)

The error being:

    System.InvalidOperationException : Could not create virtual environment. Error: [Errno 2] No such file or directory: '/csnakes/src/RedistributablePython.Tests/bin/Debug/net9.0/python/.venv/bin/python3.12'

This is because [`Environment.SpecialFolder.ApplicationData` maps to `$XDG_CONFIG_HOME` on Linux distributions](https://developers.redhat.com/blog/2018/11/07/dotnet-special-folder-api-linux) and that's not found in the .NET SDK 9 docker image. Running:

```sh
docker run --rm -it mcr.microsoft.com/dotnet/sdk:9.0 bash -ec '
    dotnet tool install -g dotnet-script
    export PATH=$PATH:/root/.dotnet/tools
    dotnet script eval "Console.WriteLine($\"Result 
 {Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\");"'
```

prints:

    Tools directory '/root/.dotnet/tools' is not currently on the PATH environment variable.
    If you are using bash, you can add it to your profile by running the following command:
    
    cat << \EOF >> ~/.bash_profile
    # Add .NET Core SDK tools
    export PATH="$PATH:/root/.dotnet/tools"
    EOF
    
    You can add it to the current session by running the following command:
    
    export PATH="$PATH:/root/.dotnet/tools"
    
    You can invoke the tool using the following command: dotnet-script
    Tool 'dotnet-script' (version '1.6.0') was successfully installed.
    Result =

Note the last line reads: `Result =`

The doc for the return value of [`Environment.GetFolderPath`] states that it will return an empty string if the folder doesn't exist:

> The path to the specified system special folder, if that folder physically exists on your computer; otherwise, an empty string ("").

The test is passing on CI because the directory probably exists on the runner.

This PR fixes the problem by using the second [overload of `Environment.GetFolderPath`][Environment.GetFolderPath-2] that takes a [`Environment.SpecialFolderOption`] and uses `Environment.SpecialFolderOption.Create`. The will cause the folder to be created if missing. I tested this change with:

```sh
docker run --rm mcr.microsoft.com/dotnet/sdk:9.0 bash -ec '
    cat /etc/os-release
    git clone --depth 1 --branch fix/missing-app-data-path https://github.com/atifaziz/CSnakes.git csnakes
    cd csnakes
    dotnet test -f net9.0 --tl:off src/RedistributablePython.Tests'
```

and the output show that the test passes:

    PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
    NAME="Debian GNU/Linux"
    VERSION_ID="12"
    VERSION="12 (bookworm)"
    VERSION_CODENAME=bookworm
    ID=debian
    HOME_URL="https://www.debian.org/"
    SUPPORT_URL="https://www.debian.org/support"
    BUG_REPORT_URL="https://bugs.debian.org/"
    Cloning into 'csnakes'...
      Determining projects to restore...
      Restored /csnakes/src/CSnakes.Runtime/CSnakes.Runtime.csproj (in 5.51 sec).
      Restored /csnakes/src/RedistributablePython.Tests/RedistributablePython.Tests.csproj (in 6.27 sec).
      Restored /csnakes/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj (in 6.36 sec).
      CSnakes.SourceGeneration -> /csnakes/src/CSnakes.SourceGeneration/bin/Debug/netstandard2.0/CSnakes.SourceGeneration.dll
      CSnakes.Runtime -> /csnakes/src/CSnakes.Runtime/bin/Debug/net9.0/CSnakes.Runtime.dll
      RedistributablePython.Tests -> /csnakes/src/RedistributablePython.Tests/bin/Debug/net9.0/RedistributablePython.Tests.dll
    Test run for /csnakes/src/RedistributablePython.Tests/bin/Debug/net9.0/RedistributablePython.Tests.dll (.NETCoreApp,Version=v9.0)
    VSTest version 17.12.0 (x64)
    
    Starting test execution, please wait...
    A total of 1 test files matched the specified pattern.
    
    Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 12 s - RedistributablePython.Tests.dll (net9.0)
   
---
PS I also propose to use `Environment.SpecialFolder.LocalApplicationData` instead of `Environment.SpecialFolder.ApplicationData` because I don't see any value in caching the installation into a _roaming profile_ on Windows. I can do that in this PR or as a follow-up one to keep the changes separate. Let me know your preference.
  
[SpecialFolder:fields]: https://learn.microsoft.com/en-us/dotnet/api/system.environment.specialfolder#fields
[`Environment.GetFolderPath`]: https://learn.microsoft.com/en-us/dotnet/api/system.environment.getfolderpath
[Environment.GetFolderPath-2]: https://learn.microsoft.com/en-us/dotnet/api/system.environment.getfolderpath?view=net-9.0#system-environment-getfolderpath(system-environment-specialfolder-system-environment-specialfolderoption)
[`Environment.SpecialFolderOption`]: https://learn.microsoft.com/en-us/dotnet/api/system.environment.specialfolderoption?view=net-9.0
