### PR TITLE
Use system mutex in `RedistributableLocator` during installation

### DIFF
--- a/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
@@ -134,6 +134,8 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, in
             throw;
         }
 
+        mutex.ReleaseMutex(); // Everything supposedly went well so release mutex
+
         return LocatePythonInternal(installPath);
     }
 


### PR DESCRIPTION
This PR suggests to replace installation lock file with the use of a named [`Mutex`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.mutex.-ctor?view=net-9.0#system-threading-mutex-ctor(system-boolean-system-string)), which requires less code (no polling with sleeps and lock file management), supports timing out, has cross-platform support and doesn't suffer from race conditions of file operations (which require more care). Moreover, a process that crashes and whose thread owned the mutex can signal [abandonment](https://github.com/dotnet/runtime/blob/9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3/src/coreclr/pal/src/include/pal/mutex.hpp#L111-L116) to others so they can acquire the lock.

Incidentally, the [`Mutex` implementation on some non-Windows platforms also uses a lock file](https://github.com/dotnet/runtime/blob/9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3/src/coreclr/pal/src/include/pal/mutex.hpp#L94-L98) behind the scenes.