### PR TITLE
Fix `PATH` path separator in package installers

### DIFF
--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -38,7 +38,7 @@ internal class PipInstaller(ILogger<PipInstaller> logger, string requirementsFil
             string venvScriptPath = Path.Combine(virtualEnvironmentLocation, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Scripts" : "bin");
             // TODO: Check that the pip executable exists, and if not, raise an exception with actionable steps.
             fileName = Path.Combine(venvScriptPath, pipBinaryName);
-            path = $"{venvScriptPath};{Environment.GetEnvironmentVariable("PATH")}";
+            path = string.Join(Path.PathSeparator, venvScriptPath, Environment.GetEnvironmentVariable("PATH"));
             IReadOnlyDictionary<string, string> extraEnv = new Dictionary<string, string>
             {
                 { "VIRTUAL_ENV", virtualEnvironmentLocation }

--- a/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
@@ -46,7 +46,7 @@ internal class UVInstaller(ILogger<UVInstaller> logger, string requirementsFileN
             }
 
             fileName = uvPath;
-            path = $"{venvScriptPath};{Environment.GetEnvironmentVariable("PATH")}";
+            path = string.Join(Path.PathSeparator, venvScriptPath, Environment.GetEnvironmentVariable("PATH"));
             IReadOnlyDictionary<string, string?> extraEnv = new Dictionary<string, string?>
             {
                 { "VIRTUAL_ENV", virtualEnvironmentLocation },


### PR DESCRIPTION
The `PATH` path separator in the package installers was hard-coded to `;`, which is only valid for Windows. On Linux and macOS, it's usually `:`. This PR fixes the issue by using [`Path.PathSeparator`], which returns the correct path separator for the host OS.

[`Path.PathSeparator`]: https://learn.microsoft.com/en-us/dotnet/api/system.io.path.pathseparator
