### PR TITLE
Allow users to run Python code from a string

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -6,14 +6,14 @@ public class RunTests : RuntimeTestBase
     [Fact]
     public void TestSimpleString()
     {
-        using var result = env.Execute("1+1");
+        using var result = env.ExecuteExpression("1+1");
         Assert.Equal("2", result.ToString());
     }
 
     [Fact]
     public void TestBadString()
     {
-        Assert.Throws<PythonInvocationException>(() => env.Execute("1+"));
+        Assert.Throws<PythonInvocationException>(() => env.ExecuteExpression("1+"));
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class RunTests : RuntimeTestBase
         {
             ["a"] = PyObject.From(101)
         };
-        using var result = env.Execute("a+1", locals);
+        using var result = env.ExecuteExpression("a+1", locals);
         Assert.Equal("102", result.ToString());
     }
 
@@ -38,7 +38,26 @@ public class RunTests : RuntimeTestBase
         {
             ["b"] = PyObject.From(100)
         };
-        using var result = env.Execute("a+b+1", locals, globals);
+        using var result = env.ExecuteExpression("a+b+1", locals, globals);
         Assert.Equal("202", result.ToString());
+    }
+
+    [Fact]
+    public void TestMultilineInput()
+    {
+        var c = """
+a = 101
+b = c + a
+""";
+        var locals = new Dictionary<string, PyObject>
+        {
+            ["c"] = PyObject.From(101)
+        };
+        var globals = new Dictionary<string, PyObject>
+        {
+            ["d"] = PyObject.From(100)
+        };
+        using var result = env.Execute(c, locals, globals);
+        Assert.Equal("None", result.ToString());
     }
 }

--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -1,0 +1,10 @@
+﻿namespace CSnakes.Runtime.Tests.Python;
+public class RunTests : RuntimeTestBase
+{
+    [Fact]
+    public void TestSimpleString()
+    {
+        using var result = env.Execute("1+1");
+        Assert.Equal("2", result.ToString());
+    }
+}

--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -1,4 +1,6 @@
-﻿namespace CSnakes.Runtime.Tests.Python;
+﻿using CSnakes.Runtime.Python;
+
+namespace CSnakes.Runtime.Tests.Python;
 public class RunTests : RuntimeTestBase
 {
     [Fact]
@@ -12,5 +14,31 @@ public class RunTests : RuntimeTestBase
     public void TestBadString()
     {
         Assert.Throws<PythonInvocationException>(() => env.Execute("1+"));
+    }
+
+    [Fact]
+    public void TestSimpleStringWithLocals()
+    {
+        var locals = new Dictionary<string, PyObject>
+        {
+            ["a"] = PyObject.From(101)
+        };
+        using var result = env.Execute("a+1", locals);
+        Assert.Equal("102", result.ToString());
+    }
+
+    [Fact]
+    public void TestSimpleStringWithLocalsAndGlobals()
+    {
+        var locals = new Dictionary<string, PyObject>
+        {
+            ["a"] = PyObject.From(101)
+        };
+        var globals = new Dictionary<string, PyObject>
+        {
+            ["b"] = PyObject.From(100)
+        };
+        using var result = env.Execute("a+b+1", locals);
+        Assert.Equal("202", result.ToString());
     }
 }

--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -7,4 +7,10 @@ public class RunTests : RuntimeTestBase
         using var result = env.Execute("1+1");
         Assert.Equal("2", result.ToString());
     }
+
+    [Fact]
+    public void TestBadString()
+    {
+        Assert.Throws<PythonInvocationException>(() => env.Execute("1+"));
+    }
 }

--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -38,7 +38,7 @@ public class RunTests : RuntimeTestBase
         {
             ["b"] = PyObject.From(100)
         };
-        using var result = env.Execute("a+b+1", locals);
+        using var result = env.Execute("a+b+1", locals, globals);
         Assert.Equal("202", result.ToString());
     }
 }

--- a/src/CSnakes.Runtime/CPython/Run.cs
+++ b/src/CSnakes.Runtime/CPython/Run.cs
@@ -5,8 +5,15 @@ namespace CSnakes.Runtime.CPython;
 
 internal unsafe partial class CPythonAPI
 {
-    internal static PyObject PyRun_String(string str, PyObject globals, PyObject locals) => PyObject.Create(PyRun_String_(str, 0, globals, locals));
+    internal enum InputType
+    {
+        Py_single_input = 256,
+        Py_file_input = 257,
+        Py_eval_input = 258
+    }
+
+    internal static PyObject PyRun_String(string str, InputType start, PyObject globals, PyObject locals) => PyObject.Create(PyRun_String_(str, start, globals, locals));
 
     [LibraryImport(PythonLibraryName, EntryPoint = "PyRun_String", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(NonFreeUtf8StringMarshaller))]
-    private static partial nint PyRun_String_(string str, int start, PyObject globals, PyObject locals);
+    private static partial nint PyRun_String_(string str, InputType start, PyObject globals, PyObject locals);
 }

--- a/src/CSnakes.Runtime/CPython/Run.cs
+++ b/src/CSnakes.Runtime/CPython/Run.cs
@@ -1,0 +1,12 @@
+﻿using CSnakes.Runtime.Python;
+using System.Runtime.InteropServices;
+
+namespace CSnakes.Runtime.CPython;
+
+internal unsafe partial class CPythonAPI
+{
+    internal static PyObject PyRun_String(string str, PyObject globals, PyObject locals) => PyObject.Create(PyRun_String_(str, 0, globals, locals));
+
+    [LibraryImport(PythonLibraryName, EntryPoint = "PyRun_String", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(NonFreeUtf8StringMarshaller))]
+    private static partial nint PyRun_String_(string str, int start, PyObject globals, PyObject locals);
+}

--- a/src/CSnakes.Runtime/IPythonEnvironment.cs
+++ b/src/CSnakes.Runtime/IPythonEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using CSnakes.Runtime.CPython;
+using CSnakes.Runtime.Python;
 using Microsoft.Extensions.Logging;
 
 namespace CSnakes.Runtime;
@@ -16,4 +17,7 @@ public interface IPythonEnvironment : IDisposable
     public bool IsDisposed();
 
     public ILogger<IPythonEnvironment> Logger { get; }
+
+    public PyObject Execute(string code);
+    public PyObject Execute(string code, IDictionary<string, PyObject> globals, IDictionary<string, PyObject> locals);
 }

--- a/src/CSnakes.Runtime/IPythonEnvironment.cs
+++ b/src/CSnakes.Runtime/IPythonEnvironment.cs
@@ -17,8 +17,4 @@ public interface IPythonEnvironment : IDisposable
     public bool IsDisposed();
 
     public ILogger<IPythonEnvironment> Logger { get; }
-
-    public PyObject Execute(string code);
-    public PyObject Execute(string code, IDictionary<string, PyObject> locals);
-    public PyObject Execute(string code, IDictionary<string, PyObject> globals, IDictionary<string, PyObject> locals);
 }

--- a/src/CSnakes.Runtime/IPythonEnvironment.cs
+++ b/src/CSnakes.Runtime/IPythonEnvironment.cs
@@ -19,5 +19,6 @@ public interface IPythonEnvironment : IDisposable
     public ILogger<IPythonEnvironment> Logger { get; }
 
     public PyObject Execute(string code);
+    public PyObject Execute(string code, IDictionary<string, PyObject> locals);
     public PyObject Execute(string code, IDictionary<string, PyObject> globals, IDictionary<string, PyObject> locals);
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -9,6 +9,7 @@ using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.EnvironmentManagement;
 using CSnakes.Runtime.Locators;
 using CSnakes.Runtime.PackageManagement;
+using CSnakes.Runtime.Python;
 using Microsoft.Extensions.Logging;
 
 namespace CSnakes.Runtime;
@@ -143,5 +144,20 @@ internal class PythonEnvironment : IPythonEnvironment
     public bool IsDisposed()
     {
         return disposedValue;
+    }
+
+    public PyObject Execute(string code)
+    {
+        using (GIL.Acquire())
+        {
+            using var globals = PyObject.Create(CPythonAPI.PyDict_New());
+            using var locals = PyObject.Create(CPythonAPI.PyDict_New());
+            return CPythonAPI.PyRun_String(code, globals, locals);
+        }
+    }
+
+    public PyObject Execute(string code, IDictionary<string, PyObject> globals, IDictionary<string, PyObject> locals)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -156,8 +156,23 @@ internal class PythonEnvironment : IPythonEnvironment
         }
     }
 
+    public PyObject Execute(string code, IDictionary<string, PyObject> locals)
+    {
+        using (GIL.Acquire())
+        {
+            using var localsPyDict = PyObject.From<IDictionary<string, PyObject>>(locals);
+            using var globalsPyDict = PyObject.Create(CPythonAPI.PyDict_New());
+            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
+        }
+    }
+
     public PyObject Execute(string code, IDictionary<string, PyObject> globals, IDictionary<string, PyObject> locals)
     {
-        throw new NotImplementedException();
+        using (GIL.Acquire())
+        {
+            using var localsPyDict = PyObject.From<IDictionary<string, PyObject>>(locals);
+            using var globalsPyDict = PyObject.From<IDictionary<string, PyObject>>(globals);
+            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
+        }
     }
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -152,7 +152,7 @@ internal class PythonEnvironment : IPythonEnvironment
         {
             using var globals = PyObject.Create(CPythonAPI.PyDict_New());
             using var locals = PyObject.Create(CPythonAPI.PyDict_New());
-            return CPythonAPI.PyRun_String(code, globals, locals);
+            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globals, locals);
         }
     }
 

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -145,34 +145,4 @@ internal class PythonEnvironment : IPythonEnvironment
     {
         return disposedValue;
     }
-
-    public PyObject Execute(string code)
-    {
-        using (GIL.Acquire())
-        {
-            using var globals = PyObject.Create(CPythonAPI.PyDict_New());
-            using var locals = PyObject.Create(CPythonAPI.PyDict_New());
-            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globals, locals);
-        }
-    }
-
-    public PyObject Execute(string code, IDictionary<string, PyObject> locals)
-    {
-        using (GIL.Acquire())
-        {
-            using var localsPyDict = PyObject.From<IDictionary<string, PyObject>>(locals);
-            using var globalsPyDict = PyObject.Create(CPythonAPI.PyDict_New());
-            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
-        }
-    }
-
-    public PyObject Execute(string code, IDictionary<string, PyObject> globals, IDictionary<string, PyObject> locals)
-    {
-        using (GIL.Acquire())
-        {
-            using var localsPyDict = PyObject.From<IDictionary<string, PyObject>>(locals);
-            using var globalsPyDict = PyObject.From<IDictionary<string, PyObject>>(globals);
-            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
-        }
-    }
 }

--- a/src/CSnakes.Runtime/PythonRunString.cs
+++ b/src/CSnakes.Runtime/PythonRunString.cs
@@ -1,0 +1,75 @@
+﻿
+using CSnakes.Runtime.CPython;
+using CSnakes.Runtime.Python;
+
+namespace CSnakes.Runtime;
+public static class PythonRunString
+{
+    /// <summary>
+    /// Execute a single expression in Python and return the result,
+    /// e.g. `1 + 1` or `len([1, 2, 3])`
+    /// </summary>
+    /// <param name="code">The Python code</param>
+    /// <returns>The resulting Python object</returns>
+    public static PyObject ExecuteExpression(this IPythonEnvironment env, string code)
+    {
+        using (GIL.Acquire())
+        {
+            using var globals = PyObject.Create(CPythonAPI.PyDict_New());
+            using var locals = PyObject.Create(CPythonAPI.PyDict_New());
+            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globals, locals);
+        }
+    }
+
+    /// <summary>
+    /// Execute a single expression in Python and return the result, with locals
+    /// e.g. `1 + b`
+    /// </summary>
+    /// <param name="code">The Python code</param>
+    /// <param name="locals">A dictionary of local variables</param>
+    /// <returns>The resulting Python object</returns>
+    public static PyObject ExecuteExpression(this IPythonEnvironment env, string code, IDictionary<string, PyObject> locals)
+    {
+        using (GIL.Acquire())
+        {
+            using var localsPyDict = PyObject.From(locals);
+            using var globalsPyDict = PyObject.Create(CPythonAPI.PyDict_New());
+            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
+        }
+    }
+
+    /// <summary>
+    /// Execute a single expression in Python and return the result, with locals
+    /// e.g. `1 + b`
+    /// </summary>
+    /// <param name="code">The Python code</param>
+    /// <param name="locals">A dictionary of local variables</param>
+    /// <param name="globals">A dictionary of global variables</param>
+    /// <returns>The resulting Python object</returns>
+    public static PyObject ExecuteExpression(this IPythonEnvironment env, string code, IDictionary<string, PyObject> locals, IDictionary<string, PyObject> globals)
+    {
+        using (GIL.Acquire())
+        {
+            using var localsPyDict = PyObject.From(locals);
+            using var globalsPyDict = PyObject.From(globals);
+            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
+        }
+    }
+
+    /// <summary>
+    /// Execute Python program from a string, typically multiple lines of code
+    /// </summary>
+    /// <param name="code">The Python code</param>
+    /// <param name="locals">A dictionary of local variables</param>
+    /// <param name="globals">A dictionary of global variables</param>
+    /// <returns>Normally nothing</returns>
+    public static PyObject Execute(this IPythonEnvironment env, string code, IDictionary<string, PyObject> locals, IDictionary<string, PyObject> globals)
+    {
+        using (GIL.Acquire())
+        {
+            using var localsPyDict = PyObject.From(locals);
+            using var globalsPyDict = PyObject.From(globals);
+            return CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_file_input, globalsPyDict, localsPyDict);
+        }
+    }
+}


### PR DESCRIPTION
Implements #290 

Adds two different types of API:
- IPythonEnvironment.ExecuteExpression which takes a simple expression (`1+1`) and returns the result
- IPythonEnvironment.Execute which takes a string, typically multiple lines