### PR TITLE
Reduce memory load of redistributable download

### DIFF
--- a/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
@@ -163,12 +163,11 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, in
     private static async Task<string> DownloadFileToTempDirectoryAsync(string fileUrl)
     {
         using HttpClient client = new();
-        using HttpResponseMessage response = await client.GetAsync(fileUrl);
-        response.EnsureSuccessStatusCode();
+        using var contentStream = await client.GetStreamAsync(fileUrl);
 
         string tempFilePath = Path.GetTempFileName();
         using FileStream fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
-        await response.Content.CopyToAsync(fileStream);
+        await contentStream.CopyToAsync(fileStream);
 
         return tempFilePath;
     }


### PR DESCRIPTION
The use of [`HttpClient.GetAsync` ](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getasync?view=net-9.0#system-net-http-httpclient-getasync(system-string)) to download the Python redistributable in `RedistributableLocator` causes 
the _entire_ response content to be buffered to memory before being written to disk. Just stepping over the following line in the debugger:

https://github.com/tonybaloney/CSnakes/blob/de05da4d0a40477bd3f69a6c1388f7e408617066/src/CSnakes.Runtime/Locators/RedistributableLocator.cs#L166

shows the memory spike (over 2,600 objects and tens of MBs allocated):

<p><img width="50%" height="50%" src="https://github.com/user-attachments/assets/b320fece-98ac-4ee9-be10-e0818b3ecc32"></p>

If one examines the heap for byte arrays, we find a 41.6MB allocation done by [`HttpContent.LimitMemoryStream`](https://github.com/dotnet/runtime/blob/c8acea22626efab11c13778c028975acdc34678f/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs#L865-L944)

<p><img width="75%" height="75%" src="https://github.com/user-attachments/assets/a0bf5ce0-eed2-48f5-a862-65c3baca5726"></p>

The exact allocation size of 416,204,438 corresponds to the HTTP content length:

![Screenshot 2025-01-18 150747](https://github.com/user-attachments/assets/13ecbdde-f171-47f7-9bba-f2b098dd893a)

The PR fixes the problem by using [`HttpClient.GetStreamAsync`](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getstreamasync?view=net-9.0#system-net-http-httpclient-getstreamasync(system-string)), which checks for a success response code before returning a stream over the content (instead of entirely buffering it). The image below shows the memory usage drops _dramatically_, allocating just 284.4 KB after stepping over the `HttpClient.GetStreamAsync` call (ID 2) and something similar until the end of the [`DownloadFileToTempDirectoryAsync`](https://github.com/tonybaloney/CSnakes/blob/de05da4d0a40477bd3f69a6c1388f7e408617066/src/CSnakes.Runtime/Locators/RedistributableLocator.cs#L163-L174) method (ID 3):

<p><img width="50%" height="50%" src="https://github.com/user-attachments/assets/6cf66bd2-22e7-41ae-9e9d-fe3107047bca"></p>

