### PR TITLE
Remove no longer needed initialization lock

### DIFF
--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -11,7 +11,6 @@ internal unsafe partial class CPythonAPI : IDisposable
     public string PythonPath { get; internal set; } = string.Empty;
 
     private static string? pythonLibraryPath = null;
-    private static readonly Lock initLock = new();
     private static Version PythonVersion = new("0.0.0");
     private bool disposedValue = false;
     private Task? initializationTask = null;
@@ -105,42 +104,39 @@ internal unsafe partial class CPythonAPI : IDisposable
 
     private void InitializeEmbeddedPython()
     {
-        lock (initLock)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            Py_SetPath_UCS2_UTF16(PythonPath);
+        else
+            Py_SetPath_UCS4_UTF32(PythonPath);
+        Debug.WriteLine($"Initializing Python on thread {GetNativeThreadId()}");
+        Py_Initialize();
+
+        // Setup type statics
+        using (GIL.Acquire())
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                Py_SetPath_UCS2_UTF16(PythonPath);
-            else
-                Py_SetPath_UCS4_UTF32(PythonPath);
-            Debug.WriteLine($"Initializing Python on thread {GetNativeThreadId()}");
-            Py_Initialize();
+            if (PyErr_Occurred())
+                throw new InvalidOperationException("Python initialization failed.");
 
-            // Setup type statics
-            using (GIL.Acquire())
-            {
-                if (PyErr_Occurred())
-                    throw new InvalidOperationException("Python initialization failed.");
+            if (!IsInitialized)
+                throw new InvalidOperationException("Python initialization failed.");
 
-                if (!IsInitialized)
-                    throw new InvalidOperationException("Python initialization failed.");
-
-                PyUnicodeType = GetTypeRaw(AsPyUnicodeObject(string.Empty));
-                Py_True = PyBool_FromLong(1);
-                Py_False = PyBool_FromLong(0);
-                PyBoolType = GetTypeRaw(Py_True);
-                PyEmptyTuple = PyTuple_New(0);
-                PyTupleType = GetTypeRaw(PyEmptyTuple);
-                PyFloatType = GetTypeRaw(PyFloat_FromDouble(0.0));
-                PyLongType = GetTypeRaw(PyLong_FromLongLong(0));
-                PyListType = GetTypeRaw(PyList_New(0));
-                PyDictType = GetTypeRaw(PyDict_New());
-                PyBytesType = GetTypeRaw(PyBytes_FromByteSpan(new byte[] { }));
-                ItemsStrIntern = AsPyUnicodeObject("items");
-                PyNone = GetBuiltin("None");
-                AsyncioModule = Import("asyncio");
-                NewEventLoopFactory = AsyncioModule.GetAttr("new_event_loop");
-            }
-            PyEval_SaveThread();
+            PyUnicodeType = GetTypeRaw(AsPyUnicodeObject(string.Empty));
+            Py_True = PyBool_FromLong(1);
+            Py_False = PyBool_FromLong(0);
+            PyBoolType = GetTypeRaw(Py_True);
+            PyEmptyTuple = PyTuple_New(0);
+            PyTupleType = GetTypeRaw(PyEmptyTuple);
+            PyFloatType = GetTypeRaw(PyFloat_FromDouble(0.0));
+            PyLongType = GetTypeRaw(PyLong_FromLongLong(0));
+            PyListType = GetTypeRaw(PyList_New(0));
+            PyDictType = GetTypeRaw(PyDict_New());
+            PyBytesType = GetTypeRaw(PyBytes_FromByteSpan(new byte[] { }));
+            ItemsStrIntern = AsPyUnicodeObject("items");
+            PyNone = GetBuiltin("None");
+            AsyncioModule = Import("asyncio");
+            NewEventLoopFactory = AsyncioModule.GetAttr("new_event_loop");
         }
+        PyEval_SaveThread();
     }
 
     internal static bool IsInitialized => Py_IsInitialized() == 1;
@@ -165,31 +161,28 @@ internal unsafe partial class CPythonAPI : IDisposable
 
     protected void FinalizeEmbeddedPython()
     {
-        lock (initLock)
-        {
-            if (!IsInitialized)
-                return;
+        if (!IsInitialized)
+            return;
 
-            // Shut down asyncio coroutines
-            CloseEventLoops();
+        // Shut down asyncio coroutines
+        CloseEventLoops();
 
-            // Clean-up interns
-            NewEventLoopFactory?.Dispose();
-            AsyncioModule?.Dispose();
-            // TODO: Add more cleanup code here
+        // Clean-up interns
+        NewEventLoopFactory?.Dispose();
+        AsyncioModule?.Dispose();
+        // TODO: Add more cleanup code here
 
-            Debug.WriteLine($"Calling Py_Finalize() on thread {GetNativeThreadId()}");
+        Debug.WriteLine($"Calling Py_Finalize() on thread {GetNativeThreadId()}");
 
-            // Acquire the GIL only to dispose it immediately because `PyGILState_Release`
-            // is not available after `Py_Finalize` is called. This is done primarily to
-            // trigger the disposal of handles that have been queued before the Python
-            // runtime is finalized.
+        // Acquire the GIL only to dispose it immediately because `PyGILState_Release`
+        // is not available after `Py_Finalize` is called. This is done primarily to
+        // trigger the disposal of handles that have been queued before the Python
+        // runtime is finalized.
 
-            GIL.Acquire().Dispose();
+        GIL.Acquire().Dispose();
 
-            PyGILState_Ensure();
-            Py_Finalize();
-        }
+        PyGILState_Ensure();
+        Py_Finalize();
     }
 
     protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
This PR removes the initialization lock since it's no longer necessary since both initialization and finalization run on the same thread.