### PR TITLE
Make GIL disposal idempotent once disposed

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/GILTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/GILTests.cs
@@ -1,0 +1,13 @@
+using CSnakes.Runtime.Python;
+
+namespace CSnakes.Runtime.Tests.Python;
+public class GILTests : RuntimeTestBase
+{
+    [Fact]
+    public void DisposeIsIdempotentOnceDisposed()
+    {
+        var gil = GIL.Acquire();
+        gil.Dispose();
+        gil.Dispose();
+    }
+}

--- a/src/CSnakes.Runtime/Python/GIL.cs
+++ b/src/CSnakes.Runtime/Python/GIL.cs
@@ -59,6 +59,11 @@ public static class GIL
 
         public void Dispose()
         {
+            if (recursionCount == 0)
+            {
+                Debug.WriteLine("GIL disposed more times than it was acquired by thread.");
+                return;
+            }
             recursionCount--;
             if (recursionCount > 0)
             {


### PR DESCRIPTION
If `GIL.Disposed` is called more times than `GIL.Acquire` then a fatal error is reported

    Exit code is -1073740791 (Fatal Python error: PyEval_SaveThread: the function must be called with the GIL held, after Python initialization and before Python finalization, but the GIL is released (the current Python thread state is NULL)
        Python runtime state: initialized
        
        Current thread 0x000088dc (most recent call first):
          <no Python frame>
        
        Thread 0x000088cc (most recent call first):
          <no Python frame>)

This PR fixes the problem by making `GIL.Dispose` idempotent once the recursion count falls to 0 and the GIL has been previously released.