### PR TITLE
Cleanup dependencies now that .NET 9 has hit RTM

### DIFF
--- a/src/CSnakes.Runtime/CSnakes.Runtime.csproj
+++ b/src/CSnakes.Runtime/CSnakes.Runtime.csproj
@@ -15,7 +15,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Numerics.Tensors" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,12 +23,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
   <!--
     Test-only dependencies

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -26,9 +26,9 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
-    <PackageVersion Include="System.Numerics.Tensors" Version="9.0.0-rc.2.24473.5" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
   <!--
     Test-only dependencies


### PR DESCRIPTION
Tony thank you for the excellent talk today with Hanselman I am in love with this library!

I noticed when digging through my dependency graph that it was still pulling in RC2 .NET 9 stuff as well as System.Text.Json but STJ is included in the runtime when your target framework moniker is set at 8 or 9.