### PR TITLE
Reset GIL thread static data when disposing an environment

### DIFF
--- a/src/CSnakes.Runtime/CPython/Init.cs
+++ b/src/CSnakes.Runtime/CPython/Init.cs
@@ -219,6 +219,7 @@ internal unsafe partial class CPythonAPI : IDisposable
 
         PyEval_RestoreThread(initializationTState);
         Py_Finalize();
+        GIL.Reset();
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/CSnakes.Runtime/Python/GIL.cs
+++ b/src/CSnakes.Runtime/Python/GIL.cs
@@ -100,5 +100,11 @@ public static class GIL
         handlesToDispose.Enqueue(handle);
     }
 
+    internal static void Reset()
+    {
+        currentState = null;
+        pythonThreadState = 0;
+    }
+
     public static bool IsAcquired => currentState != null && currentState.RecursionCount > 0;
 }

--- a/src/Integration.Tests/EnvironmentTests.cs
+++ b/src/Integration.Tests/EnvironmentTests.cs
@@ -1,0 +1,51 @@
+﻿using CSnakes.Runtime.Python;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Integration.Tests;
+
+public class EnvironmentTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
+{
+    [Fact]
+    public void TestEnvironment_DisposeAndCreateOther()
+    {
+        var number = Env.TestReload().TestNumber();
+        Env.Dispose();
+        
+        var otherEnv = CreateOtherEnvironment();
+
+        var otherNumber = otherEnv.Other().TestOtherNumber();
+
+        Assert.Equal(52, number);
+        Assert.Equal(80, otherNumber);
+    }
+
+    private IPythonEnvironment CreateOtherEnvironment()
+    {
+        string pythonVersionWindows = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.9";
+        string pythonVersionMacOS = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12";
+        string pythonVersionLinux = Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12";
+        bool freeThreaded = Environment.GetEnvironmentVariable("PYTHON_FREETHREADED") == "true";
+        string venvPath = Path.Join(Environment.CurrentDirectory, "python_other", ".venv_other");
+
+        var app = Host.CreateDefaultBuilder()
+            .ConfigureServices((context, services) =>
+            {
+                var pb = services.WithPython();
+                pb.WithHome(Path.Join(Environment.CurrentDirectory, "python_other"));
+
+                pb.FromNuGet(pythonVersionWindows)
+                    .FromMacOSInstallerLocator(pythonVersionMacOS, freeThreaded)
+                    .FromWindowsStore("3.12")
+                    .FromEnvironmentVariable("Python3_ROOT_DIR", pythonVersionLinux)
+                    .WithVirtualEnvironment(venvPath);
+
+                services.AddLogging(builder => builder.AddXUnit());
+            })
+            .Build();
+
+        var env = app.Services.GetRequiredService<IPythonEnvironment>();
+        return env;
+    }
+}

--- a/src/Integration.Tests/Integration.Tests.csproj
+++ b/src/Integration.Tests/Integration.Tests.csproj
@@ -31,6 +31,9 @@
     <AdditionalFiles Include="python\*.py">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </AdditionalFiles>
+    <AdditionalFiles Include="python_other\other.py">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </AdditionalFiles>
     <Content Include="python\requirements.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/Integration.Tests/python_other/other.py
+++ b/src/Integration.Tests/python_other/other.py
@@ -1,0 +1,2 @@
+﻿def test_other_number() -> int:
+    return 80


### PR DESCRIPTION
To allow using multiple Python environments sequentially, it is necessary to completely reset the internal data of the GIL class when an environment is disposed and the Python interpreter is finalized. Otherwise, an exception will be raised when trying to access a thread state that no longer exists.

This fix doesn't fully resolve the issue #296, but it at least allows sequential execution of multiple different environments.