### PR TITLE
More rebust search for conda source folder

### DIFF
--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -12,16 +12,26 @@ public class CondaTestBase : IDisposable
     {
         string condaEnv = Environment.GetEnvironmentVariable("CONDA") ?? string.Empty;
         string? pythonVersion = Environment.GetEnvironmentVariable("PYTHON_VERSION");
+
         if (string.IsNullOrEmpty(condaEnv))
         {
-            if (OperatingSystem.IsWindows())
-                condaEnv = Environment.GetEnvironmentVariable("LOCALAPPDATA") ?? "";
-            condaEnv = Path.Join(condaEnv, "anaconda3");
-            if (!Directory.Exists(condaEnv))
-            {
-                condaEnv = condaEnv.Replace("anaconda3", "miniconda3");
+            string? basePath = null;
+            if (OperatingSystem.IsWindows()) {
+                basePath = Environment.GetEnvironmentVariable("LOCALAPPDATA");
             }
+            else{
+                basePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);;
+            }
+
+            if (basePath is not null)
+            {
+                condaEnv = new[] { "anaconda3", "miniconda3" }
+                    .Select(condaName => Path.Join(basePath, condaName))
+                    .FirstOrDefault(Directory.Exists) ?? condaEnv;
+            }
+
         }
+
         var condaBinPath = OperatingSystem.IsWindows() ? Path.Join(condaEnv, "Scripts", "conda.exe") : Path.Join(condaEnv, "bin", "conda");
         var environmentSpecPath = Path.Join(Environment.CurrentDirectory, "python", "environment.yml");
         app = Host.CreateDefaultBuilder()


### PR DESCRIPTION
This PR changes `CondaTestBase.cs` to look for the conda folder in the home directory instead of the working directory.

This change makes these tests runnable on my OSX machine.