### PR TITLE
Add missing `System.Threading.Tasks` import in generated code

### DIFF
--- a/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
+++ b/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
@@ -75,6 +75,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
             using System.Collections.Generic;
             using System.Diagnostics;
             using System.Reflection.Metadata;
+            using System.Threading.Tasks;
 
             using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Integration.Tests/ArgsTests.cs
+++ b/src/Integration.Tests/ArgsTests.cs
@@ -1,4 +1,5 @@
 using CSnakes.Runtime.Python;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Integration.Tests;

--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -1,3 +1,4 @@
+using System;
 using CSnakes.Runtime.Python;
 using Xunit;
 

--- a/src/Integration.Tests/CoroutineTests.cs
+++ b/src/Integration.Tests/CoroutineTests.cs
@@ -1,5 +1,7 @@
 using CSnakes.Runtime.Python;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Integration.Tests;
 public class CoroutineTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)

--- a/src/Integration.Tests/DictsTests.cs
+++ b/src/Integration.Tests/DictsTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Integration.Tests;
 public class TestDicts(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {

--- a/src/Integration.Tests/ExceptionTests.cs
+++ b/src/Integration.Tests/ExceptionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using CSnakes.Runtime.Python;
 
 namespace Integration.Tests;

--- a/src/Integration.Tests/FalseReturns.cs
+++ b/src/Integration.Tests/FalseReturns.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Integration.Tests;
 
 public class FalseReturns(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)

--- a/src/Integration.Tests/GeneratorTests.cs
+++ b/src/Integration.Tests/GeneratorTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Integration.Tests;
 public class GeneratorTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
 {

--- a/src/Integration.Tests/Integration.Tests.csproj
+++ b/src/Integration.Tests/Integration.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <ImplicitUsings>disable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>

--- a/src/Integration.Tests/IntegrationTestBase.cs
+++ b/src/Integration.Tests/IntegrationTestBase.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/Integration.Tests/ReloadTests.cs
+++ b/src/Integration.Tests/ReloadTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+
 namespace Integration.Tests;
 
 public class ReloadTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)

--- a/src/Integration.Tests/TupleTests.cs
+++ b/src/Integration.Tests/TupleTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Integration.Tests;
 
 public class TupleTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)


### PR DESCRIPTION
This PR fixes #408.

This is now validated through the integration tests where implicit usings is disabled. This also means that imports that were implicitly present previously had to be added explicitly to test project files where necessary.