### PR TITLE
Fix `PyObject.As` for `int` on LP64 & LLP64

### DIFF
--- a/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
@@ -19,7 +19,8 @@ public class IntConverterTest : ConverterTestBase
     [InlineData(int.MinValue - 1L)]
     public void TestOverflow(long input)
     {
-        void Act() => _ = PyObject.From(input).As<int>();
+        using var n = PyObject.From(input);
+        void Act() => _ = n.As<int>();
         _ = Assert.Throws<OverflowException>(Act);
     }
 }

--- a/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
@@ -1,0 +1,25 @@
+using CSnakes.Runtime.Python;
+
+namespace CSnakes.Runtime.Tests.Converter;
+
+public class IntConverterTest : ConverterTestBase
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(42)]
+    [InlineData(-42)]
+    [InlineData(int.MaxValue)]
+    [InlineData(int.MinValue)]
+    public void TestIntBidirectional(int input) => RunTest(input);
+
+    [Theory]
+    [InlineData(int.MaxValue + 1L)]
+    [InlineData(int.MinValue - 1L)]
+    public void TestOverflow(long input)
+    {
+        void Act() => _ = PyObject.From(input).As<int>();
+        _ = Assert.Throws<OverflowException>(Act);
+    }
+}

--- a/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
@@ -15,6 +15,15 @@ public class IntConverterTest : ConverterTestBase
     public void TestIntBidirectional(int input) => RunTest(input);
 
     [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void TestSignedIntFidelity(int input)
+    {
+        using var obj = PyObject.From(input);
+        Assert.Equal(input, obj.As<long>());
+    }
+
+    [Theory]
     [InlineData(int.MaxValue + 1L)]
     [InlineData(int.MinValue - 1L)]
     public void TestOverflow(long input)

--- a/src/CSnakes.Runtime/CPython/Long.cs
+++ b/src/CSnakes.Runtime/CPython/Long.cs
@@ -31,24 +31,6 @@ internal unsafe partial class CPythonAPI
     [LibraryImport(PythonLibraryName, EntryPoint = "PyLong_AsLongLong")]
     private static partial long PyLong_AsLongLong_(PyObject p);
 
-    /// <summary>
-    /// Calls PyLong_AsLong and throws a Python Exception if an error occurs.
-    /// </summary>
-    /// <param name="p"></param>
-    /// <returns></returns>
-    internal static long PyLong_AsLong(PyObject p)
-    {
-        long result = PyLong_AsLong_(p);
-        if (result == -1 && PyErr_Occurred())
-        {
-            throw PyObject.ThrowPythonExceptionAsClrException("Error converting Python object to int, check that the object was a Python int or that the value wasn't too large. See InnerException for details.");
-        }
-        return result;
-    }
-
-    [LibraryImport(PythonLibraryName, EntryPoint = "PyLong_AsLong")]
-    private static partial int PyLong_AsLong_(PyObject p);
-
     internal static bool IsPyLong(PyObject p)
     {
         return PyObject_IsInstance(p, PyLongType);

--- a/src/CSnakes.Runtime/CPython/Long.cs
+++ b/src/CSnakes.Runtime/CPython/Long.cs
@@ -8,7 +8,7 @@ internal unsafe partial class CPythonAPI
     private static nint PyLongType = IntPtr.Zero;
 
     [LibraryImport(PythonLibraryName)]
-    internal static partial nint PyLong_FromLong(int v);
+    internal static partial nint PyLong_FromLong(CLong v);
 
     [LibraryImport(PythonLibraryName)]
     internal static partial nint PyLong_FromLongLong(long v);

--- a/src/CSnakes.Runtime/Python/Interns/ImmortalSmallInteger.cs
+++ b/src/CSnakes.Runtime/Python/Interns/ImmortalSmallInteger.cs
@@ -7,6 +7,6 @@ internal class ImmortalSmallInteger(int value) : ImmortalPyObject(GetSmallIntHan
     private static nint GetSmallIntHandle(int value)
     {
         using (GIL.Acquire())
-            return CPythonAPI.PyLong_FromLong(value);
+            return CPythonAPI.PyLong_FromLong(new(value));
     }
 }

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -461,7 +461,7 @@ public partial class PyObject : SafeHandle, ICloneable
             {
                 var t when t == typeof(PyObject) => Clone(),
                 var t when t == typeof(bool) => CPythonAPI.IsPyTrue(this),
-                var t when t == typeof(int) => CPythonAPI.PyLong_AsLong(this),
+                var t when t == typeof(int) => checked((int)CPythonAPI.PyLong_AsLongLong(this)),
                 var t when t == typeof(long) => CPythonAPI.PyLong_AsLongLong(this),
                 var t when t == typeof(double) => CPythonAPI.PyFloat_AsDouble(this),
                 var t when t == typeof(float) => (float)CPythonAPI.PyFloat_AsDouble(this),

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -490,7 +490,7 @@ public partial class PyObject : SafeHandle, ICloneable
                 int i when i == 0 => Zero,
                 int i when i == 1 => One,
                 int i when i == -1 => NegativeOne,
-                int i => Create(CPythonAPI.PyLong_FromLong(i)),
+                int i => Create(CPythonAPI.PyLong_FromLong(new(i))),
                 long l => Create(CPythonAPI.PyLong_FromLongLong(l)),
                 double d => Create(CPythonAPI.PyFloat_FromDouble(d)),
                 float f => Create(CPythonAPI.PyFloat_FromDouble((double)f)),


### PR DESCRIPTION
`PyObject.As` for `int`/`Int32` ends up calling [`PyLong_AsLong`](https://docs.python.org/3/c-api/long.html#c.PyLong_AsLong), which returns a `long`, but a `long` has different widths on different 64-bit platforms. For example, Windows uses the LLP64 data model where a `long` is 32 bits wide and Linux uses LP64 where a `long` is 64 bits wide. This PR fixes the problem by using [`PyLong_AsLongLong`](https://docs.python.org/3/c-api/long.html#c.PyLong_AsLongLong) instead since it returns `long long` and that's consistently 64 bits wide across LLP64 and LP64 data models. On the .NET side, `long long` pops up as `Int64`, which is then converted to `int`/`Int32` with an overflow check. This change makes the behaviour consistent.

This fix also indirectly addresses another (more surprising) problem. When an `int` is sent to Python and then converted back, you get an `InvalidCastException` with the message:

> Unable to cast object of type 'System.Int64' to type 'System.Int32'.
