### PR TITLE
🚧 Rewrite `PyObject.As<>` to compile-time imports via interception

### DIFF
--- a/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj
+++ b/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj
@@ -30,6 +30,7 @@
       System.Diagnostics.CodeAnalysis.NotNullAttribute;
       System.Diagnostics.CodeAnalysis.NotNullWhenAttribute;
       System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute;
+      System.Runtime.CompilerServices.IsExternalInit;
     </PolySharpIncludeGeneratedTypes>
   </PropertyGroup>
 

--- a/src/CSnakes.SourceGeneration/SourceCodeLocation.cs
+++ b/src/CSnakes.SourceGeneration/SourceCodeLocation.cs
@@ -1,0 +1,12 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace CSnakes.SourceGeneration;
+
+public readonly record struct SourceCodeLocation(string FilePath, TextSpan TextSpan, LinePositionSpan LineSpan)
+{
+    public static SourceCodeLocation? CreateFrom(Location location) =>
+        location is { SourceTree.FilePath: var filePath } someLocation
+            ? new SourceCodeLocation(filePath, someLocation.SourceSpan, someLocation.GetLineSpan().Span)
+            : null;
+}

--- a/src/CSnakes.SourceGeneration/TypeInfo.cs
+++ b/src/CSnakes.SourceGeneration/TypeInfo.cs
@@ -1,0 +1,44 @@
+namespace CSnakes;
+public abstract record TypeInfo
+{
+    public static readonly TypeInfo Boolean = new BooleanTypeInfo();
+    public static readonly TypeInfo Int64 = new Int64TypeInfo();
+    public static readonly TypeInfo Double = new DoubleTypeInfo();
+    public static readonly TypeInfo String = new StringTypeInfo();
+    public static readonly TypeInfo ByteArray = new ByteArrayTypeInfo();
+
+    public abstract string GetReturnTypeSyntax();
+    public abstract string GetImporterTypeSyntax();
+
+    private abstract record StaticTypeInfo(string ReturnType, string ImporterType) : TypeInfo
+    {
+        public override string GetReturnTypeSyntax() => ReturnType;
+        public override string GetImporterTypeSyntax() => ImporterType;
+    }
+
+    private const string PyObjectImporters = "global::CSnakes.Runtime.Python.PyObjectImporters";
+
+    private sealed record BooleanTypeInfo() : StaticTypeInfo("bool", $"{PyObjectImporters}.Boolean");
+    private sealed record Int64TypeInfo() : StaticTypeInfo("long", $"{PyObjectImporters}.Int64");
+    private sealed record DoubleTypeInfo() : StaticTypeInfo("double", $"{PyObjectImporters}.Double");
+    private sealed record StringTypeInfo() : StaticTypeInfo("string", $"{PyObjectImporters}.String");
+    private sealed record ByteArrayTypeInfo() : StaticTypeInfo("byte[]", $"{PyObjectImporters}.ByteArray");
+}
+
+public sealed record ListTypeInfo(TypeInfo ItemType) : TypeInfo
+{
+    public override string GetReturnTypeSyntax() =>
+        $"global::System.Collections.Generic.IReadOnlyList<{ItemType.GetReturnTypeSyntax()}>";
+
+    public override string GetImporterTypeSyntax() =>
+        $"global::CSnakes.Runtime.Python.PyObjectImporters.List<{ItemType.GetReturnTypeSyntax()}, {ItemType.GetImporterTypeSyntax()}>";
+}
+
+public sealed record DictionaryTypeInfo(TypeInfo KeyType, TypeInfo ValueType) : TypeInfo
+{
+    public override string GetReturnTypeSyntax() =>
+        $"global::System.Collections.Generic.IReadOnlyDictionary<{KeyType.GetReturnTypeSyntax()}, {ValueType.GetReturnTypeSyntax()}>";
+
+    public override string GetImporterTypeSyntax() =>
+        $"global::CSnakes.Runtime.Python.PyObjectImporters.Dictionary<{KeyType.GetReturnTypeSyntax()}, {ValueType.GetReturnTypeSyntax()}, {KeyType.GetImporterTypeSyntax()}, {ValueType.GetImporterTypeSyntax()}>";
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.3.0" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.8" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="SharpCompress" Version="0.38.0" />

--- a/src/Integration.Tests/ConversionTests.cs
+++ b/src/Integration.Tests/ConversionTests.cs
@@ -1,0 +1,69 @@
+using CSnakes.Runtime.Python;
+using System.Collections.Generic;
+
+namespace Integration.Tests;
+public class ConversionTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
+{
+    [Fact]
+    public void BooleanIsIntercepted()
+    {
+        Assert.True(PyObject.True.As<bool>());
+        Assert.False(PyObject.False.As<bool>());
+    }
+
+    [Fact]
+    public void Int64IsIntercepted()
+    {
+        const long value = 42;
+        var result = PyObject.From(value).As<long>();
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void DoubleIsIntercepted()
+    {
+        const double value = 42.0;
+        var result = PyObject.From(value).As<double>();
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void StringIsIntercepted()
+    {
+        const string value = "foobar";
+        var result = PyObject.From(value).As<string>();
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void ByteArrayIsIntercepted()
+    {
+        byte[] value = [1, 2, 3, 4];
+        var result = PyObject.From(value).As<byte[]>();
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void ListIsIntercepted()
+    {
+        var value = new[] { "foo", "bar", "baz" };
+        var result = PyObject.From(value).As<IReadOnlyList<string>>();
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void NestedListIsIntercepted()
+    {
+        var value = new string[][] { ["foo", "bar", "baz"], ["FOO", "BAR", "BAZ"] };
+        var result = PyObject.From(value).As<IReadOnlyList<IReadOnlyList<string>>>();
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void DictionaryIsIntercepted()
+    {
+        var value = new Dictionary<long, string> { [1] = "foo", [2] = "bar", [3] = "baz" };
+        var result = PyObject.From(value).As<IReadOnlyDictionary<long, string>>();
+        Assert.Equal(value, result);
+    }
+}

--- a/src/Integration.Tests/Integration.Tests.csproj
+++ b/src/Integration.Tests/Integration.Tests.csproj
@@ -5,7 +5,12 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);CSnakes.Runtime.Python.Generated</InterceptorsNamespaces>
   </PropertyGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />


### PR DESCRIPTION
This is a draft PR to summon early feedback on an idea. It builds on top of (experimental) abstractions, types and plumbing introduced in PR #413.

This PR enhances the source generator to [intercept](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12#interceptors) `PyObject.As<>` invocations and translate them to `PyObject.ImportAs<,>` invocations such that there's no chance of inducing reflection or dynamic code generation. It enables code to be written as before, but still compile a version that's friendly for Native AOT scenarios.

The implementation is a bit rough and doesn't cover all cases, but it covers sufficient ones to demonstrate the overall concept and benefits.

If the source generator sees a call as follows:

```c#
var n = pyObject.As<long>();
```

then it will intercept and redirect it to a generated method that will use compile-time, statically-bound, conversion:

```
var n = pyObject.ImportAs<long, PyObjectImporters.Int64>();
```

In effect, it's as if the user wrote the above code. The source generator only generates a single method for all call sites that would be intercepted for a given `T` in `PyObject.As<T>`.

What's more, the source generator (or an analyzer) could flag any unsupported cases (scalars, lists & dictionaries with any level of nesting of such), instead of throwing at run-time. This isn't done right now in this initial prototype of the idea.

Below is the code generated for the tests in `src/Integration.Tests/ConversionTests.cs` (note multiple interception locations per method):

```c#
//------------------------------------------------------------------------------
// <auto-generated>
//     This code was generated by a tool.
//
//     Changes to this file may cause incorrect behavior and will be lost if
//     the code is regenerated.
// </auto-generated>
//------------------------------------------------------------------------------

#nullable enable

namespace System.Runtime.CompilerServices
{
    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
    file sealed class InterceptsLocationAttribute : global::System.Attribute
    {
        public InterceptsLocationAttribute(int version, string data) { }
    }
}

#pragma warning disable PRTEXP001

namespace CSnakes.Runtime.Python.Generated
{
    file static class Interceptions
    {
        // ExceptionTests.cs:(23,44)-(23,52)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "zij86GqSppAI1VgR3FEklhEFAABFeGNlcHRpb25UZXN0cy5jcw==")]
        // ExceptionTests.cs:(24,44)-(24,52)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "zij86GqSppAI1VgR3FEklksFAABFeGNlcHRpb25UZXN0cy5jcw==")]
        // ConversionTests.cs:(17,42)-(17,50)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZeu0BAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static long As1(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>();

        // ConversionTests.cs:(9,34)-(9,42)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZeiEBAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        // ConversionTests.cs:(10,36)-(10,44)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZelMBAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static bool As2(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<bool, global::CSnakes.Runtime.Python.PyObjectImporters.Boolean>();

        // ConversionTests.cs:(25,42)-(25,52)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZerECAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static double As3(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<double, global::CSnakes.Runtime.Python.PyObjectImporters.Double>();

        // ConversionTests.cs:(33,42)-(33,52)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZensDAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static string As4(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();

        // ConversionTests.cs:(41,42)-(41,52)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZekYEAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static byte[] As5(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<byte[], global::CSnakes.Runtime.Python.PyObjectImporters.ByteArray>();

        // ConversionTests.cs:(49,42)-(49,67)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZehoFAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static global::System.Collections.Generic.IReadOnlyList<string> As6(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<global::System.Collections.Generic.IReadOnlyList<string>, global::CSnakes.Runtime.Python.PyObjectImporters.List<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>>();

        // ConversionTests.cs:(57,42)-(57,82)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZeiUGAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<string>> As7(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.IReadOnlyList<string>>, global::CSnakes.Runtime.Python.PyObjectImporters.List<global::System.Collections.Generic.IReadOnlyList<string>, global::CSnakes.Runtime.Python.PyObjectImporters.List<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>>>();

        // ConversionTests.cs:(65,42)-(65,79)
        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "Qu8j6AC6XDw8KH5o6hwZekYHAABDb252ZXJzaW9uVGVzdHMuY3M=")]
        public static global::System.Collections.Generic.IReadOnlyDictionary<long, string> As8(this global::CSnakes.Runtime.Python.PyObject obj) =>
            obj.ImportAs<global::System.Collections.Generic.IReadOnlyDictionary<long, string>, global::CSnakes.Runtime.Python.PyObjectImporters.Dictionary<long, string, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.String>>();
    }
}
```
