### PR TITLE
Return immortals from `PyObject.From` for `long` + `BigInteger`

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/ImmortalTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/ImmortalTests.cs
@@ -1,60 +1,93 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class ImmortalTests : RuntimeTestBase
+
+public interface IImmortalFromTestCasesContainer<T>
 {
+    static abstract TheoryData<T> TestCases { get; }
+}
+
+public abstract class ImmortalTestsBase<T, TTestCases>(string repr) : RuntimeTestBase
+    where TTestCases : IImmortalFromTestCasesContainer<T>
+{
+    protected abstract PyObject Subject { get; }
+
     [Fact]
-    public void TestZero()
+    public void TestString()
     {
-        Assert.Equal("0", PyObject.Zero.ToString());
-        Assert.Equal("0", PyObject.Zero.GetRepr());
-        Assert.False(PyObject.Zero.IsNone());
-        Assert.Equal(PyObject.Zero, PyObject.Zero.Clone());
-        using var zero = PyObject.From(0);
-        Assert.Equal(PyObject.Zero, zero);
+        Assert.Equal(repr, Subject.ToString());
     }
 
     [Fact]
-    public void TestNegativeOne()
+    public void TestRepr()
     {
-        Assert.Equal("-1", PyObject.NegativeOne.ToString());
-        Assert.Equal("-1", PyObject.NegativeOne.GetRepr());
-        Assert.False(PyObject.NegativeOne.IsNone());
-        Assert.Equal(PyObject.NegativeOne, PyObject.NegativeOne.Clone());
-        using var negativeOne = PyObject.From(-1);
-        Assert.Equal(PyObject.NegativeOne, negativeOne);
+        Assert.Equal(repr, Subject.GetRepr());
     }
 
     [Fact]
-    public void TestOne()
+    public void TestIsNotNone()
     {
-        Assert.Equal("1", PyObject.One.ToString());
-        Assert.Equal("1", PyObject.One.GetRepr());
-        Assert.False(PyObject.One.IsNone());
-        Assert.Equal(PyObject.One, PyObject.One.Clone());
-        using var one = PyObject.From(1);
-        Assert.Equal(PyObject.One, one);
+        Assert.False(Subject.IsNone());
     }
 
     [Fact]
-    public void TestFalse()
+    public void TestCloneReturnsSameInstance()
     {
-        Assert.Equal("False", PyObject.False.ToString());
-        Assert.Equal("False", PyObject.False.GetRepr());
-        Assert.False(PyObject.False.IsNone());
-        Assert.Equal(PyObject.False, PyObject.False.Clone());
-        using var pyFalse = PyObject.From(false);
-        Assert.Equal(PyObject.False, pyFalse);
+        Assert.Same(Subject, Subject.Clone());
     }
 
-    [Fact]
-    public void TestTrue()
+    public static TheoryData<T> TestCases => TTestCases.TestCases;
+
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void TestFrom(T input)
     {
-        Assert.Equal("True", PyObject.True.ToString());
-        Assert.Equal("True", PyObject.True.GetRepr());
-        Assert.False(PyObject.True.IsNone());
-        Assert.Equal(PyObject.True, PyObject.True.Clone());
-        using var pyTrue = PyObject.From(true);
-        Assert.Equal(PyObject.True, pyTrue);
+        using var value = PyObject.From(input);
+        Assert.Same(Subject, value);
     }
+}
+
+public class ImmortalZeroTests() :
+    ImmortalTestsBase<object, ImmortalZeroTests>("0"),
+    IImmortalFromTestCasesContainer<object>
+{
+    protected override PyObject Subject => PyObject.Zero;
+
+    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 0, 0L };
+}
+
+public class ImmortalOneTests() :
+    ImmortalTestsBase<object, ImmortalOneTests>("1"),
+    IImmortalFromTestCasesContainer<object>
+{
+    protected override PyObject Subject => PyObject.One;
+
+    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 1, 1L };
+}
+
+public class ImmortalNegativeOneTests() :
+    ImmortalTestsBase<object, ImmortalNegativeOneTests>("-1"),
+    IImmortalFromTestCasesContainer<object>
+{
+    protected override PyObject Subject => PyObject.NegativeOne;
+
+    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { -1, -1L };
+}
+
+public class ImmortalTrueTests() :
+    ImmortalTestsBase<bool, ImmortalTrueTests>("True"),
+    IImmortalFromTestCasesContainer<bool>
+{
+    protected override PyObject Subject => PyObject.True;
+
+    static TheoryData<bool> IImmortalFromTestCasesContainer<bool>.TestCases => new() { true };
+}
+
+public class ImmortalFalseTests() :
+    ImmortalTestsBase<bool, ImmortalFalseTests>("False"),
+    IImmortalFromTestCasesContainer<bool>
+{
+    protected override PyObject Subject => PyObject.False;
+
+    static TheoryData<bool> IImmortalFromTestCasesContainer<bool>.TestCases => new() { false };
 }

--- a/src/CSnakes.Runtime.Tests/Python/ImmortalTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/ImmortalTests.cs
@@ -1,4 +1,5 @@
 using CSnakes.Runtime.Python;
+using System.Numerics;
 
 namespace CSnakes.Runtime.Tests.Python;
 
@@ -53,7 +54,7 @@ public class ImmortalZeroTests() :
 {
     protected override PyObject Subject => PyObject.Zero;
 
-    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 0, 0L };
+    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 0, 0L, new BigInteger(0) };
 }
 
 public class ImmortalOneTests() :
@@ -62,7 +63,7 @@ public class ImmortalOneTests() :
 {
     protected override PyObject Subject => PyObject.One;
 
-    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 1, 1L };
+    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 1, 1L, new BigInteger(1) };
 }
 
 public class ImmortalNegativeOneTests() :
@@ -71,7 +72,7 @@ public class ImmortalNegativeOneTests() :
 {
     protected override PyObject Subject => PyObject.NegativeOne;
 
-    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { -1, -1L };
+    static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { -1, -1L, new BigInteger(-1) };
 }
 
 public class ImmortalTrueTests() :

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -483,9 +483,10 @@ public partial class PyObject : SafeHandle, ICloneable
             case null: return None;
             case true: return True;
             case false: return False;
-            case 0 or 0L: return Zero;
-            case 1 or 1L: return One;
-            case -1 or -1L: return NegativeOne;
+            case 0 or 0L or BigInteger { IsZero: true }: return Zero;
+            case 1 or 1L or BigInteger { IsOne: true }: return One;
+            case -1 or -1L:
+            case BigInteger n when n == -1: return NegativeOne;
             default:
             {
                 using (GIL.Acquire())

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -494,7 +494,7 @@ public partial class PyObject : SafeHandle, ICloneable
                     return value switch
                     {
                         ICloneable pyObject => pyObject.Clone(),
-                        int i => Create(CPythonAPI.PyLong_FromLong(i)),
+                        int i => Create(CPythonAPI.PyLong_FromLong(new(i))),
                         long l => Create(CPythonAPI.PyLong_FromLongLong(l)),
                         double d => Create(CPythonAPI.PyFloat_FromDouble(d)),
                         float f => Create(CPythonAPI.PyFloat_FromDouble((double)f)),

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -478,31 +478,36 @@ public partial class PyObject : SafeHandle, ICloneable
 
     public static PyObject From<T>(T value)
     {
-        using (GIL.Acquire())
+        switch (value)
         {
-            if (value is null)
-                return None;
-
-            return value switch
+            case null: return None;
+            case true: return True;
+            case false: return False;
+            case 0 or 0L: return Zero;
+            case 1 or 1L: return One;
+            case -1 or -1L: return NegativeOne;
+            default:
             {
-                ICloneable pyObject => pyObject.Clone(),
-                bool b => b ? True : False,
-                int i when i == 0 => Zero,
-                int i when i == 1 => One,
-                int i when i == -1 => NegativeOne,
-                int i => Create(CPythonAPI.PyLong_FromLong(i)),
-                long l => Create(CPythonAPI.PyLong_FromLongLong(l)),
-                double d => Create(CPythonAPI.PyFloat_FromDouble(d)),
-                float f => Create(CPythonAPI.PyFloat_FromDouble((double)f)),
-                string s => Create(CPythonAPI.AsPyUnicodeObject(s)),
-                byte[] bytes => PyObject.Create(CPythonAPI.PyBytes_FromByteSpan(bytes.AsSpan())),
-                IDictionary dictionary => PyObjectTypeConverter.ConvertFromDictionary(dictionary),
-                ITuple t => PyObjectTypeConverter.ConvertFromTuple(t),
-                ICollection l => PyObjectTypeConverter.ConvertFromList(l),
-                IEnumerable e => PyObjectTypeConverter.ConvertFromList(e),
-                BigInteger b => PyObjectTypeConverter.ConvertFromBigInteger(b),
-                _ => throw new InvalidCastException($"Cannot convert {value} to PyObject"),
-            };
+                using (GIL.Acquire())
+                {
+                    return value switch
+                    {
+                        ICloneable pyObject => pyObject.Clone(),
+                        int i => Create(CPythonAPI.PyLong_FromLong(i)),
+                        long l => Create(CPythonAPI.PyLong_FromLongLong(l)),
+                        double d => Create(CPythonAPI.PyFloat_FromDouble(d)),
+                        float f => Create(CPythonAPI.PyFloat_FromDouble((double)f)),
+                        string s => Create(CPythonAPI.AsPyUnicodeObject(s)),
+                        byte[] bytes => PyObject.Create(CPythonAPI.PyBytes_FromByteSpan(bytes.AsSpan())),
+                        IDictionary dictionary => PyObjectTypeConverter.ConvertFromDictionary(dictionary),
+                        ITuple t => PyObjectTypeConverter.ConvertFromTuple(t),
+                        ICollection l => PyObjectTypeConverter.ConvertFromList(l),
+                        IEnumerable e => PyObjectTypeConverter.ConvertFromList(e),
+                        BigInteger b => PyObjectTypeConverter.ConvertFromBigInteger(b),
+                        _ => throw new InvalidCastException($"Cannot convert {value} to PyObject"),
+                    };
+                }
+            }
         }
     }
 


### PR DESCRIPTION
`PyObject.From` would return immortals for 0, 1 and -1 as long as they were `int` values. It would allocate a new `PyObject` if 0, 1 and -1 were typed as `long` or `BigInteger`. This PR extends `PyObject.From` to also consider `long` and `BigInteger` values. Tests have been extended for both cases (refactored to break out each case and consolidate all duplication). At the same time, all immortals ard considered for returning outside of taking the GIL, which I believe is safe. `PyObject.From` takes the GIL when it's exhausted those optimisations or immortal cases.

---
PS I believe some of the tests are failing on Linux ARM and macOS due to the problem that #415 fixes.