### PR TITLE
Make generator iterator disposal idempotent

### DIFF
--- a/src/CSnakes.Runtime/Python/GeneratorIterator.cs
+++ b/src/CSnakes.Runtime/Python/GeneratorIterator.cs
@@ -41,7 +41,6 @@ public class GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnIm
 
     public void Dispose()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
         Dispose(true);
         GC.SuppressFinalize(this);
     }

--- a/src/Integration.Tests/GeneratorTests.cs
+++ b/src/Integration.Tests/GeneratorTests.cs
@@ -26,4 +26,12 @@ public class GeneratorTests(PythonEnvironmentFixture fixture) : IntegrationTestB
         var generator = mod.TestNormalGenerator();
         Assert.Equal<string[]>(["one", "two"], generator.ToArray());
     }
+
+    [Fact]
+    public void TestIdempotentDisposal()
+    {
+        var mod = Env.TestGenerators();
+        using var generator = mod.TestNormalGenerator();
+        generator.Dispose(); // should be harmless
+    }
 }


### PR DESCRIPTION
Per the [**Remarks** section](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?view=net-9.0#remarks) of the [`IDisposable.Dispose`](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?view=net-9.0) documentation, an object disposal should be idempotent:

> If an object's [`Dispose`](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?view=net-9.0) method is called more than once, the object must ignore all calls after the first one.

However, `GeneratorIterator.Dispose` throws `ObjectDisposedException` if the object was previously disposed. This PR removes the check and throw so that disposal become idempotent.
