### PR TITLE
Fix `CancellationToken` parameters to be non-nullable

### DIFF
--- a/docs/async_support.md
+++ b/docs/async_support.md
@@ -49,4 +49,4 @@ See [Free-Threading Mode](advanced.md#free-threading-mode) for more information.
 
 ## Cancellation Tokens
 
-Coroutine objects have an `AsTask<TYield>(CancellationToken?)` API, but the source generator does not yet propagate the cancellation token argument to the generated interfaces, if you want to use cancellation tokens, please raise an issue with your use case.
+Coroutine objects have an `AsTask<TYield>(CancellationToken)` API, but the source generator does not yet propagate the cancellation token argument to the generated interfaces, if you want to use cancellation tokens, please raise an issue with your use case.

--- a/src/CSnakes.Runtime/Python/Coroutine.cs
+++ b/src/CSnakes.Runtime/Python/Coroutine.cs
@@ -18,7 +18,7 @@ public class Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(
     public TYield Current => current;
     public TReturn Return => @return;
 
-    public Task<TYield?> AsTask(CancellationToken? cancellationToken = null)
+    public Task<TYield?> AsTask(CancellationToken cancellationToken = default)
     {
         return Task.Run(
             () =>

--- a/src/CSnakes.Runtime/Python/ICoroutine.cs
+++ b/src/CSnakes.Runtime/Python/ICoroutine.cs
@@ -2,7 +2,7 @@ namespace CSnakes.Runtime.Python;
 
 public interface ICoroutine<TYield, TSend, TReturn> : ICoroutine
 {
-    public Task<TYield?> AsTask(CancellationToken? cancellationToken = null);
+    public Task<TYield?> AsTask(CancellationToken cancellationToken = default);
 }
 
 public interface ICoroutine { }


### PR DESCRIPTION
This PR fixes `CancellationToken` parameters in member related to coroutines to be non-nullable, which is more standard. The documentation for [`CancellationToken.None`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.none?view=net-9.0) has more on this:

> The cancellation token returned by this property cannot be canceled; that is, its [`CanBeCanceled`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken.canbecanceled?view=net-9.0) property is `false`.
>
> You can also use the C# [`default(CancellationToken)`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/default) statement to create an empty cancellation token.
>
> Two empty cancellation tokens are always equal.

Making a `CancellationToken` nullable unnecessarily adds a third state, which is redundant with an empty one.