### PR TITLE
Make coroutine task result be just `TYield`

### DIFF
--- a/src/CSnakes.Runtime/Python/Coroutine.cs
+++ b/src/CSnakes.Runtime/Python/Coroutine.cs
@@ -18,7 +18,7 @@ public class Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(
     public TYield Current => current;
     public TReturn Return => @return;
 
-    public Task<TYield?> AsTask(CancellationToken? cancellationToken = null)
+    public Task<TYield> AsTask(CancellationToken? cancellationToken = null)
     {
         return Task.Run(
             () =>

--- a/src/CSnakes.Runtime/Python/ICoroutine.cs
+++ b/src/CSnakes.Runtime/Python/ICoroutine.cs
@@ -2,7 +2,7 @@ namespace CSnakes.Runtime.Python;
 
 public interface ICoroutine<TYield, TSend, TReturn> : ICoroutine
 {
-    public Task<TYield?> AsTask(CancellationToken? cancellationToken = null);
+    public Task<TYield> AsTask(CancellationToken? cancellationToken = null);
 }
 
 public interface ICoroutine { }


### PR DESCRIPTION
This PR takes care of the following warnings:

```
A:\CSnakes\main\src\Profile\obj\Debug\net8.0\CSnakes.SourceGeneration\CSnakes.PythonStaticGenerator\AsyncBenchmarks.py.cs(88,24): warning CS8619: Nullability of reference types in value of type 'Task<PyObject?>' doesn't match target type 'Task<PyObject>'.
A:\CSnakes\main\src\Integration.Tests\obj\Debug\net9.0\generated\CSnakes.SourceGeneration\CSnakes.PythonStaticGenerator\TestCoroutines.py.cs(122,24): warning CS8619: Nullability of reference types in value of type 'Task<PyObject?>' doesn't match target type 'Task<PyObject>'.
```

There's no need for `TYield` to have the nullability specifier `?`.
