### PR TITLE
Skip C# proxies for underscored functions

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Function.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Function.cs
@@ -108,7 +108,11 @@ public static partial class PythonParser
             }
         }
 
-        pythonSignatures = [.. functionDefinitions];
+        pythonSignatures = [..
+            from fd in functionDefinitions
+            where fd.Name is not ['_', ..]
+            select fd
+        ];
         errors = [.. currentErrors];
         return errors.Length == 0;
     }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -22,7 +22,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "c869d3a7ab525465cb794827044b4601"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "c9f266d12c416006de17b285369f898f"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {

--- a/src/Integration.Tests/python/test_basic.py
+++ b/src/Integration.Tests/python/test_basic.py
@@ -1,5 +1,8 @@
 from typing import Sequence
 
+def _test_private() -> None:
+    pass
+
 def test_int_float(a: int, b: float) -> float:
     return a + b
 


### PR DESCRIPTION
This PR skips code generation of C# proxies for Python functions whose name starts with an underscore (`_`). As per [PEP 8](https://peps.python.org/pep-0008/), these are conventionally considered _internal_:

> - `_single_leading_underscore`: weak “internal use” indicator. E.g. `from M import *` does not import objects whose names start with an underscore.
