### PR TITLE
Remove recognition `typing.Buffer` that never was

### DIFF
--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -5,7 +5,7 @@ The `IPyBuffer` interface is used to represent Python objects that support the B
 
 Since NumPy ndarrays also support the Buffer Protocol, you can use the `IPyBuffer` interface to efficiently read and write data from NumPy arrays.
 
-`typing.Buffer` (`collections.abc.Buffer`) was introduced in Python 3.12, but for older versions you can import `Buffer` from the `typing_extensions` package on PyPi. 
+`collections.abc.Buffer` was introduced in Python 3.12, but for older versions you can import `Buffer` from the `typing_extensions` package on PyPi.
 
 For example:
 

--- a/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
@@ -28,7 +28,7 @@ public static class TypeReflection
             ({ Name: "float" }, _) => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.DoubleKeyword)),
             ({ Name: "bool" }, _) => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.BoolKeyword)),
             ({ Name: "bytes" }, _) => SyntaxFactory.ParseTypeName("byte[]"),
-            ({ Name: "Buffer" or "typing.Buffer" or "collections.abc.Buffer" }, ConversionDirection.FromPython) => SyntaxFactory.ParseTypeName("IPyBuffer"),
+            ({ Name: "Buffer" or "collections.abc.Buffer" }, ConversionDirection.FromPython) => SyntaxFactory.ParseTypeName("IPyBuffer"),
             _ => SyntaxFactory.ParseTypeName("PyObject"),
         };
 

--- a/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
+++ b/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
@@ -40,7 +40,7 @@ internal static class ResultConversionCodeGenerator
             case { Name: "float" }: return Double;
             case { Name: "bool" }: return Boolean;
             case { Name: "bytes" }: return ByteArray;
-            case { Name: "Buffer" or "typing.Buffer" or "collections.abc.Buffer" }: return Buffer;
+            case { Name: "Buffer" or "collections.abc.Buffer" }: return Buffer;
 
             case { Name: "list" or "typing.List" or "List", Arguments: [var t] }:
             {


### PR DESCRIPTION
This PR is a follow-up to: https://github.com/tonybaloney/CSnakes/pull/413#discussion_r2053377528
