### PR TITLE
Make GIL acquisition a `ref struct`

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/GILTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/GILTests.cs
@@ -14,7 +14,6 @@ public class GILTests : RuntimeTestBase
     {
         using var gil = GIL.Acquire();
 
-        Assert.NotNull(gil);
         Assert.True(GIL.IsAcquired);
     }
 
@@ -52,7 +51,7 @@ public class GILTests : RuntimeTestBase
             using (var inner = GIL.Acquire())
             {
                 Assert.True(GIL.IsAcquired);
-                Assert.Same(outer, inner); // Should get the same instance
+                Assert.True(outer.Equals(inner)); // Should be the same lock
             }
 
             Assert.True(GIL.IsAcquired); // After inner disposal, GIL should still be held

--- a/src/CSnakes.Runtime/Python/GIL.cs
+++ b/src/CSnakes.Runtime/Python/GIL.cs
@@ -83,18 +83,18 @@ public static class GIL
         public int RecursionCount => recursionCount;
     }
 
-    public readonly ref struct AcquiredLock : IDisposable
+    public readonly ref struct Lock : IDisposable
     {
         private readonly PyGilState state;
 
-        internal AcquiredLock(PyGilState state) => this.state = state;
+        internal Lock(PyGilState state) => this.state = state;
 
         public void Dispose() => state.Dispose();
 
-        internal bool Equals(AcquiredLock other) => state == other.state;
+        internal bool Equals(Lock other) => state == other.state;
     }
 
-    public static AcquiredLock Acquire()
+    public static Lock Acquire()
     {
         if (currentState == null)
         {

--- a/src/CSnakes.Runtime/Python/GIL.cs
+++ b/src/CSnakes.Runtime/Python/GIL.cs
@@ -83,9 +83,7 @@ public static class GIL
         public int RecursionCount => recursionCount;
     }
 
-#pragma warning disable IDE0250 // Make struct 'readonly' (logically read-write)
-    public ref struct AcquiredLock : IDisposable
-#pragma warning restore IDE0250 // Make struct 'readonly'
+    public readonly ref struct AcquiredLock : IDisposable
     {
         private readonly PyGilState state;
 


### PR DESCRIPTION
This PR proposes to return the GIL acquisition as a `ref struct` called ~~`AcquiredLock`~~ `GIL.Lock`. The semantics are as before except the `ref struct` ensures that the lock cannot escape to the heap easily when state machines get formed indirectly in code using `async`/`await` and `yield`. Either way, it prevents the code from compiling if the code after a `yield` or `await` could resume on a different thread than on which the lock was acquired.

The following code was possible up to now:

```c#
static IEnumerable<int> Test()
{
    using (GIL.Acquire())
        yield return 42;
}

static async Task<int> TestAsync()
{
    using (GIL.Acquire())
        await Task.Yield();
    return 42;
}
```

but will produce error CS4007 after this PR:

    error CS4007: Instance of type 'CSnakes.Runtime.Python.GIL.Lock' cannot be preserved across 'await' or 'yield' boundary.

The fix would be to do as follows instead:

```c#
static IEnumerable<int> Test()
{
    using (GIL.Acquire())
    {
        // ...do something...
    }

    yield return 42;

    using (GIL.Acquire())
    {
        // ...do something more...
    }
}

static async Task<int> TestAsync()
{
    using (GIL.Acquire())
    {
        // ...do something...
    }

    await Task.Yield();

    using (GIL.Acquire())
    {
        // ...do something more...
        return 42;
    }

}
```
