### PR TITLE
Add `CancellationToken` parameter to generated async methods

### DIFF
--- a/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
+++ b/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
@@ -77,6 +77,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
             using System.Collections.Generic;
             using System.Diagnostics;
             using System.Reflection.Metadata;
+            using System.Threading;
             using System.Threading.Tasks;
 
             using Microsoft.Extensions.Logging;

--- a/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
@@ -22,6 +22,8 @@ public static class MethodReflection
 
         TypeSyntax returnSyntax;
         TypeSyntax? coroutineSyntax = null;
+        ParameterSyntax? cancellationTokenParameterSyntax = null;
+        const string cancellationTokenName = "cancellationToken";
 
         if (!function.IsAsync)
         {
@@ -36,7 +38,10 @@ public static class MethodReflection
         }
         else
         {
-            coroutineSyntax = TypeReflection.AsPredefinedType(returnPythonType, TypeReflection.ConversionDirection.FromPython);
+            cancellationTokenParameterSyntax =
+                Parameter(Identifier(cancellationTokenName))
+                    .WithType(IdentifierName("CancellationToken"))
+                    .WithDefault(EqualsValueClause(LiteralExpression(SyntaxKind.DefaultLiteralExpression)));
             returnSyntax = returnPythonType switch
             {
                 { Name: "Coroutine", Arguments: [{ Name: "None" }, _, _] } =>
@@ -146,18 +151,12 @@ public static class MethodReflection
                 if (returnSyntax is GenericNameSyntax rg)
                     parameterGenericArgs.Add(rg);
 
-                resultConversionStatements = ResultConversionCodeGenerator.GenerateCode(returnPythonType, "__result_pyObject", "__return");
+                resultConversionStatements =
+                    ResultConversionCodeGenerator.GenerateCode(returnPythonType,
+                                                               "__result_pyObject", "__return",
+                                                               cancellationTokenName);
 
-                returnExpression =
-                    ReturnStatement(
-                        returnSyntax is GenericNameSyntax { Identifier.Text: "Task" } && coroutineSyntax is not null
-                        ? InvocationExpression(
-                              MemberAccessExpression(
-                                  SyntaxKind.SimpleMemberAccessExpression,
-                                  IdentifierName("__return"),
-                                  IdentifierName("AsTask")),
-                              ArgumentList(SingletonSeparatedList(Argument(IdentifierName("cancellationToken")))))
-                        : IdentifierName("__return"));
+                returnExpression = ReturnStatement(IdentifierName("__return"));
                 break;
             }
         }
@@ -252,14 +251,8 @@ public static class MethodReflection
                     .Select((a) => a.cSharpParameter)
             );
 
-        if (coroutineSyntax is not null)
-        {
-            methodParameters =
-                methodParameters.Append(
-                    Parameter(Identifier("cancellationToken"))
-                        .WithType(IdentifierName("CancellationToken"))
-                        .WithDefault(EqualsValueClause(LiteralExpression(SyntaxKind.DefaultLiteralExpression))));
-        }
+        if (cancellationTokenParameterSyntax is { } someCancellationTokenParameterSyntax)
+            methodParameters = methodParameters.Append(someCancellationTokenParameterSyntax);
 
         var syntax = MethodDeclaration(
             returnSyntax,

--- a/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
@@ -21,7 +21,6 @@ public static class MethodReflection
         PythonTypeSpec returnPythonType = function.ReturnType;
 
         TypeSyntax returnSyntax;
-        TypeSyntax? coroutineSyntax = null;
         ParameterSyntax? cancellationTokenParameterSyntax = null;
         const string cancellationTokenName = "cancellationToken";
 

--- a/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
@@ -155,7 +155,8 @@ public static class MethodReflection
                               MemberAccessExpression(
                                   SyntaxKind.SimpleMemberAccessExpression,
                                   IdentifierName("__return"),
-                                  IdentifierName("AsTask")))
+                                  IdentifierName("AsTask")),
+                              ArgumentList(SingletonSeparatedList(Argument(IdentifierName("cancellationToken")))))
                         : IdentifierName("__return"));
                 break;
             }
@@ -250,6 +251,15 @@ public static class MethodReflection
                     .Where((a) => a.pythonParameter.ParameterType == PythonFunctionParameterType.DoubleStar)
                     .Select((a) => a.cSharpParameter)
             );
+
+        if (coroutineSyntax is not null)
+        {
+            methodParameters =
+                methodParameters.Append(
+                    Parameter(Identifier("cancellationToken"))
+                        .WithType(IdentifierName("CancellationToken"))
+                        .WithDefault(EqualsValueClause(LiteralExpression(SyntaxKind.DefaultLiteralExpression))));
+        }
 
         var syntax = MethodDeclaration(
             returnSyntax,

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -96,8 +96,8 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
-                return __return.AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                return __return;
             }
         }
 
@@ -108,8 +108,8 @@ public static class TestClassExtensions
                 logger.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_raises_exception");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_raises_exception;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
-                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
-                return __return.AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                return __return;
             }
         }
 
@@ -121,8 +121,8 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_returns_nothing;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<PyObject, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<PyObject, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
-                return __return.AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<PyObject, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<PyObject, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                return __return;
             }
         }
     }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "070712b6bff34f5e689b902a98fce79f"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "61c51b5413b819959bcfa362dfc8b9cf"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {
@@ -87,19 +88,20 @@ public static class TestClassExtensions
             module.Dispose();
         }
 
-        public Task<long> TestCoroutine()
+        public Task<long> TestCoroutine(double seconds = 0.1, CancellationToken cancellationToken = default)
         {
             using (GIL.Acquire())
             {
                 logger.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine;
-                using PyObject __result_pyObject = __underlyingPythonFunc.Call();
+                using PyObject seconds_pyObject = PyObject.From(seconds)!;
+                using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
                 var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
-                return __return.AsTask();
+                return __return.AsTask(cancellationToken);
             }
         }
 
-        public Task<long> TestCoroutineRaisesException()
+        public Task<long> TestCoroutineRaisesException(CancellationToken cancellationToken = default)
         {
             using (GIL.Acquire())
             {
@@ -107,19 +109,20 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_raises_exception;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
-                return __return.AsTask();
+                return __return.AsTask(cancellationToken);
             }
         }
 
-        public Task<PyObject> TestCoroutineReturnsNothing()
+        public Task<PyObject> TestCoroutineReturnsNothing(double seconds = 0.1, CancellationToken cancellationToken = default)
         {
             using (GIL.Acquire())
             {
                 logger.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_returns_nothing");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_returns_nothing;
-                using PyObject __result_pyObject = __underlyingPythonFunc.Call();
+                using PyObject seconds_pyObject = PyObject.From(seconds)!;
+                using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
                 var __return = __result_pyObject.BareImportAs<ICoroutine<PyObject, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<PyObject, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
-                return __return.AsTask();
+                return __return.AsTask(cancellationToken);
             }
         }
     }
@@ -133,10 +136,10 @@ public interface ITestClass : IReloadableModuleImport
     /// <summary>
     /// Invokes the Python function <c>test_coroutine</c>:
     /// <code><![CDATA[
-    /// async def test_coroutine() -> Coroutine[int, None, None]: ...
+    /// async def test_coroutine(seconds: float = 0.1) -> Coroutine[int, None, None]: ...
     /// ]]></code>
     /// </summary>
-    Task<long> TestCoroutine();
+    Task<long> TestCoroutine(double seconds = 0.1, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Invokes the Python function <c>test_coroutine_raises_exception</c>:
@@ -144,13 +147,13 @@ public interface ITestClass : IReloadableModuleImport
     /// async def test_coroutine_raises_exception() -> Coroutine[int, None, None]: ...
     /// ]]></code>
     /// </summary>
-    Task<long> TestCoroutineRaisesException();
+    Task<long> TestCoroutineRaisesException(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Invokes the Python function <c>test_coroutine_returns_nothing</c>:
     /// <code><![CDATA[
-    /// async def test_coroutine_returns_nothing() -> Coroutine[None, None, None]: ...
+    /// async def test_coroutine_returns_nothing(seconds: float = 0.1) -> Coroutine[None, None, None]: ...
     /// ]]></code>
     /// </summary>
-    Task<PyObject> TestCoroutineReturnsNothing();
+    Task<PyObject> TestCoroutineReturnsNothing(double seconds = 0.1, CancellationToken cancellationToken = default);
 }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;

--- a/src/Integration.Tests/CoroutineTests.cs
+++ b/src/Integration.Tests/CoroutineTests.cs
@@ -1,6 +1,7 @@
-using CSnakes.Runtime.Python;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Integration.Tests;
@@ -31,16 +32,30 @@ public class CoroutineTests(PythonEnvironmentFixture fixture) : IntegrationTestB
     public async Task MultipleCoroutineCallsIsParallel()
     {
         var mod = Env.TestCoroutines();
-        var tasks = new List<Task<PyObject>>();
-        for (int i = 0; i < 10; i++)
+        var tasks =
+            from _ in Enumerable.Range(0, 10)
+            select mod.TestCoroutine();
+        _ = await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task MultipleCoroutineCallsIsParallelThatGetCancelled()
+    {
+        var mod = Env.TestCoroutines();
+
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        var tasks =
+            from _ in Enumerable.Range(0, 10)
+            select mod.TestCoroutine(seconds: 5, cancellationTokenSource.Token);
+
+        foreach (var task in tasks)
         {
-            tasks.Add(mod.TestCoroutineReturnsNothing());
+            async Task Act() => await task.WaitAsync(TimeSpan.FromSeconds(10));
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(Act);
+            Assert.Equal(cancellationTokenSource.Token, ex.CancellationToken);
+            Assert.Equal(TaskStatus.Canceled, task.Status);
         }
-        // Check this takes less than 10 seconds
-        var start = Stopwatch.StartNew();
-        var r = await Task.WhenAll(tasks);
-        start.Stop();
-        Assert.True(start.ElapsedMilliseconds < 10000);
     }
 
     [Fact]

--- a/src/Integration.Tests/python/test_coroutines.py
+++ b/src/Integration.Tests/python/test_coroutines.py
@@ -2,8 +2,8 @@ from typing import Coroutine
 import asyncio
 
 
-async def test_coroutine() -> Coroutine[int, None, None]:
-    await asyncio.sleep(0.1)
+async def test_coroutine(seconds: float = 0.1) -> Coroutine[int, None, None]:
+    await asyncio.sleep(seconds)
     return 5
 
 
@@ -11,5 +11,5 @@ async def test_coroutine_raises_exception() -> Coroutine[int, None, None]:
     raise ValueError("This is a Python exception")
 
 
-async def test_coroutine_returns_nothing() -> Coroutine[None, None, None]:
-    await asyncio.sleep(1.0)
+async def test_coroutine_returns_nothing(seconds: float = 0.1) -> Coroutine[None, None, None]:
+    await asyncio.sleep(seconds)


### PR DESCRIPTION
This PR closes #353.

It adds a test to exercise the cancellation, which surfaced a bug in `Coroutine.AsTask` and is fixed by transforming a `CancelledError` from Python into the task being treated as cancelled on the .NET side. Otherwise the task would fail with a `PythonInvocationException` on being cancelled.

I've also gone ahead and removed special-casing of coroutine conversion to `Task` in `MethodReflection.FromMethod` (adding further to #377) so now it's done entirely within `CoroutineConversionGenerator`, which is just another (new) `IResultConversionCodeGenerator` implementation.