### PR TITLE
Fix `AsEnumerable` semantics

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/PyDictionaryTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyDictionaryTests.cs
@@ -37,6 +37,28 @@ public class PyDictionaryTests : RuntimeTestBase
     }
 
     [Fact]
+    public void TestKeysEnumeratorFunctionsDespiteEarlyDictionaryDisposal()
+    {
+        var testDict = new Dictionary<string, string>
+        {
+            ["Hello"] = "World?",
+            ["Foo"] = "Bar"
+        };
+        var pyDict = PyObject.From(testDict).As<IReadOnlyDictionary<string, string>>();
+
+        using var e = pyDict.Keys.GetEnumerator();
+        ((IDisposable)pyDict).Dispose();
+
+        Assert.True(e.MoveNext());
+        Assert.Equal("Hello", e.Current);
+
+        Assert.True(e.MoveNext());
+        Assert.Equal("Foo", e.Current);
+
+        Assert.False(e.MoveNext());
+    }
+
+    [Fact]
     public void TestValues()
     {
         var testDict = new Dictionary<string, string>()
@@ -50,6 +72,28 @@ public class PyDictionaryTests : RuntimeTestBase
         Assert.Equal(2, pyDict.Count);
         Assert.Contains("World?", pyDict.Values);
         Assert.Contains("Bar", pyDict.Values);
+    }
+
+    [Fact]
+    public void TestValuesEnumeratorFunctionsDespiteEarlyDictionaryDisposal()
+    {
+        var testDict = new Dictionary<string, string>
+        {
+            ["Hello"] = "World?",
+            ["Foo"] = "Bar"
+        };
+        var pyDict = PyObject.From(testDict).As<IReadOnlyDictionary<string, string>>();
+
+        using var e = pyDict.Values.GetEnumerator();
+        ((IDisposable)pyDict).Dispose();
+
+        Assert.True(e.MoveNext());
+        Assert.Equal("World?", e.Current);
+
+        Assert.True(e.MoveNext());
+        Assert.Equal("Bar", e.Current);
+
+        Assert.False(e.MoveNext());
     }
 
     [Fact]
@@ -98,5 +142,27 @@ public class PyDictionaryTests : RuntimeTestBase
         Assert.True(pyDict.TryGetValue("Foo", out value));
         Assert.Equal("Bar", value);
         Assert.False(pyDict.TryGetValue("Bar", out _));
+    }
+
+    [Fact]
+    public void TestGetEnumeratorFunctionsDespiteEarlyDictionaryDisposal()
+    {
+        var testDict = new Dictionary<string, string>
+        {
+            ["Hello"] = "World?",
+            ["Foo"] = "Bar"
+        };
+        var pyDict = PyObject.From(testDict).As<IReadOnlyDictionary<string, string>>();
+
+        using var e = pyDict.GetEnumerator();
+        ((IDisposable)pyDict).Dispose();
+
+        Assert.True(e.MoveNext());
+        Assert.Equal(new KeyValuePair<string, string>("Hello", "World?"), e.Current);
+
+        Assert.True(e.MoveNext());
+        Assert.Equal(new KeyValuePair<string, string>("Foo", "Bar"), e.Current);
+
+        Assert.False(e.MoveNext());
     }
 }

--- a/src/CSnakes.Runtime.Tests/Python/PyListTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyListTests.cs
@@ -1,0 +1,18 @@
+using CSnakes.Runtime.Python;
+
+namespace CSnakes.Runtime.Tests.Python;
+public class PyListTests : RuntimeTestBase
+{
+    [Fact]
+    public void TestGetEnumeratorFunctionsDespiteEarlyListDisposal()
+    {
+        var list = PyObject.From(new[] { 42 }).As<IReadOnlyList<int>>();
+
+        using var e = list.GetEnumerator();
+        ((IDisposable)list).Dispose();
+
+        Assert.True(e.MoveNext());
+        Assert.Equal(42, e.Current);
+        Assert.False(e.MoveNext());
+    }
+}

--- a/src/CSnakes.Runtime/Python/PyDictionary.cs
+++ b/src/CSnakes.Runtime/Python/PyDictionary.cs
@@ -90,8 +90,9 @@ internal class PyDictionary<TKey, TValue, TKeyImporter, TValueImporter>(PyObject
     {
         using (GIL.Acquire())
         {
-            using var items = PyObject.Create(CPythonAPI.PyMapping_Items(_dictionaryObject));
-            return new PyEnumerable<KeyValuePair<TKey, TValue>, KeyValuePairImporter>(items).GetEnumerator();
+            var items = PyObject.Create(CPythonAPI.PyMapping_Items(_dictionaryObject));
+            using var pairs = new PyEnumerable<KeyValuePair<TKey, TValue>, KeyValuePairImporter>(items);
+            return pairs.GetEnumerator();
         }
     }
 

--- a/src/CSnakes.Runtime/Python/PyList.cs
+++ b/src/CSnakes.Runtime/Python/PyList.cs
@@ -50,7 +50,8 @@ internal class PyList<T, TImporter>(PyObject listObject) :
         // TODO: If someone fetches the same index multiple times, we cache the result to avoid multiple round trips to Python
         using (GIL.Acquire())
         {
-            return new PyEnumerable<T, TImporter>(listObject);
+            using var items = new PyEnumerable<T, TImporter>(listObject.Clone());
+            return items.GetEnumerator();
         }
     }
 

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -156,25 +156,33 @@ public partial class PyObject : SafeHandle, ICloneable
     }
 
     /// <summary>
-    /// Calls iter() on the object and returns an IEnumerable that yields values of type T.
+    /// Returns an <see cref="IEnumerable{T}"/> that calls <c>iter()</c> on the
+    /// object and yields values of type T when iterated.
     /// </summary>
     /// <typeparam name="T">The type for each item in the iterator</typeparam>
-    /// <returns></returns>
+    /// <remarks>
+    /// This method does not check if the object is iterable until <see
+    /// cref="IEnumerable{T}.GetEnumerator"/> is called on the result.
+    /// </remarks>
     public IEnumerable<T> AsEnumerable<T>() =>
         AsEnumerable<T, PyObjectImporters.Runtime<T>>();
 
     /// <summary>
-    /// Calls iter() on the object and returns an IEnumerable that yields values of type T.
+    /// Returns an <see cref="IEnumerable{T}"/> that calls <c>iter()</c> on the
+    /// object and yields values of type T when iterated.
     /// </summary>
     /// <typeparam name="T">The type for each item in the iterator</typeparam>
     /// <typeparam name="TImporter">The type for importing each item type</typeparam>
-    /// <returns></returns>
+    /// <remarks>
+    /// This method does not check if the object is iterable until <see
+    /// cref="IEnumerable{T}.GetEnumerator"/> is called on the result.
+    /// </remarks>
     public IEnumerable<T> AsEnumerable<T, TImporter>()
         where TImporter : IPyObjectImporter<T>
     {
         using (GIL.Acquire())
         {
-            return new PyEnumerable<T, TImporter>(this);
+            return new PyEnumerable<T, TImporter>(Clone());
         }
     }
 

--- a/src/Integration.Tests/PyObjectTests.cs
+++ b/src/Integration.Tests/PyObjectTests.cs
@@ -1,0 +1,63 @@
+using CSnakes.Runtime.Python;
+using System.Linq;
+
+namespace Integration.Tests;
+public class PyObjectTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
+{
+    [Theory]
+    [InlineData("[1, 2, 3, 4, 5]")]
+    [InlineData("(1, 2, 3, 4, 5)")]
+    [InlineData("range(1, 6)")]
+    public void AsEnumerable_SourceCanBeReiterated(string expression)
+    {
+        using var range = Env.ExecuteExpression(expression);
+        var expected = new[] { 1, 2, 3, 4, 5 };
+        var xs = range.AsEnumerable<int>();
+        Assert.Equal(expected, xs.ToArray());   // First iteration
+        Assert.Equal(15, xs.Sum());             // Second iteration
+    }
+
+    [Fact]
+    public void AsEnumerable_IteratorsAreIndependent()
+    {
+        using var range = Env.ExecuteExpression("range(1, 6)");
+        var xs = range.AsEnumerable<int>();
+        var result = xs.Zip(xs, xs.Skip(1));
+        Assert.Equal([(1, 1, 2),
+                      (2, 2, 3),
+                      (3, 3, 4),
+                      (4, 4, 5)],
+                     result);
+    }
+
+    [Fact]
+    public void AsEnumerable_Clones()
+    {
+        using var range = Env.ExecuteExpression("range(1, 6)");
+        var xs = range.AsEnumerable<int>();
+        range.Dispose();
+        using var e = xs.GetEnumerator();
+        Assert.True(e.MoveNext());
+    }
+
+    [Fact]
+    public void AsEnumerable_IteratorReleasesGilBetweenYields()
+    {
+        using var range = Env.ExecuteExpression("range(1, 6)");
+        foreach (var _ in range.AsEnumerable<int>())
+            Assert.False(GIL.IsAcquired);
+    }
+
+    [Fact]
+    public void AsEnumerable_IteratorFailsOnFirstIterationForIncompatibleObject()
+    {
+        using var range = Env.ExecuteExpression("42");
+        var xs = range.AsEnumerable<int>();
+
+        void Act() => xs.GetEnumerator().Dispose();
+
+        var pyInvocationException = Assert.Throws<PythonInvocationException>(Act);
+        var pyRuntimeException = Assert.IsType<PythonRuntimeException>(pyInvocationException.InnerException);
+        Assert.Equal("'int' object is not iterable", pyRuntimeException.Message);
+    }
+}


### PR DESCRIPTION
This PR fixes the semantics of `PyObject.AsEnumerable<T>()`, which has a number of problems.

`PyEnumerable` was declared as an enumerable _and_ an enumerator at the same time:

https://github.com/tonybaloney/CSnakes/blob/07e4e2171d88deac63cf3974e7bef19721e5a915/src/CSnakes.Runtime/Python/PyEnumerable.cs#L6

The `GetEnumerator` would just return `this`:

https://github.com/tonybaloney/CSnakes/blob/07e4e2171d88deac63cf3974e7bef19721e5a915/src/CSnakes.Runtime/Python/PyEnumerable.cs#L26

However, an [`IEnumerable<T>.GetEnumerator`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1.getenumerator) implementation should return a new enumerator on each call such that each enumerator represents an _independent_ iteration through the sequence. If the same enumerator is returned on each call, the iteration state is shared between all consumers of the sequence and can lead to surprising results. For example, the following code:

```c#
static void Test(IPythonEnvironment env)
{
    using var range = env.ExecuteExpression("range(1, 6)");
    var xs = range.AsEnumerable<int>();
    // Following should print: 1 + 2 + 3 + 4 + 5 = 15
    Console.WriteLine($"{string.Join(" + ", xs)} = {xs.Sum()}"); // ...but throws!
}
```

throws `ObjectDisposedException` because `PyEnumerable` is disposed after the first iteration done by `string.Join` and so cannot by used by `Sum`. The same works in Python:

```python
xs = range(1, 6)
print(f"{' + '.join(str(x) for x in xs)} = {sum(xs)}")
# prints: 1 + 2 + 3 + 4 + 5 = 15
```

so it shouldn't be more limiting in .NET. With this PR, the semantics becomes aligned between Python and .NET. That said, I do feel that [Python isn't always honest and consistent about its iterable-iterator distinction](https://realpython.com/python-iterators-iterables/#comparing-iterators-vs-iterables). For example, an iterator/generator _function_ (or even [generator expression]) is simultaneously an iterable and an iterator, but acts more like an iterator, which I think is a compromise taken to allow use in `for` loops and comprehensions. That could still confuse a .NET developer, but I'd this has to be accepted as an idiosyncrasy of Python? For example, building on top of [`range`] with a generator expression gives the wrong result:

```python
xs = (x * 2 for x in range(1, 6))
print(f"{' + '.join(str(x) for x in xs)} = {sum(xs)}")
# prints: 2 + 4 + 6 + 8 + 10 = 0
```

You have to materialise via a list comprehension:

```python
xs = [x * 2 for x in range(1, 6)]
print(f"{' + '.join(str(x) for x in xs)} = {sum(xs)}")
# prints: 2 + 4 + 6 + 8 + 10 = 30
```

However, at the least the observed behaviour will be the same in .NET and Python.

A side-effect of this change is that `PyObject.AsEnumerable<T>()` does not call [`GetIter`] (and in turn [`PyObject_GetIter`]) until a call to `GetEnumerator` is made. I'm not sure we want to incur the cost of calling [`PyObject_GetIter`] just to throw away the object in order to test the object eagerly for being [iterable][py-iterable]. When used in a `foreach` loop, it would end up calling `PyObject_GetIter` _twice_. I think that's an acceptable trade-off? Nevertheless, I've called this out as a remark in the method documentation.

Note that the same semantics problem described in this PR also applies to `IGeneratorIterator<TYield, TSend, TReturn>` that claims to `IEnumerator<TYield>` _and_ `IEnumerable<TYield>` (and should be fixed in a separate PR):

https://github.com/tonybaloney/CSnakes/blob/5b60ce20ab9cffdcb43b160b0945e822a91fa2aa/src/CSnakes.Runtime/Python/IGeneratorIterator.cs#L5-L7

[`GetIter`]: https://github.com/tonybaloney/CSnakes/blob/5b60ce20ab9cffdcb43b160b0945e822a91fa2aa/src/CSnakes.Runtime/Python/PyObject.cs#L149
[`PyObject_GetIter`]: https://docs.python.org/3/c-api/object.html#c.PyObject_GetIter
[py-iterable]: https://docs.python.org/3/glossary.html#term-iterable
[`range`]: https://docs.python.org/3/library/stdtypes.html#range
[generator expression]: https://docs.python.org/3/reference/expressions.html#generator-expressions
