### PR TITLE
Use `BenchmarkSwitcher` in profiling project

### DIFF
--- a/src/Profile/Program.cs
+++ b/src/Profile/Program.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Running;
 using Profile;
 
-var summary = BenchmarkRunner.Run<MarshallingBenchmarks>(args: args);
-BenchmarkRunner.Run<AsyncBenchmarks>(args: args);
+BenchmarkSwitcher.FromAssembly(typeof(BaseBenchmark).Assembly)
+                 .Run(args);


### PR DESCRIPTION
PR #419 refactored benchmarks into two suites, but it's no longer possible to select other benchmarks than `MarshallingBenchmarks` from the CLI. For example, running:

    dotnet run --project src/Profile -c Release -f net9.0 -- --list tree

produces the following output and ends in an error:

    Using launch settings from src\Profile\Properties\launchSettings.json...
    Profile
     └─MarshallingBenchmarks
        ├─ComplexReturn
        ├─ComplexReturnLazy
        ├─FunctionReturnsList
        ├─FunctionTakesList
        ├─FunctionTakesDictionary
        ├─FunctionReturnsDictionary
        ├─FunctionReturnsTuple
        ├─FunctionTakesTuple
        ├─FunctionTakesValueTypes
        └─EmptyFunction
    Unhandled exception. System.InvalidOperationException: Sequence contains no elements
       at System.Linq.ThrowHelper.ThrowNoElementsException()
       at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source)
       at BenchmarkDotNet.Running.BenchmarkRunner.RunWithDirtyAssemblyResolveHelper(Type type, IConfig config, String[] args)
       at BenchmarkDotNet.Running.BenchmarkRunner.<>c__DisplayClass0_0`1.<Run>b__0()
       at BenchmarkDotNet.Running.BenchmarkRunner.RunWithExceptionHandling(Func`1 run)
       at BenchmarkDotNet.Running.BenchmarkRunner.Run[T](IConfig config, String[] args)
       at Program.<Main>$(String[] args) in A:\CSnakes\main\src\Profile\Program.cs:line 4

Note that `AsyncBenchmarks` is missing from the tree.

After applying the PR, the tree lists all benchmarks and doesn't end in the unhandled `InvalidOperationException` exception:

    Using launch settings from src\Profile\Properties\launchSettings.json...
    Profile
     ├─AsyncBenchmarks
     │  └─AsyncFunction
     └─MarshallingBenchmarks
        ├─ComplexReturn
        ├─ComplexReturnLazy
        ├─FunctionReturnsList
        ├─FunctionTakesList
        ├─FunctionTakesDictionary
        ├─FunctionReturnsDictionary
        ├─FunctionReturnsTuple
        ├─FunctionTakesTuple
        ├─FunctionTakesValueTypes
        └─EmptyFunction

Using `BenchmarkSwitcher` means running:

    dotnet run --project src/Profile -c Release -f net9.0

now will prompt the user for the benchmark to run and also enable use of, e.g. `--filter *AsyncBenchmarks*`, to specify which benchmarks to run.
