### PR TITLE
Add memory diagnoser to benchmarks

### DIFF
--- a/src/Profile/BaseBenchmark.cs
+++ b/src/Profile/BaseBenchmark.cs
@@ -1,8 +1,11 @@
+using BenchmarkDotNet.Attributes;
 using CSnakes.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Profile;
+
+[MemoryDiagnoser]
 public class BaseBenchmark
 {
     protected readonly IPythonEnvironment Env;


### PR DESCRIPTION
This PR proposed to add the memory diagnoser for benchmarks since it's generally useful to measure memory impact in size vs speed trade-offs. For example, this adds the `Allocated` below:

| Method        | Mean     | Error    | StdDev   | Allocated |
|-------------- |---------:|---------:|---------:|----------:|
| AsyncFunction | 15.54 ms | 0.188 ms | 0.176 ms |     777 B |
