### PR TITLE
Implement truthy-falsy for `PyObject`

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
@@ -158,4 +158,48 @@ public class PyObjectTests : RuntimeTestBase
         Assert.Equal(expectedLT, obj1 <= obj2);
         Assert.Equal(expectedGT, obj1 >= obj2);
     }
+
+    public static IEnumerable<object[]> BooleanishTestCases(bool yes) => new TheoryData<bool, object?>
+    {
+        { yes,  /* True      */ true },
+        { !yes, /* False     */ false },
+        { !yes, /* None      */ null },
+        { yes,  /* -42       */ -42 },
+        { !yes, /* 0         */ 0 },
+        { yes,  /* 42        */ 42 },
+        { !yes, /* ""        */ "" },
+        { yes,  /* "foobar"  */ "foobar" },
+        { !yes, /* []        */ Array.Empty<int>() },
+        { yes,  /* [42]      */ new[] { 42 } },
+        { !yes, /* {}        */ new Dictionary<int, string>() },
+        { yes,  /* { 0: "" } */ new Dictionary<int, string> { [0] = "" } },
+        { !yes, /* ()        */ new ValueTuple() },
+        { yes,  /* (0,)      */ new ValueTuple<int>(0) },
+    };
+
+    /// <summary>
+    /// Exercises <see cref="PyObject.op_True"/>.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(BooleanishTestCases), true)]
+    public void TestTruthy(bool expected, object input)
+    {
+        using var obj = PyObject.From(input);
+        if (obj)
+            Assert.True(expected);
+        else
+            Assert.False(expected);
+    }
+
+    /// <summary>
+    /// Exercises <see cref="PyObject.op_LogicalNot"/>.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(BooleanishTestCases), false)]
+    public void TestFalsy(bool expected, object input)
+    {
+        using var obj = PyObject.From(input);
+        var result = !obj;
+        Assert.Equal(expected, result);
+    }
 }

--- a/src/CSnakes.Runtime/CPython/Object.cs
+++ b/src/CSnakes.Runtime/CPython/Object.cs
@@ -195,4 +195,20 @@ internal unsafe partial class CPythonAPI
 
     [LibraryImport(PythonLibraryName)]
     internal static partial int PyObject_RichCompareBool(PyObject ob1, PyObject ob2, RichComparisonType comparisonType);
+
+    /// <summary>
+    /// Returns 1 if the object is considered to be <see langword="true" />, and
+    /// 0 otherwise. This is equivalent to the Python expression <c>not not
+    /// ob</c>. On failure, return -1.
+    /// </summary>
+    [LibraryImport(PythonLibraryName)]
+    internal static partial int PyObject_IsTrue(PyObject ob);
+
+    /// <summary>
+    /// Returns 0 if the object is considered to be <see langword="true" />, and
+    /// 1 otherwise. This is equivalent to the Python expression <c>not ob</c>.
+    /// On failure, return -1.
+    /// </summary>
+    [LibraryImport(PythonLibraryName)]
+    internal static partial int PyObject_Not(PyObject ob);
 }

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -304,6 +304,43 @@ public partial class PyObject : SafeHandle, ICloneable
         }
     }
 
+    /// <summary>
+    /// Check if the object is false. Equivalent to the <c>not</c> operator in Python.
+    /// </summary>
+    public static bool operator !(PyObject obj)
+    {
+        using (GIL.Acquire())
+        {
+            return CPythonAPI.PyObject_Not(obj) switch
+            {
+                < 0 => throw ThrowPythonExceptionAsClrException(),
+                0 => false,
+                _ => true,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Check if the object is true. Equivalent to the <c>bool()</c> function in Python.
+    /// </summary>
+    public static bool operator true(PyObject obj)
+    {
+        using (GIL.Acquire())
+        {
+            return CPythonAPI.PyObject_IsTrue(obj) switch
+            {
+                < 0 => throw ThrowPythonExceptionAsClrException(),
+                0 => false,
+                _ => true,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Check if the object is false. Equivalent to the <c>not</c> operator in Python.
+    /// </summary>
+    public static bool operator false(PyObject obj) => !obj;
+
     public override int GetHashCode()
     {
         using (GIL.Acquire())

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -309,7 +309,7 @@ public partial class PyObject : SafeHandle, ICloneable
     /// </summary>
     public static bool operator !(PyObject obj)
     {
-        if (obj.Is(False))
+        if (obj.Is(False) || obj.IsNone())
             return true;
 
         using (GIL.Acquire())
@@ -330,6 +330,9 @@ public partial class PyObject : SafeHandle, ICloneable
     {
         if (obj.Is(True))
             return true;
+
+        if (obj.IsNone())
+            return false;
 
         using (GIL.Acquire())
         {

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -311,7 +311,7 @@ public partial class PyObject : SafeHandle, ICloneable
     {
         using (GIL.Acquire())
         {
-            return CPythonAPI.PyObject_Not(obj) switch
+            return obj.Is(False) || CPythonAPI.PyObject_Not(obj) switch
             {
                 < 0 => throw ThrowPythonExceptionAsClrException(),
                 0 => false,
@@ -327,7 +327,7 @@ public partial class PyObject : SafeHandle, ICloneable
     {
         using (GIL.Acquire())
         {
-            return CPythonAPI.PyObject_IsTrue(obj) switch
+            return obj.Is(True) || CPythonAPI.PyObject_IsTrue(obj) switch
             {
                 < 0 => throw ThrowPythonExceptionAsClrException(),
                 0 => false,

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -309,9 +309,12 @@ public partial class PyObject : SafeHandle, ICloneable
     /// </summary>
     public static bool operator !(PyObject obj)
     {
+        if (obj.Is(False))
+            return true;
+
         using (GIL.Acquire())
         {
-            return obj.Is(False) || CPythonAPI.PyObject_Not(obj) switch
+            return CPythonAPI.PyObject_Not(obj) switch
             {
                 < 0 => throw ThrowPythonExceptionAsClrException(),
                 0 => false,
@@ -325,9 +328,12 @@ public partial class PyObject : SafeHandle, ICloneable
     /// </summary>
     public static bool operator true(PyObject obj)
     {
+        if (obj.Is(True))
+            return true;
+
         using (GIL.Acquire())
         {
-            return obj.Is(True) || CPythonAPI.PyObject_IsTrue(obj) switch
+            return CPythonAPI.PyObject_IsTrue(obj) switch
             {
                 < 0 => throw ThrowPythonExceptionAsClrException(),
                 0 => false,


### PR DESCRIPTION
## Overview

This PR adds support for Python's truthy-falsy behavior to the `PyObject` class in CSnakes. This enhancement allows C# code to use Python objects directly in boolean contexts (conditionals, logical operations) in a way that mimics Python's behavior.

## Background

In Python, objects can be evaluated in boolean contexts, following specific rules for truthiness:

- Objects like empty collections (`[]`, `{}`, `()`), zero (`0`), `None`, and empty strings (`""`) evaluate to `False`
- Non-empty collections, non-zero numbers, non-empty strings, and most other objects evaluate to `True`

This PR implements this behavior for CSnakes, allowing seamless integration of Python's boolean semantics in C#.

## Technical Details

The implementation adds:

1. Three operator overloads in `PyObject`:
   - `operator true` - Determines if a Python object is truthy
   - `operator !` - Implements logical negation, determining if an object is falsy
   - `operator false` - Required by C# when `operator true` is defined, but simply delegates to `operator !`

2. Corresponding native function bindings to CPython's API:
   - `PyObject_IsTrue` - Returns 1 if the object is considered true, 0 if false
   - `PyObject_Not` - Returns 1 if the object is considered false, 0 if true

3. Comprehensive test cases covering various Python types and their expected boolean evaluation:
   - Basic values (`True`, `False`, `None`)
   - Numeric values (negative, zero, positive)
   - Strings (empty, non-empty)
   - Collections (empty and non-empty lists, dictionaries, tuples)

**Note on `operator false`**: C# requires both `operator true` and `operator false` to be defined together when overloading Boolean operators. However, `operator false` is not directly testable, but it is somewhat indirectly covered by tests for `operator !` since `operator false` just delegates to `operator !`.

## Usage Example

```csharp
using var pyList = PyObject.From(new[] { 1, 2, 3 });

// Python-style boolean evaluation
if (pyList)
{
    // Will execute because non-empty lists are truthy
}

using var pyEmptyDict = PyObject.From(new Dictionary<string, object>());

// Python-style logical not
if (!pyEmptyDict)
{
    // Will execute because empty dictionaries are falsy
}
```

This enhancement improves the ergonomics of working with Python objects in C#, making the API more natural and Pythonic.
