### PR TITLE
Refactor to use a single event loop for coroutines

### DIFF
--- a/src/CSnakes.Runtime/CPython/EventLoop.cs
+++ b/src/CSnakes.Runtime/CPython/EventLoop.cs
@@ -1,0 +1,322 @@
+using CSnakes.Runtime.Python;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace CSnakes.Runtime.CPython;
+internal sealed class EventLoop : IDisposable
+{
+    private bool disposed;
+    private readonly PyObject loop = CPythonAPI.NewEventLoop();
+    private Methods methods;
+    private Task runForeverTask;
+    private readonly ConcurrentQueue<Request> requestQueue = new();
+    private readonly PyObject taskLoopStopFunction;
+
+    private abstract class Request : IDisposable
+    {
+        public virtual void Dispose() { }
+    }
+
+    private sealed class ScheduleRequest(PyObject coroutine, CancellationToken cancellationToken) : Request
+    {
+        public PyObject Coroutine { get; } = coroutine.Clone();
+        public CancellationToken CancellationToken { get; } = cancellationToken;
+        public TaskCompletionSource<TaskCompletionSource<PyObject>> CompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override void Dispose() => coroutine.Dispose();
+    }
+
+    private sealed class CancelRequest(CoroutineTask coroTask, CancellationToken cancellationToken) : Request
+    {
+        public CoroutineTask Task { get; } = coroTask;
+        public CancellationToken CancellationToken { get; } = cancellationToken;
+    }
+
+    private sealed class StopRequest : Request
+    {
+        public static readonly StopRequest Instance = new();
+
+        private StopRequest() { }
+    }
+
+    private sealed class CoroutineTask(PyObject pyTask) : IDisposable
+    {
+        private readonly PyObject pyTask = pyTask;
+        private PyObject? doneMethod;
+        private CancellationToken cancellationToken;
+
+        public TaskCompletionSource<PyObject> CompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <remarks>
+        /// Since <c>done</c> is expected to be called many times, cache the the
+        /// method object to avoid the overhead of calling <see
+        /// cref="PyObject.GetAttr"/> each time.
+        /// </remarks>
+        private PyObject DoneMethod => this.doneMethod ??= pyTask.GetAttr("done");
+
+        public void Dispose()
+        {
+            this.doneMethod?.Dispose();
+            this.pyTask.Dispose();
+        }
+
+        public void Cancel(CancellationToken cancellationToken = default)
+        {
+            using var cancelMethod = pyTask.GetAttr("cancel");
+            cancelMethod.Call().Dispose();
+            this.cancellationToken = cancellationToken;
+        }
+
+        public bool Conclude()
+        {
+            if (ProcessConclusion() == TaskStatus.Running)
+                return false;
+
+            Dispose();
+            return true;
+        }
+
+        private TaskStatus ProcessConclusion()
+        {
+            if (this.pyTask.IsClosed)
+                return CompletionSource.Task.Status;
+
+            // If the task is not done yet, return without doing anything.
+
+            if (DoneMethod.Call().Is(PyObject.False)) // TODO Use falsy-ness when PR #437 is merged
+                return TaskStatus.Running;
+
+            // If the Python task is cancelled, set the corresponding .NET task to cancelled.
+
+            using (var cancelledMethod = this.pyTask.GetAttr("cancelled"))
+            {
+                if (cancelledMethod.Call().Is(PyObject.True)) // TODO Use truthy-ness when PR #437 is merged
+                {
+                    CompletionSource.SetCanceled(this.cancellationToken);
+                    return TaskStatus.Canceled;
+                }
+            }
+
+            // If the Python task raised an exception, set the corresponding .NET task to faulted.
+
+            using (var exceptionMethod = this.pyTask.GetAttr("exception"))
+            {
+                PyObject? exception = exceptionMethod.Call();
+                try
+                {
+                    if (!exception.IsNone())
+                    {
+                        using var type = exception.GetPythonType();
+                        string name = type.GetAttr("__name__").ImportAs<string, PyObjectImporters.String>();
+                        CompletionSource.SetException(new PythonInvocationException(name, exception, null));
+                        exception = null;
+                        return TaskStatus.Faulted;
+                    }
+                }
+                finally
+                {
+                    exception?.Dispose();
+                }
+            }
+
+            // If the Python task is finished, set the result in the corresponding .NET task.
+
+            using var resultFunction = this.pyTask.GetAttr("result");
+            PyObject? result = resultFunction.Call();
+            try
+            {
+                CompletionSource.SetResult(result);
+                result = null; // yield ownership
+                return TaskStatus.RanToCompletion;
+            }
+            finally
+            {
+                result?.Dispose();
+            }
+        }
+    }
+
+    public static EventLoop RunNewForever() => new();
+
+    private EventLoop()
+    {
+        this.methods = new Methods(this.loop);
+        using var vars = PyObject.Create(CPythonAPI.PyDict_New());
+        this.taskLoopStopFunction = CPythonAPI.PyRun_String("lambda task: task.get_loop().stop()", CPythonAPI.InputType.Py_eval_input, vars, vars);
+        this.runForeverTask = Task.Run(RunForever);
+    }
+
+    public void Dispose()
+    {
+        if (this.disposed)
+            return;
+
+        try
+        {
+            Enqueue(StopRequest.Instance);
+            this.runForeverTask.WaitAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+            _ = this.methods.Close.Call();
+        }
+        catch (Exception ex)
+        {
+            Debug.Fail(ex.Message, ex.ToString());
+        }
+
+        this.methods.Dispose();
+        this.loop.Dispose();
+        this.taskLoopStopFunction.Dispose();
+        this.disposed = true;
+    }
+
+    public async Task<PyObject> RunCoroutineAsync(PyObject coroutine, CancellationToken cancellationToken)
+    {
+        using var request = new ScheduleRequest(coroutine, cancellationToken);
+        Enqueue(request);
+        var taskCompletionSource = await request.CompletionSource.Task.ConfigureAwait(false);
+        return await taskCompletionSource.Task.ConfigureAwait(false);
+    }
+
+    private void Enqueue(Request request)
+    {
+        this.requestQueue.Enqueue(request);
+        _ = this.methods.CallSoonThreadSafe.Call(this.methods.Stop);
+    }
+
+    enum RunState
+    {
+        Running,
+        Stopping,
+    }
+
+    private void RunForever()
+    {
+        var state = RunState.Running;
+        var coroTasks = new List<CoroutineTask>();
+
+        do
+        {
+            // Run the event loop forever. The event loop gets stopped and the call returns when
+            // either of the following happens:
+            //
+            // - The cancellation token for the run is triggered.
+            // - A request to schedule a new coroutine as a task is received.
+            // - A running task is done.
+
+            _ = this.methods.RunForever.Call();
+
+            while (requestQueue.TryDequeue(out var poppedRequest))
+            {
+                using (poppedRequest)
+                {
+                    switch (poppedRequest, state)
+                    {
+                        case (ScheduleRequest request, RunState.Stopping):
+                        {
+                            // Cancel any request to schedule a coroutine if the event loop is
+                            // stopping.
+
+                            request.CompletionSource.SetCanceled();
+                            break;
+                        }
+                        case (ScheduleRequest { CancellationToken.IsCancellationRequested: true } request, _):
+                        {
+                            // Cancel any request to schedule a coroutine if the task cancellation
+                            // token is triggered.
+
+                            request.CompletionSource.SetCanceled(request.CancellationToken);
+                            break;
+                        }
+                        case (ScheduleRequest request, RunState.Running):
+                        {
+                            // Create a task and add a done callback to it that will stop
+                            // the event loop when the task is done.
+
+                            var pyTask = this.methods.CreateTask.Call(request.Coroutine);
+                            IDisposable? disposable = pyTask;
+
+                            try
+                            {
+                                var coroTask = new CoroutineTask(pyTask);
+                                disposable = coroTask; // yield ownership
+
+                                using (var addDoneCallbackMethod = pyTask.GetAttr("add_done_callback"))
+                                    _ = addDoneCallbackMethod.Call(this.taskLoopStopFunction);
+
+                                if (request.CancellationToken is { CanBeCanceled: true } cancellationToken)
+                                {
+                                    _ = cancellationToken.Register(() =>
+                                        Enqueue(new CancelRequest(coroTask, cancellationToken)));
+                                }
+
+                                // Create a "TaskCompletionSource" to represent the task on the
+                                // .NET side and add it to the list of tasks.
+
+                                coroTasks.Add(coroTask);
+                                disposable = null; // yield ownership
+
+                                // Signal that the task was successfully scheduled.
+
+                                request.CompletionSource.SetResult(coroTask.CompletionSource);
+                            }
+                            catch (Exception ex)
+                            {
+                                // If the task could not be scheduled, set the exception.
+
+                                request.CompletionSource.SetException(ex);
+                            }
+                            finally
+                            {
+                                disposable?.Dispose();
+                            }
+                            break;
+                        }
+                        case (CancelRequest request, _):
+                        {
+                            request.Task.Cancel(request.CancellationToken);
+                            break;
+                        }
+                        case (StopRequest, RunState.Running):
+                        {
+                            state = RunState.Stopping;
+                            foreach (var task in coroTasks)
+                                task.Cancel();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            _ = coroTasks.RemoveAll(t => t.Conclude());
+        }
+        while (state is RunState.Running || coroTasks.Count > 0);
+    }
+
+    private struct Methods(PyObject loop) : IDisposable
+    {
+        private PyObject? createTask;
+        private PyObject? callSoonThreadSafe;
+        private PyObject? runForever;
+        private PyObject? stop;
+        private PyObject? close;
+
+        public PyObject CreateTask => this.createTask ??= loop.GetAttr("create_task");
+        public PyObject CallSoonThreadSafe => this.callSoonThreadSafe ??= loop.GetAttr("call_soon_threadsafe");
+        public PyObject RunForever => this.runForever ??= loop.GetAttr("run_forever");
+        public PyObject Stop => this.stop ??= loop.GetAttr("stop");
+        public PyObject Close => this.close ??= loop.GetAttr("close");
+
+        public void Dispose()
+        {
+            this.createTask?.Dispose();
+            this.createTask = null;
+            this.callSoonThreadSafe?.Dispose();
+            this.callSoonThreadSafe = null;
+            this.runForever?.Dispose();
+            this.runForever = null;
+            this.stop?.Dispose();
+            this.stop = null;
+            this.close?.Dispose();
+            this.close = null;
+        }
+    }
+}

--- a/src/CSnakes.Runtime/CPython/EventLoop.cs
+++ b/src/CSnakes.Runtime/CPython/EventLoop.cs
@@ -108,6 +108,8 @@ internal sealed class EventLoop : IDisposable
                     {
                         using var type = exception.GetPythonType();
                         string name = type.GetAttr("__name__").ImportAs<string, PyObjectImporters.String>();
+                        // TODO We are effectively losing the traceback here so copy the traceback or somehow attach it to "PythonInvocationException"
+                        // https://github.com/tonybaloney/CSnakes/pull/438#discussion_r2068321787
                         CompletionSource.SetException(new PythonInvocationException(name, exception, null));
                         exception = null;
                         return TaskStatus.Faulted;

--- a/src/CSnakes.Runtime/CPython/EventLoop.cs
+++ b/src/CSnakes.Runtime/CPython/EventLoop.cs
@@ -83,14 +83,14 @@ internal sealed class EventLoop : IDisposable
 
             // If the task is not done yet, return without doing anything.
 
-            if (DoneMethod.Call().Is(PyObject.False)) // TODO Use falsy-ness when PR #437 is merged
+            if (!DoneMethod.Call())
                 return TaskStatus.Running;
 
             // If the Python task is cancelled, set the corresponding .NET task to cancelled.
 
             using (var cancelledMethod = this.pyTask.GetAttr("cancelled"))
             {
-                if (cancelledMethod.Call().Is(PyObject.True)) // TODO Use truthy-ness when PR #437 is merged
+                if (cancelledMethod.Call())
                 {
                     CompletionSource.SetCanceled(this.cancellationToken);
                     return TaskStatus.Canceled;

--- a/src/Profile/AsyncBenchmarks.cs
+++ b/src/Profile/AsyncBenchmarks.cs
@@ -13,9 +13,26 @@ public class AsyncBenchmarks : BaseBenchmark
         mod = Env.AsyncBenchmarks();
     }
 
+    [Params(1, 10, 100, 1_000)]
+    public int N { get; set; }
+
+    [Params(0.001, 1)]
+    public double Delay { get; set; }
+
     [Benchmark]
     public async Task AsyncFunction()
     {
-        await mod!.AsyncSleepy();
+        if (N == 1)
+        {
+            await mod!.AsyncSleepy(Delay);
+        }
+        else
+        {
+            var tasks =
+                from n in Enumerable.Range(0, N)
+                select mod!.AsyncSleepy(Delay);
+
+            await Task.WhenAll(tasks);
+        }
     }
 }

--- a/src/Profile/async_benchmarks.py
+++ b/src/Profile/async_benchmarks.py
@@ -2,5 +2,5 @@ import asyncio
 from typing import Any, Coroutine
 
 
-async def async_sleepy() -> Coroutine[None, None, None]:
-    await asyncio.sleep(0.001)
+async def async_sleepy(delay: float = 0.001) -> Coroutine[None, None, None]:
+    await asyncio.sleep(delay)


### PR DESCRIPTION
## Summary

This PR refactors the Python coroutine handling in CSnakes to use a single shared event loop _and_ thread for all coroutines instead of creating a new one for each coroutine operation and per thread. The change significantly improves performance and operational behaviour (more on that later), especially when running multiple coroutines concurrently.

## Design Overview

The refactored implementation:

- uses a single, lazily-initialized, shared event loop that runs continuously.
- implements a message queue pattern for scheduling coroutines on the shared loop.
- runs the event loop on a dedicated background thread via `Task.Run`.
- supports cancellation, failure and successful completion of tasks.

## Technical Details

### Key Components

1. **Shared Event Loop**
   - A singleton `EventLoop` instance is created on demand and maintained until disposed with finalisation
   - Uses a simple lock-based lazy initialization pattern through `GetDefaultEventLoop()`
   - The [event loop runs forever](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_forever) until it is [stopped/interrupted](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.stop) by some change that's signaled via a message arriving on the queue.

2. **Message Queue**
   - A `ConcurrentQueue<Request>` is used for communication with the event loop thread.
   - Scheduling of new coroutines and cancellation of existing tasks can happen on any thread, so [`call_soon_threadsafe`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon_threadsafe) is used to safely move these operations to the thread servicing the event loop.
   - Different messages are sent to the queue to signal:
     - scheduling of a new task
     - completion of task, whether it got cancelled, failed or completed
     - stopping of the event loop (when getting disposed)

3. **Task Management**
   - `CoroutineTask` class wraps Python tasks and handles their lifecycle
   - Support for cancellation and exception handling
   - Proper disposal and resource cleanup

4. **Compatible API**
   - The public `Coroutine<TYield, TSend, TReturn>.AsTask(CancellationToken)` API remains unchanged
   - Internal implementation is significantly simplified and more robust

## Performance Improvements

At the micro-level, benchmarks demonstrate significant performance improvements, especially as number concurrent operations increase:

| Coroutine Count | Performance Improvement | Memory Overhead |
|-----------------|-------------------------|-----------------|
| 1               | 10% faster              | 764B → 1.45KB |
| 10              | 61% faster              | 6.6KB → 13.8KB |
| 100             | 69% faster              | 61KB → 134KB |
| 1000            | 76% faster              | 601KB → 1.3MB |

This is despite making more calls into Python and the _O(N<sup>2</sup>) time complexity of scanning and disposing done tasks.

While memory usage doubles, the performance improvement is substantial, especially at scale. This trade-off is well worth it for any application running multiple Python coroutines, which won't be uncommon. One must bear in mind that there is also less native memory pressure due to only a single thread and event loop being used for all coroutines. So on the balance of things, the effective and working set memory usage may not be exactly double.

The detailed benchmark is as follows:

| Diff    | Method          | N    |                 Mean | Error          |      Allocated |
| ------- | --------------- | ---- | -------------------: | -------------- | -------------: |
| Old     | `AsyncFunction` | 1    |             15.51 ms | 0.045 ms       |          764 B |
| **New** |                 |      | **14.035 ms (-10%)** | **0.4669 ms**  |    **1.45 KB** |
| Old     | `AsyncFunction` | 10   |             15.57 ms | 0.035 ms       |         6643 B |
| **New** |                 |      |  **5.998 ms (-61%)** | **0.8086 ms**  |   **13.78 KB** |
| Old     | `AsyncFunction` | 100  |             62.51 ms | 1.243 ms       |        61243 B |
| **New** |                 |      | **19.470 ms (-69%)** | **2.8330 ms**  |  **134.16 KB** |
| Old     | `AsyncFunction` | 1000 |            295.31 ms | 18.179 ms      |       601752 B |
| **New** |                 |      | **72.220 ms (-76%)** | **14.1494 ms** | **1335.27 KB** |

At the macro-level, the improvements are even more significant. Using a single even loop yields more correct and predictable operation. With the current design, increasing the sleep delay in `AsyncFunction` to 1 second and then launching 1,000 coroutines concurrently takes 47 seconds and over 20 threads (and an event loop per thread) from the thread pool to complete. With the refactored design, all thousand coroutines complete in 1.07 seconds, which is reasonable to expect! If there was a timeout associated with the overall operation of say 10 seconds, the former would always time-out and therefore never complete!

## Ideas for future/further improvements

- Adding event loop statistics and monitoring capabilities
- More efficient tracking of the task that just got done, reducing the _O(N<sup>2</sup>) time complexity
- Reduce memory usage for very large coroutine counts
