### PR TITLE
Remove redundant GIL acquisition during `PyObject` release

### DIFF
--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -45,10 +45,7 @@ public partial class PyObject : SafeHandle, ICloneable
         }
         if (GIL.IsAcquired)
         {
-            using (GIL.Acquire())
-            {
-                CPythonAPI.Py_DecRefRaw(handle);
-            }
+            CPythonAPI.Py_DecRefRaw(handle);
         }
         else
         {


### PR DESCRIPTION
This PR removes a redundant GIL acquisition during the release of a `PyObject`.