### PR TITLE
Improve performance with per-type overloads for `PyObject.From`

### DIFF
--- a/src/CSnakes.Runtime.Tests/Python/ImportTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/ImportTests.cs
@@ -31,7 +31,7 @@ public class ImportTests : RuntimeTestBase
     {
         using (GIL.Acquire())
         {
-            PyObject sys = PyObject.From<int>(42); // definitely not a module
+            PyObject sys = PyObject.From(42); // definitely not a module
             Assert.NotNull(sys);
             Assert.Throws<PythonInvocationException>(() => Import.ReloadModule(ref sys));
         }

--- a/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
@@ -86,8 +86,8 @@ public class PyObjectTests : RuntimeTestBase
     [Fact]
     public void TestObjectEqualsCollection()
     {
-        using var obj1 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
-        using var obj2 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
+        using var obj1 = PyObject.From(new[] { "Hello!", "World!" });
+        using var obj2 = PyObject.From(new[] { "Hello!", "World!" });
         Assert.True(obj1!.Equals(obj2));
         Assert.True(obj1 == obj2);
     }
@@ -109,8 +109,8 @@ public class PyObjectTests : RuntimeTestBase
     [Fact]
     public void TestObjectNotEqualsCollection()
     {
-        using var obj1 = PyObject.From<IEnumerable<string>>(["Hello!", "World!"]);
-        using var obj2 = PyObject.From<IEnumerable<string>>(["Hello?", "World?"]);
+        using var obj1 = PyObject.From(new[] { "Hello!", "World!" });
+        using var obj2 = PyObject.From(new[] { "Hello?", "World?" });
         Assert.True(obj1!.NotEquals(obj2));
         Assert.True(obj1 != obj2);
     }


### PR DESCRIPTION
This PR proposes to replace the generic `PyObject.From<T>` method with multiple type-specific overloads. The change improves code readability, maintainability, and performance by providing dedicated conversion paths for each supported type.

## Design Changes

The previous implementation used a single generic method with a large switch statement that handled many different types. This approach had several drawbacks:

- It obscured which types were actually supported
- The single method contained complex branching logic (possibly hurting [CPU branch prediction](https://en.wikipedia.org/wiki/Branch_predictor))

The new design:

- Provides dedicated overloads for each supported type (bool, long, double, string, etc.)
- Uses more idiomatic C# method overloading
- Makes supported types explicit in the API surface
- Enables IDE features like _find all references_ for specific type conversions (including in code produced by source generator)
- Reduces branching in the conversion path for each type

## Breaking Changes

None. All previously supported types continue to be supported with the same behavior. The fallback `From(object?)` method ensures backward compatibility for existing code.

## Performance Improvements

Performance testing shows consistent improvements across various scenarios in terms of memory _and_ speed:

| Scenario                    | Mean Time Improvement | Memory Allocation Improvement |
| --------------------------- | --------------------: | ----------------------------: |
| `ComplexReturn`             |             7% faster |               10% less memory |
| `ComplexReturnLazy`         |             3% faster |               12% less memory |
| `FunctionReturnsList`       |             2% faster |                     No change |
| `FunctionTakesList`         |             3% faster |               12% more memory |
| `FunctionTakesDictionary`   |             3% faster |                     No change |
| `FunctionReturnsDictionary` |             1% faster |                     No change |
| `FunctionReturnsTuple`      |             1% faster |                     No change |
| `FunctionTakesTuple`        |             8% faster |               19% less memory |
| `FunctionTakesValueTypes`   |             7% faster |                     No change |
| `EmptyFunction`             |             8% faster |                     No change |

These improvements come primarily from reduced type checking and more direct conversion paths.

Detailed performance numbers:

| Diff    | Method                      |                  Mean | Error         |          Allocated |
| ------- | --------------------------- | --------------------: | ------------- | -----------------: |
| Old     | `ComplexReturn`             |            1,903.7 ns | 37.97 ns      |              672 B |
| **New** |                             |  **1,768.4 ns (-7%)** | **34.26 ns**  |   **608 B (-10%)** |
| Old     | `ComplexReturnLazy`         |            1,721.1 ns | 32.27 ns      |              528 B |
| **New** |                             |  **1,672.3 ns (-3%)** | **31.67 ns**  |   **464 B (-12%)** |
| Old     | `FunctionReturnsList`       |            2,315.2 ns | 43.97 ns      |              208 B |
| **New** |                             |  **2,266.7 ns (-2%)** | **45.25 ns**  |     **208 B (0%)** |
| Old     | `FunctionTakesList`         |           18,355.1 ns | 344.61 ns     |            11016 B |
| **New** |                             | **17,848.6 ns (-3%)** | **344.00 ns** | **12352 B (+12%)** |
| Old     | `FunctionTakesDictionary`   |           37,612.3 ns | 745.50 ns     |            22320 B |
| **New** |                             | **36,436.5 ns (-3%)** | **714.39 ns** |   **22320 B (0%)** |
| Old     | `FunctionReturnsDictionary` |            9,842.9 ns | 135.28 ns     |              208 B |
| **New** |                             |  **9,747.5 ns (-1%)** | **111.25 ns** |     **208 B (0%)** |
| Old     | `FunctionReturnsTuple`      |              565.7 ns | 9.23 ns       |              224 B |
| **New** |                             |    **560.1 ns (-1%)** | **11.20 ns**  |     **224 B (0%)** |
| Old     | `FunctionTakesTuple`        |            1,032.0 ns | 20.68 ns      |              504 B |
| **New** |                             |    **949.7 ns (-8%)** | **18.16 ns**  |   **408 B (-19%)** |
| Old     | `FunctionTakesValueTypes`   |              523.6 ns | 10.35 ns      |              272 B |
| **New** |                             |    **487.8 ns (-7%)** | **9.48 ns**   |     **272 B (0%)** |
| Old     | `EmptyFunction`             |              165.6 ns | 3.30 ns       |               32 B |
| **New** |                             |    **152.0 ns (-8%)** | **2.14 ns**   |      **32 B (0%)** |

## Ideas for Future Improvements

- Explore further performance optimizations for dictionary and list conversion
- Investigate why there's a 12% increase in memory consumption with `FunctionTakesList`

## Testing

All existing tests have been updated to use the new syntax and continue to pass.

