### PR TITLE
Make all loggers & logging optional

### DIFF
--- a/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/CondaEnvironmentManagement.cs
@@ -4,10 +4,10 @@ using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.EnvironmentManagement;
 #pragma warning disable CS9113 // Parameter is unread. There for future use.
-internal class CondaEnvironmentManagement(ILogger logger, string name, bool ensureEnvironment, CondaLocator conda, string? environmentSpecPath, string? pythonEnvironmentVersion) : IEnvironmentManagement
+internal class CondaEnvironmentManagement(ILogger? logger, string name, bool ensureEnvironment, CondaLocator conda, string? environmentSpecPath, string? pythonEnvironmentVersion) : IEnvironmentManagement
 #pragma warning restore CS9113 // Parameter is unread.
 {
-    ILogger IEnvironmentManagement.Logger => logger;
+    ILogger? IEnvironmentManagement.Logger => logger;
 
     public void EnsureEnvironment(PythonLocationMetadata pythonLocation)
     {
@@ -17,7 +17,7 @@ internal class CondaEnvironmentManagement(ILogger logger, string name, bool ensu
         var fullPath = Path.GetFullPath(GetPath());
         if (!Directory.Exists(fullPath))
         {
-            logger.LogError("Cannot find conda environment at {fullPath}.", fullPath);
+            logger?.LogError("Cannot find conda environment at {fullPath}.", fullPath);
 
             throw new InvalidOperationException($"Cannot find conda environment at {fullPath}.");
 
@@ -25,13 +25,13 @@ internal class CondaEnvironmentManagement(ILogger logger, string name, bool ensu
             //var result = conda.ExecuteCondaShellCommand($"env create -n {name} -f {environmentSpecPath}");
             //if (!result)
             //{
-            //    logger.LogError("Failed to create conda environment.");
+            //    logger?.LogError("Failed to create conda environment.");
             //    throw new InvalidOperationException("Could not create conda environment");
             //}
         }
         else
         {
-            logger.LogDebug("Conda environment already exists at {fullPath}", fullPath);
+            logger?.LogDebug("Conda environment already exists at {fullPath}", fullPath);
             // TODO: Check if the environment is up to date
         }
     }

--- a/src/CSnakes.Runtime/EnvironmentManagement/IEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/IEnvironmentManagement.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace CSnakes.Runtime.EnvironmentManagement;
 public interface IEnvironmentManagement
 {
-    ILogger Logger { get; }
+    ILogger? Logger { get; }
 
     public string GetPath();
     public virtual string GetExtraPackagePath(PythonLocationMetadata location)
@@ -18,7 +18,7 @@ public interface IEnvironmentManagement
             string suffix = location.FreeThreaded ? "t" : "";
             envLibPath = Path.Combine(GetPath(), "lib", $"python{location.Version.Major}.{location.Version.Minor}{suffix}", "site-packages");
         }
-        Logger.LogDebug("Adding environment site-packages to extra paths: {VenvLibPath}", envLibPath);
+        Logger?.LogDebug("Adding environment site-packages to extra paths: {VenvLibPath}", envLibPath);
         return envLibPath;
     }
     public void EnsureEnvironment(PythonLocationMetadata pythonLocation);

--- a/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
@@ -2,9 +2,9 @@ using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.Logging;
 
 namespace CSnakes.Runtime.EnvironmentManagement;
-internal class VenvEnvironmentManagement(ILogger logger, string path, bool ensureExists) : IEnvironmentManagement
+internal class VenvEnvironmentManagement(ILogger? logger, string path, bool ensureExists) : IEnvironmentManagement
 {
-    ILogger IEnvironmentManagement.Logger => logger;
+    ILogger? IEnvironmentManagement.Logger => logger;
 
     public void EnsureEnvironment(PythonLocationMetadata pythonLocation)
     {
@@ -13,19 +13,19 @@ internal class VenvEnvironmentManagement(ILogger logger, string path, bool ensur
 
         if (string.IsNullOrEmpty(path))
         {
-            logger.LogError("Virtual environment location is not set but it was requested to be created.");
+            logger?.LogError("Virtual environment location is not set but it was requested to be created.");
             throw new ArgumentNullException(nameof(path), "Virtual environment location is not set.");
         }
         var fullPath = Path.GetFullPath(path);
         if (!Directory.Exists(path))
         {
-            logger.LogDebug("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
+            logger?.LogDebug("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
             var (process1, _, _) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-VV");
             var (process2, _, error) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-m venv {fullPath}");
 
             if (process1.ExitCode != 0 || process2.ExitCode != 0)
             {
-                logger.LogError("Failed to create virtual environment.");
+                logger?.LogError("Failed to create virtual environment.");
                 process1.Dispose();
                 process2.Dispose();
                 throw new InvalidOperationException($"Could not create virtual environment. {error}");
@@ -35,7 +35,7 @@ internal class VenvEnvironmentManagement(ILogger logger, string path, bool ensur
         }
         else
         {
-            logger.LogDebug("Virtual environment already exists at {VirtualEnvPath}", fullPath);
+            logger?.LogDebug("Virtual environment already exists at {VirtualEnvPath}", fullPath);
         }
     }
 

--- a/src/CSnakes.Runtime/IPythonEnvironment.cs
+++ b/src/CSnakes.Runtime/IPythonEnvironment.cs
@@ -23,5 +23,5 @@ public interface IPythonEnvironment : IDisposable
 
     public bool IsDisposed();
 
-    public ILogger<IPythonEnvironment> Logger { get; }
+    public ILogger<IPythonEnvironment>? Logger { get; }
 }

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -8,19 +8,19 @@ internal class CondaLocator : PythonLocator
 {
     private readonly string folder;
     private readonly Version version;
-    private readonly ILogger logger;
+    private readonly ILogger? logger;
     private readonly string condaBinaryPath;
 
     protected override Version Version { get { return version; } }
 
-    internal CondaLocator(ILogger logger, string condaBinaryPath)
+    internal CondaLocator(ILogger? logger, string condaBinaryPath)
     {
         this.logger = logger;
         this.condaBinaryPath = condaBinaryPath;
         var (process, result, errors) = ExecuteCondaCommand($"info --json");
         if (process.ExitCode != 0)
         {
-            logger.LogError("Failed to determine Python version from Conda {Error}.", errors);
+            logger?.LogError("Failed to determine Python version from Conda {Error}.", errors);
             throw new InvalidOperationException("Could not determine Python version from Conda.");
         }
         process.Dispose();

--- a/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
@@ -32,7 +32,7 @@ public enum RedistributablePythonVersion
     Python3_14,
 }
 
-internal class RedistributableLocator(ILogger<RedistributableLocator> logger, RedistributablePythonVersion version, int installerTimeout = 360, bool debug = false, bool freeThreaded = false) : PythonLocator
+internal class RedistributableLocator(ILogger<RedistributableLocator>? logger, RedistributablePythonVersion version, int installerTimeout = 360, bool debug = false, bool freeThreaded = false) : PythonLocator
 {
     private const string standaloneRelease = "20250212";
     private const string MutexName = @"Global\CSnakesPythonInstall-1"; // run-time name includes Python version
@@ -188,11 +188,11 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, Re
             string downloadUrl = $"https://github.com/astral-sh/python-build-standalone/releases/download/{standaloneRelease}/cpython-{Version.Major}.{Version.Minor}.{Version.Build}+{standaloneRelease}-{platform}.tar.zst";
 
             // Download and extract the Zstd tarball
-            logger.LogDebug("Downloading Python from {DownloadUrl}", downloadUrl);
+            logger?.LogDebug("Downloading Python from {DownloadUrl}", downloadUrl);
             string tempFilePath = DownloadFileToTempDirectoryAsync(downloadUrl).GetAwaiter().GetResult();
             string tarFilePath = DecompressZstFile(tempFilePath);
             ExtractTar(tarFilePath, downloadPath, logger);
-            logger.LogDebug("Extracted Python to {downloadPath}", downloadPath);
+            logger?.LogDebug("Extracted Python to {downloadPath}", downloadPath);
 
             // Delete the tarball and temp file
             File.Delete(tarFilePath);
@@ -200,7 +200,7 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, Re
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to download and extract Python");
+            logger?.LogError(ex, "Failed to download and extract Python");
             // If the install failed somewhere, delete the folder incase it's half downloaded
             if (Directory.Exists(installPath))
             {
@@ -265,7 +265,7 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, Re
         return tarFilePath;
     }
 
-    private static void ExtractTar(string tarFilePath, string extractPath, ILogger logger)
+    private static void ExtractTar(string tarFilePath, string extractPath, ILogger? logger)
     {
         using FileStream tarStream = File.OpenRead(tarFilePath);
         using TarReader tarReader = new(tarStream);
@@ -277,7 +277,7 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, Re
             if (entry.EntryType == TarEntryType.Directory)
             {
                 Directory.CreateDirectory(entryPath);
-                logger.LogDebug("Creating directory: {EntryPath}", entryPath);
+                logger?.LogDebug("Creating directory: {EntryPath}", entryPath);
             }
             else if (entry.EntryType == TarEntryType.RegularFile)
             {
@@ -291,19 +291,19 @@ internal class RedistributableLocator(ILogger<RedistributableLocator> logger, Re
             }
             else
             {
-                logger.LogDebug("Skipping entry: {EntryPath} ({EntryType})", entryPath, entry.EntryType);
+                logger?.LogDebug("Skipping entry: {EntryPath} ({EntryType})", entryPath, entry.EntryType);
             }
         }
         foreach (var (path, link) in symlinks)
         {
-            logger.LogDebug("Creating symlink: {Path} -> {Link}", path, link);
+            logger?.LogDebug("Creating symlink: {Path} -> {Link}", path, link);
             try
             {
                 File.CreateSymbolicLink(path, link);
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to create symlink: {Path} -> {Link}", path, link);
+                logger?.LogError(ex, "Failed to create symlink: {Path} -> {Link}", path, link);
             }
         }
     }

--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.PackageManagement;
 
-internal class PipInstaller(ILogger<PipInstaller> logger, string requirementsFileName) : IPythonPackageInstaller
+internal class PipInstaller(ILogger<PipInstaller>? logger, string requirementsFileName) : IPythonPackageInstaller
 {
     static readonly string pipBinaryName = $"pip{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
 
@@ -13,18 +13,18 @@ internal class PipInstaller(ILogger<PipInstaller> logger, string requirementsFil
         string requirementsPath = Path.GetFullPath(Path.Combine(home, requirementsFileName));
         if (File.Exists(requirementsPath))
         {
-            logger.LogDebug("File {Requirements} was found.", requirementsPath);
+            logger?.LogDebug("File {Requirements} was found.", requirementsPath);
             InstallPackagesWithPip(home, environmentManager, $"-r {requirementsFileName}", logger);
         }
         else
         {
-            logger.LogWarning("File {Requirements} was not found.", requirementsPath);
+            logger?.LogWarning("File {Requirements} was not found.", requirementsPath);
         }
 
         return Task.CompletedTask;
     }
 
-    internal static void InstallPackagesWithPip(string home, IEnvironmentManagement? environmentManager, string requirements, ILogger logger)
+    internal static void InstallPackagesWithPip(string home, IEnvironmentManagement? environmentManager, string requirements, ILogger? logger)
     {
         string fileName = pipBinaryName;
         string workingDirectory = home;
@@ -34,7 +34,7 @@ internal class PipInstaller(ILogger<PipInstaller> logger, string requirementsFil
         if (environmentManager is not null)
         {
             string virtualEnvironmentLocation = Path.GetFullPath(environmentManager.GetPath());
-            logger.LogDebug("Using virtual environment at {VirtualEnvironmentLocation} to install packages with pip.", virtualEnvironmentLocation);
+            logger?.LogDebug("Using virtual environment at {VirtualEnvironmentLocation} to install packages with pip.", virtualEnvironmentLocation);
             string venvScriptPath = Path.Combine(virtualEnvironmentLocation, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Scripts" : "bin");
             // TODO: Check that the pip executable exists, and if not, raise an exception with actionable steps.
             fileName = Path.Combine(venvScriptPath, pipBinaryName);

--- a/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.PackageManagement;
 
-internal class UVInstaller(ILogger<UVInstaller> logger, string requirementsFileName) : IPythonPackageInstaller
+internal class UVInstaller(ILogger<UVInstaller>? logger, string requirementsFileName) : IPythonPackageInstaller
 {
     static readonly string binaryName = $"uv{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
 
@@ -13,18 +13,18 @@ internal class UVInstaller(ILogger<UVInstaller> logger, string requirementsFileN
         string requirementsPath = Path.GetFullPath(Path.Combine(home, requirementsFileName));
         if (File.Exists(requirementsPath))
         {
-            logger.LogDebug("File {Requirements} was found.", requirementsPath);
+            logger?.LogDebug("File {Requirements} was found.", requirementsPath);
             InstallPackagesWithUv(home, environmentManager, $"-r {requirementsFileName}", logger);
         }
         else
         {
-            logger.LogWarning("File {Requirements} was not found.", requirementsPath);
+            logger?.LogWarning("File {Requirements} was not found.", requirementsPath);
         }
 
         return Task.CompletedTask;
     }
 
-    static internal void InstallPackagesWithUv(string home, IEnvironmentManagement? environmentManager, string requirements, ILogger logger)
+    static internal void InstallPackagesWithUv(string home, IEnvironmentManagement? environmentManager, string requirements, ILogger? logger)
     {
         string fileName = binaryName;
         string workingDirectory = home;
@@ -34,7 +34,7 @@ internal class UVInstaller(ILogger<UVInstaller> logger, string requirementsFileN
         if (environmentManager is not null)
         {
             string virtualEnvironmentLocation = Path.GetFullPath(environmentManager.GetPath());
-            logger.LogDebug("Using virtual environment at {VirtualEnvironmentLocation} to install packages with uv.", virtualEnvironmentLocation);
+            logger?.LogDebug("Using virtual environment at {VirtualEnvironmentLocation} to install packages with uv.", virtualEnvironmentLocation);
             string venvScriptPath = Path.Combine(virtualEnvironmentLocation, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Scripts" : "bin");
             string uvPath = Path.Combine(venvScriptPath, binaryName);
 

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -6,7 +6,7 @@ namespace CSnakes.Runtime;
 
 internal static class ProcessUtils
 {
-    internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger logger, PythonLocationMetadata pythonLocation, string arguments)
+    internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger? logger, PythonLocationMetadata pythonLocation, string arguments)
     {
         ProcessStartInfo startInfo = new()
         {
@@ -20,7 +20,7 @@ internal static class ProcessUtils
         return ExecuteCommand(logger, startInfo);
     }
 
-    internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, string fileName, string arguments)
+    internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger? logger, string fileName, string arguments)
     {
         ProcessStartInfo startInfo = new()
         {
@@ -33,9 +33,9 @@ internal static class ProcessUtils
         return ExecuteCommand(logger, startInfo);
     }
 
-    internal static bool ExecuteShellCommand(ILogger logger, string fileName, string arguments)
+    internal static bool ExecuteShellCommand(ILogger? logger, string fileName, string arguments)
     {
-        logger.LogDebug("Executing shell command {FileName} {Arguments}", fileName, arguments);
+        logger?.LogDebug("Executing shell command {FileName} {Arguments}", fileName, arguments);
         ProcessStartInfo startInfo = new()
         {
             FileName = fileName,
@@ -51,7 +51,7 @@ internal static class ProcessUtils
     }
 
 
-    private static (Process proc, string? result, string? errors) ExecuteCommand(ILogger logger, ProcessStartInfo startInfo)
+    private static (Process proc, string? result, string? errors) ExecuteCommand(ILogger? logger, ProcessStartInfo startInfo)
     {
         Process process = new() { StartInfo = startInfo };
         string? result = null;
@@ -61,7 +61,7 @@ internal static class ProcessUtils
             if (!string.IsNullOrEmpty(e.Data))
             {
                 result += e.Data;
-                logger.LogDebug("{Data}", e.Data);
+                logger?.LogDebug("{Data}", e.Data);
             }
         };
 
@@ -70,7 +70,7 @@ internal static class ProcessUtils
             if (!string.IsNullOrEmpty(e.Data))
             {
                 errors += e.Data;
-                logger.LogError("{Data}", e.Data);
+                logger?.LogError("{Data}", e.Data);
             }
         };
 
@@ -80,7 +80,7 @@ internal static class ProcessUtils
         process.WaitForExit();
         return (process, result, errors);
     }
-    internal static void ExecuteProcess(string fileName, string arguments, string workingDirectory, string path, ILogger logger, IReadOnlyDictionary<string, string?>? extraEnv = null)
+    internal static void ExecuteProcess(string fileName, string arguments, string workingDirectory, string path, ILogger? logger, IReadOnlyDictionary<string, string?>? extraEnv = null)
     {
         ProcessStartInfo startInfo = new()
         {
@@ -102,7 +102,7 @@ internal static class ProcessUtils
         }
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
-        logger.LogDebug($"Running {startInfo.FileName} with args {startInfo.Arguments} from {startInfo.WorkingDirectory}");
+        logger?.LogDebug($"Running {startInfo.FileName} with args {startInfo.Arguments} from {startInfo.WorkingDirectory}");
 
         using Process process = new() { StartInfo = startInfo };
         string stderr = string.Empty;
@@ -110,7 +110,7 @@ internal static class ProcessUtils
         {
             if (!string.IsNullOrEmpty(e.Data))
             {
-                logger.LogDebug("{Data}", e.Data);
+                logger?.LogDebug("{Data}", e.Data);
             }
         };
 
@@ -129,14 +129,14 @@ internal static class ProcessUtils
 
         if (process.ExitCode != 0)
         {
-            logger.LogError("Failed to install packages. ");
-            logger.LogError("Output was: {stderr}", stderr);
+            logger?.LogError("Failed to install packages. ");
+            logger?.LogError("Output was: {stderr}", stderr);
             throw new InvalidOperationException("Failed to install packages");
         }
         else
         {
-            logger.LogDebug("Successfully installed packages.");
-            logger.LogDebug("Output was: {stderr}", stderr);
+            logger?.LogDebug("Successfully installed packages.");
+            logger?.LogDebug("Output was: {stderr}", stderr);
         }
     }
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -16,7 +16,7 @@ namespace CSnakes.Runtime;
 
 internal class PythonEnvironment : IPythonEnvironment
 {
-    public ILogger<IPythonEnvironment> Logger { get; private set; }
+    public ILogger<IPythonEnvironment>? Logger { get; private set; }
 
     private readonly CPythonAPI api;
     private bool disposedValue;
@@ -24,7 +24,7 @@ internal class PythonEnvironment : IPythonEnvironment
     private static IPythonEnvironment? pythonEnvironment;
     private readonly static Lock locker = new();
 
-    public static IPythonEnvironment GetPythonEnvironment(IEnumerable<PythonLocator> locators, IEnumerable<IPythonPackageInstaller> packageInstallers, PythonEnvironmentOptions options, ILogger<IPythonEnvironment> logger, IEnvironmentManagement? environmentManager = null)
+    public static IPythonEnvironment GetPythonEnvironment(IEnumerable<PythonLocator> locators, IEnumerable<IPythonPackageInstaller> packageInstallers, PythonEnvironmentOptions options, ILogger<IPythonEnvironment>? logger, IEnvironmentManagement? environmentManager = null)
     {
         if (pythonEnvironment is null)
         {
@@ -40,7 +40,7 @@ internal class PythonEnvironment : IPythonEnvironment
         IEnumerable<PythonLocator> locators,
         IEnumerable<IPythonPackageInstaller> packageInstallers,
         PythonEnvironmentOptions options,
-        ILogger<IPythonEnvironment> logger,
+        ILogger<IPythonEnvironment>? logger,
         IEnvironmentManagement? environmentManager = null)
     {
         Logger = logger;
@@ -52,7 +52,7 @@ internal class PythonEnvironment : IPythonEnvironment
 
         if (location is null)
         {
-            logger.LogError("Python installation not found. There were {LocatorCount} locators registered.", locators.Count());
+            logger?.LogError("Python installation not found. There were {LocatorCount} locators registered.", locators.Count());
             throw new InvalidOperationException("Python installation not found.");
         }
 
@@ -62,7 +62,7 @@ internal class PythonEnvironment : IPythonEnvironment
         home = Path.GetFullPath(home);
         if (!Directory.Exists(home))
         {
-            logger.LogError("Python home directory does not exist: {Home}", home);
+            logger?.LogError("Python home directory does not exist: {Home}", home);
             throw new DirectoryNotFoundException("Python home directory does not exist.");
         }
 
@@ -74,7 +74,7 @@ internal class PythonEnvironment : IPythonEnvironment
             environmentManager.EnsureEnvironment(location);
         }
 
-        logger.LogDebug("Setting up Python environment from {PythonLocation} using home of {Home}", location.Folder, home);
+        logger?.LogDebug("Setting up Python environment from {PythonLocation} using home of {Home}", location.Folder, home);
 
         foreach (var installer in packageInstallers)
         {
@@ -92,7 +92,7 @@ internal class PythonEnvironment : IPythonEnvironment
 
         if (extraPaths is { Length: > 0 })
         {
-            logger.LogDebug("Adding extra paths to PYTHONPATH: {ExtraPaths}", extraPaths);
+            logger?.LogDebug("Adding extra paths to PYTHONPATH: {ExtraPaths}", extraPaths);
             api.PythonPath = api.PythonPath + sep + string.Join(sep, extraPaths);
         }
         api.Initialize();
@@ -103,8 +103,8 @@ internal class PythonEnvironment : IPythonEnvironment
         string pythonDll = pythonLocationMetadata.LibPythonPath;
         string pythonPath = pythonLocationMetadata.PythonPath;
 
-        Logger.LogDebug("Python DLL: {PythonDLL}", pythonDll);
-        Logger.LogDebug("Python path: {PythonPath}", pythonPath);
+        Logger?.LogDebug("Python DLL: {PythonDLL}", pythonDll);
+        Logger?.LogDebug("Python path: {PythonPath}", pythonPath);
 
         var api = new CPythonAPI(pythonDll, pythonLocationMetadata.Version, pythonLocationMetadata.PythonBinaryPath)
         {

--- a/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
+++ b/src/CSnakes.Runtime/PythonEnvironmentBuilder.cs
@@ -17,7 +17,7 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
         Services.AddSingleton<IEnvironmentManagement>(
             sp =>
             {
-                var logger = sp.GetRequiredService<ILogger<VenvEnvironmentManagement>>();
+                var logger = sp.GetService<ILogger<VenvEnvironmentManagement>>();
                 return new VenvEnvironmentManagement(logger, path, ensureExists);
             });
         return this;
@@ -31,7 +31,7 @@ internal partial class PythonEnvironmentBuilder(IServiceCollection services) : I
                 try
                 {
                     var condaLocator = sp.GetRequiredService<CondaLocator>();
-                    var logger = sp.GetRequiredService<ILogger<CondaEnvironmentManagement>>();
+                    var logger = sp.GetService<ILogger<CondaEnvironmentManagement>>();
                     var condaEnvManager = new CondaEnvironmentManagement(logger, name, ensureEnvironment, condaLocator, environmentSpecPath, pythonVersion);
                     return condaEnvManager;
                 }

--- a/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
+++ b/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static partial class ServiceCollectionExtensions
             var envBuilder = sp.GetRequiredService<IPythonEnvironmentBuilder>();
             var locators = sp.GetServices<PythonLocator>();
             var installers = sp.GetServices<IPythonPackageInstaller>();
-            var logger = sp.GetRequiredService<ILogger<IPythonEnvironment>>();
+            var logger = sp.GetService<ILogger<IPythonEnvironment>>();
             var environmentManager = sp.GetService<IEnvironmentManagement>();
 
             var options = envBuilder.GetOptions();
@@ -165,7 +165,7 @@ public static partial class ServiceCollectionExtensions
         builder.Services.AddSingleton<CondaLocator>(
             sp =>
             {
-                var logger = sp.GetRequiredService<ILogger<IPythonEnvironment>>();
+                var logger = sp.GetService<ILogger<IPythonEnvironment>>();
                 return new CondaLocator(logger, condaBinaryPath);
             }
         );
@@ -192,7 +192,7 @@ public static partial class ServiceCollectionExtensions
         builder.Services.AddSingleton<PythonLocator>(
             sp =>
             {
-                var logger = sp.GetRequiredService<ILogger<RedistributableLocator>>();
+                var logger = sp.GetService<ILogger<RedistributableLocator>>();
                 return new RedistributableLocator(logger, RedistributablePythonVersion.Python3_12, timeout, debug);
             }
         );
@@ -214,7 +214,7 @@ public static partial class ServiceCollectionExtensions
         builder.Services.AddSingleton<PythonLocator>(
             sp =>
             {
-                var logger = sp.GetRequiredService<ILogger<RedistributableLocator>>();
+                var logger = sp.GetService<ILogger<RedistributableLocator>>();
                 return new RedistributableLocator(logger, version, timeout, debug, freeThreaded);
             }
         );
@@ -258,7 +258,7 @@ public static partial class ServiceCollectionExtensions
         builder.Services.AddSingleton<IPythonPackageInstaller>(
             sp =>
             {
-                var logger = sp.GetRequiredService<ILogger<PipInstaller>>();
+                var logger = sp.GetService<ILogger<PipInstaller>>();
                 return new PipInstaller(logger, requirementsPath);
             }
         );
@@ -276,7 +276,7 @@ public static partial class ServiceCollectionExtensions
         builder.Services.AddSingleton<IPythonPackageInstaller>(
             sp =>
             {
-                var logger = sp.GetRequiredService<ILogger<UVInstaller>>();
+                var logger = sp.GetService<ILogger<UVInstaller>>();
                 return new UVInstaller(logger, requirementsPath);
             }
         );

--- a/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
+++ b/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
@@ -110,18 +110,18 @@ public class PythonStaticGenerator : IIncrementalGenerator
                 private class {{pascalFileName}}Internal : I{{pascalFileName}}
                 {
                     private PyObject module;
-                    private readonly ILogger<IPythonEnvironment> logger;
+                    private readonly ILogger<IPythonEnvironment>? logger;
 
             {{      Lines(IndentationLevel.Two,
                           from f in functionNames
                           select $"private PyObject {f.Field};") }}
 
-                    internal {{pascalFileName}}Internal(ILogger<IPythonEnvironment> logger)
+                    internal {{pascalFileName}}Internal(ILogger<IPythonEnvironment>? logger)
                     {
                         this.logger = logger;
                         using (GIL.Acquire())
                         {
-                            logger.LogDebug("Importing module {ModuleName}", "{{fileName}}");
+                            logger?.LogDebug("Importing module {ModuleName}", "{{fileName}}");
                             module = Import.ImportModule("{{fileName}}");
             {{              Lines(IndentationLevel.Four,
                                   from f in functionNames
@@ -131,7 +131,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
 
                     void IReloadableModuleImport.ReloadModule()
                     {
-                        logger.LogDebug("Reloading module {ModuleName}", "{{fileName}}");
+                        logger?.LogDebug("Reloading module {ModuleName}", "{{fileName}}");
                         using (GIL.Acquire())
                         {
                             Import.ReloadModule(ref module);
@@ -148,7 +148,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
 
                     public void Dispose()
                     {
-                        logger.LogDebug("Disposing module {ModuleName}", "{{fileName}}");
+                        logger?.LogDebug("Disposing module {ModuleName}", "{{fileName}}");
             {{          Lines(IndentationLevel.Three,
                               from f in functionNames
                               select $"this.{f.Field}.Dispose();") }}

--- a/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
@@ -217,19 +217,19 @@ public static class MethodReflection
             callStatement = callStatement.WithUsingKeyword(Token(SyntaxKind.UsingKeyword));
 
         var logStatement = ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName("logger"),
-                        IdentifierName("LogDebug")))
-                    .WithArgumentList(
-                        ArgumentList(
-                            SeparatedList(
-                                [
-                                    Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal("Invoking Python function: {FunctionName}"))),
-                                    Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(function.Name)))
-                                ])))
-                    );
+                ConditionalAccessExpression(
+                    IdentifierName("logger"),
+                    InvocationExpression(
+                        MemberBindingExpression(
+                            IdentifierName("LogDebug")))
+                        .WithArgumentList(
+                            ArgumentList(
+                                SeparatedList(
+                                    [
+                                        Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal("Invoking Python function: {FunctionName}"))),
+                                        Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(function.Name)))
+                                    ])))
+                        ));
 
         var body = Block(
             UsingStatement(

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
@@ -43,7 +43,7 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_positional_only_args;
         private PyObject __func_collect_star_args;
@@ -52,12 +52,12 @@ public static class TestClassExtensions
         private PyObject __func_positional_and_kwargs;
         private PyObject __func_collect_star_args_and_keyword_only_args;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_positional_only_args = module.GetAttr("positional_only_args");
                 this.__func_collect_star_args = module.GetAttr("collect_star_args");
@@ -70,7 +70,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -93,7 +93,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_positional_only_args.Dispose();
             this.__func_collect_star_args.Dispose();
             this.__func_keyword_only_args.Dispose();
@@ -107,7 +107,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "positional_only_args");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "positional_only_args");
                 PyObject __underlyingPythonFunc = this.__func_positional_only_args;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -122,7 +122,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "collect_star_args");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "collect_star_args");
                 PyObject __underlyingPythonFunc = this.__func_collect_star_args;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -136,7 +136,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "keyword_only_args");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "keyword_only_args");
                 PyObject __underlyingPythonFunc = this.__func_keyword_only_args;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -151,7 +151,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "collect_star_star_kwargs");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "collect_star_star_kwargs");
                 PyObject __underlyingPythonFunc = this.__func_collect_star_star_kwargs;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -165,7 +165,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "positional_and_kwargs");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "positional_and_kwargs");
                 PyObject __underlyingPythonFunc = this.__func_positional_and_kwargs;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -180,7 +180,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "collect_star_args_and_keyword_only_args");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "collect_star_args_and_keyword_only_args");
                 PyObject __underlyingPythonFunc = this.__func_collect_star_args_and_keyword_only_args;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
@@ -43,16 +43,16 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_with_underscore;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_with_underscore = module.GetAttr("test_with_underscore");
             }
@@ -60,7 +60,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -73,7 +73,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_with_underscore.Dispose();
             module.Dispose();
         }
@@ -82,7 +82,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_with_underscore");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_with_underscore");
                 PyObject __underlyingPythonFunc = this.__func_test_with_underscore;
                 using PyObject testx_pyObject = PyObject.From(testx)!;
                 using PyObject testy_pyObject = PyObject.From(testy)!;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -43,7 +43,7 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_int_float;
         private PyObject __func_test_int_int;
@@ -57,12 +57,12 @@ public static class TestClassExtensions
         private PyObject __func_test_sequence;
         private PyObject __func_test_none_result;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_int_float = module.GetAttr("test_int_float");
                 this.__func_test_int_int = module.GetAttr("test_int_int");
@@ -80,7 +80,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -113,7 +113,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_int_float.Dispose();
             this.__func_test_int_int.Dispose();
             this.__func_test_float_float.Dispose();
@@ -132,7 +132,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int_float");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int_float");
                 PyObject __underlyingPythonFunc = this.__func_test_int_float;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -146,7 +146,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int_int");
                 PyObject __underlyingPythonFunc = this.__func_test_int_int;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -160,7 +160,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float_float");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float_float");
                 PyObject __underlyingPythonFunc = this.__func_test_float_float;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -174,7 +174,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float_int");
                 PyObject __underlyingPythonFunc = this.__func_test_float_int;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -188,7 +188,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_list_of_ints");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_list_of_ints");
                 PyObject __underlyingPythonFunc = this.__func_test_list_of_ints;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -201,7 +201,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_two_strings");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_two_strings");
                 PyObject __underlyingPythonFunc = this.__func_test_two_strings;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -215,7 +215,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_two_lists_of_strings");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_two_lists_of_strings");
                 PyObject __underlyingPythonFunc = this.__func_test_two_lists_of_strings;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -229,7 +229,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_two_dicts");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_two_dicts");
                 PyObject __underlyingPythonFunc = this.__func_test_two_dicts;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -243,7 +243,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_bytes");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_bytes");
                 PyObject __underlyingPythonFunc = this.__func_test_bytes;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -256,7 +256,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_sequence");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_sequence");
                 PyObject __underlyingPythonFunc = this.__func_test_sequence;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject start_pyObject = PyObject.From(start)!;
@@ -271,7 +271,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_none_result");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_none_result");
                 PyObject __underlyingPythonFunc = this.__func_test_none_result;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 return;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -43,7 +43,7 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_bool_buffer;
         private PyObject __func_test_int8_buffer;
@@ -77,12 +77,12 @@ public static class TestClassExtensions
         private PyObject __func_test_ndim_4d_buffer;
         private PyObject __func_sum_of_2d_array;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_bool_buffer = module.GetAttr("test_bool_buffer");
                 this.__func_test_int8_buffer = module.GetAttr("test_int8_buffer");
@@ -120,7 +120,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -193,7 +193,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_bool_buffer.Dispose();
             this.__func_test_int8_buffer.Dispose();
             this.__func_test_uint8_buffer.Dispose();
@@ -232,7 +232,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_bool_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_bool_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_bool_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -244,7 +244,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int8_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int8_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int8_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -256,7 +256,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint8_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint8_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint8_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -268,7 +268,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int16_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int16_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int16_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -280,7 +280,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint16_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint16_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint16_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -292,7 +292,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int32_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int32_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int32_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -304,7 +304,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int64_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int64_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int64_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -316,7 +316,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint32_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint32_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint32_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -328,7 +328,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint64_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint64_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint64_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -340,7 +340,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float32_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float32_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_float32_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -352,7 +352,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float64_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float64_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_float64_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -364,7 +364,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_vector_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_vector_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_vector_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -376,7 +376,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int8_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int8_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int8_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -388,7 +388,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint8_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint8_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint8_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -400,7 +400,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int16_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int16_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int16_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -412,7 +412,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint16_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint16_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint16_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -424,7 +424,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int32_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int32_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int32_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -436,7 +436,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint32_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint32_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint32_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -448,7 +448,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int64_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int64_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_int64_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -460,7 +460,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_uint64_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_uint64_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_uint64_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -472,7 +472,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float32_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float32_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_float32_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -484,7 +484,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float64_2d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float64_2d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_float64_2d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -496,7 +496,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_global_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_global_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_global_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -508,7 +508,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_bytes_as_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_bytes_as_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_bytes_as_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -520,7 +520,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_bytearray_as_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_bytearray_as_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_bytearray_as_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -532,7 +532,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_non_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_non_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_non_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -544,7 +544,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_non_contiguous_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_non_contiguous_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_non_contiguous_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -556,7 +556,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_transposed_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_transposed_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_transposed_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -568,7 +568,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_ndim_3d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_ndim_3d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_ndim_3d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -580,7 +580,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_ndim_4d_buffer");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_ndim_4d_buffer");
                 PyObject __underlyingPythonFunc = this.__func_test_ndim_4d_buffer;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IPyBuffer, global::CSnakes.Runtime.Python.PyObjectImporters.Buffer>();
@@ -592,7 +592,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "sum_of_2d_array");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "sum_of_2d_array");
                 PyObject __underlyingPythonFunc = this.__func_sum_of_2d_array;
                 using PyObject n_pyObject = PyObject.From(n)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(n_pyObject);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -43,18 +43,18 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_coroutine;
         private PyObject __func_test_coroutine_raises_exception;
         private PyObject __func_test_coroutine_returns_nothing;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_coroutine = module.GetAttr("test_coroutine");
                 this.__func_test_coroutine_raises_exception = module.GetAttr("test_coroutine_raises_exception");
@@ -64,7 +64,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -81,7 +81,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_coroutine.Dispose();
             this.__func_test_coroutine_raises_exception.Dispose();
             this.__func_test_coroutine_returns_nothing.Dispose();
@@ -92,7 +92,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
@@ -105,7 +105,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_raises_exception");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_raises_exception");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_raises_exception;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
@@ -117,7 +117,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_returns_nothing");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_returns_nothing");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_returns_nothing;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
@@ -43,7 +43,7 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_default_str_arg;
         private PyObject __func_test_default_int_arg;
@@ -54,12 +54,12 @@ public static class TestClassExtensions
         private PyObject __func_test_optional_list;
         private PyObject __func_test_optional_any;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_default_str_arg = module.GetAttr("test_default_str_arg");
                 this.__func_test_default_int_arg = module.GetAttr("test_default_int_arg");
@@ -74,7 +74,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -101,7 +101,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_default_str_arg.Dispose();
             this.__func_test_default_int_arg.Dispose();
             this.__func_test_default_float_arg.Dispose();
@@ -117,7 +117,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_default_str_arg");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_default_str_arg");
                 PyObject __underlyingPythonFunc = this.__func_test_default_str_arg;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -130,7 +130,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_default_int_arg");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_default_int_arg");
                 PyObject __underlyingPythonFunc = this.__func_test_default_int_arg;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -143,7 +143,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_default_float_arg");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_default_float_arg");
                 PyObject __underlyingPythonFunc = this.__func_test_default_float_arg;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -156,7 +156,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int_literals");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int_literals");
                 PyObject __underlyingPythonFunc = this.__func_test_int_literals;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -170,7 +170,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_optional_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_optional_int");
                 PyObject __underlyingPythonFunc = this.__func_test_optional_int;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -183,7 +183,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_optional_str");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_optional_str");
                 PyObject __underlyingPythonFunc = this.__func_test_optional_str;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -196,7 +196,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_optional_list");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_optional_list");
                 PyObject __underlyingPythonFunc = this.__func_test_optional_list;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -209,7 +209,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_optional_any");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_optional_any");
                 PyObject __underlyingPythonFunc = this.__func_test_optional_any;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
@@ -43,16 +43,16 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_nothing;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_nothing = module.GetAttr("test_nothing");
             }
@@ -60,7 +60,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -73,7 +73,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_nothing.Dispose();
             module.Dispose();
         }
@@ -82,7 +82,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_nothing");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_nothing");
                 PyObject __underlyingPythonFunc = this.__func_test_nothing;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<bool, global::CSnakes.Runtime.Python.PyObjectImporters.Boolean>();

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
@@ -43,19 +43,19 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_dict_str_int;
         private PyObject __func_test_dict_str_list_int;
         private PyObject __func_test_dict_str_dict_int;
         private PyObject __func_test_mapping;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_dict_str_int = module.GetAttr("test_dict_str_int");
                 this.__func_test_dict_str_list_int = module.GetAttr("test_dict_str_list_int");
@@ -66,7 +66,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -85,7 +85,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_dict_str_int.Dispose();
             this.__func_test_dict_str_list_int.Dispose();
             this.__func_test_dict_str_dict_int.Dispose();
@@ -97,7 +97,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_dict_str_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_dict_str_int");
                 PyObject __underlyingPythonFunc = this.__func_test_dict_str_int;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -110,7 +110,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_dict_str_list_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_dict_str_list_int");
                 PyObject __underlyingPythonFunc = this.__func_test_dict_str_list_int;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -123,7 +123,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_dict_str_dict_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_dict_str_dict_int");
                 PyObject __underlyingPythonFunc = this.__func_test_dict_str_dict_int;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -136,7 +136,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_mapping");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_mapping");
                 PyObject __underlyingPythonFunc = this.__func_test_mapping;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
@@ -43,17 +43,17 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_raise_python_exception;
         private PyObject __func_test_nested_python_exception;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_raise_python_exception = module.GetAttr("test_raise_python_exception");
                 this.__func_test_nested_python_exception = module.GetAttr("test_nested_python_exception");
@@ -62,7 +62,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -77,7 +77,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_raise_python_exception.Dispose();
             this.__func_test_nested_python_exception.Dispose();
             module.Dispose();
@@ -87,7 +87,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_raise_python_exception");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_raise_python_exception");
                 PyObject __underlyingPythonFunc = this.__func_test_raise_python_exception;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
@@ -99,7 +99,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_nested_python_exception");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_nested_python_exception");
                 PyObject __underlyingPythonFunc = this.__func_test_nested_python_exception;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
@@ -43,7 +43,7 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_str_actually_returns_int;
         private PyObject __func_test_str_actually_returns_float;
@@ -58,12 +58,12 @@ public static class TestClassExtensions
         private PyObject __func_test_int_returns_str;
         private PyObject __func_test_int_overflows;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_str_actually_returns_int = module.GetAttr("test_str_actually_returns_int");
                 this.__func_test_str_actually_returns_float = module.GetAttr("test_str_actually_returns_float");
@@ -82,7 +82,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -117,7 +117,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_str_actually_returns_int.Dispose();
             this.__func_test_str_actually_returns_float.Dispose();
             this.__func_test_str_actually_returns_list.Dispose();
@@ -137,7 +137,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_int");
                 PyObject __underlyingPythonFunc = this.__func_test_str_actually_returns_int;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
@@ -149,7 +149,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_float");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_float");
                 PyObject __underlyingPythonFunc = this.__func_test_str_actually_returns_float;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
@@ -161,7 +161,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_list");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_list");
                 PyObject __underlyingPythonFunc = this.__func_test_str_actually_returns_list;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
@@ -173,7 +173,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_tuple");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_str_actually_returns_tuple");
                 PyObject __underlyingPythonFunc = this.__func_test_str_actually_returns_tuple;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
@@ -185,7 +185,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_tuple_actually_returns_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_tuple_actually_returns_int");
                 PyObject __underlyingPythonFunc = this.__func_test_tuple_actually_returns_int;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<(long, long), global::CSnakes.Runtime.Python.PyObjectImporters.Tuple<long, long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>>();
@@ -197,7 +197,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_tuple_actually_returns_float");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_tuple_actually_returns_float");
                 PyObject __underlyingPythonFunc = this.__func_test_tuple_actually_returns_float;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<(double, double), global::CSnakes.Runtime.Python.PyObjectImporters.Tuple<double, double, global::CSnakes.Runtime.Python.PyObjectImporters.Double, global::CSnakes.Runtime.Python.PyObjectImporters.Double>>();
@@ -209,7 +209,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_tuple_actually_returns_list");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_tuple_actually_returns_list");
                 PyObject __underlyingPythonFunc = this.__func_test_tuple_actually_returns_list;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<(IReadOnlyList<long>, IReadOnlyList<long>), global::CSnakes.Runtime.Python.PyObjectImporters.Tuple<IReadOnlyList<long>, IReadOnlyList<long>, global::CSnakes.Runtime.Python.PyObjectImporters.List<long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>, global::CSnakes.Runtime.Python.PyObjectImporters.List<long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>>>();
@@ -221,7 +221,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float_returns_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float_returns_int");
                 PyObject __underlyingPythonFunc = this.__func_test_float_returns_int;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<double, global::CSnakes.Runtime.Python.PyObjectImporters.Double>();
@@ -233,7 +233,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_float_returns_str");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_float_returns_str");
                 PyObject __underlyingPythonFunc = this.__func_test_float_returns_str;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<double, global::CSnakes.Runtime.Python.PyObjectImporters.Double>();
@@ -245,7 +245,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int_returns_float");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int_returns_float");
                 PyObject __underlyingPythonFunc = this.__func_test_int_returns_float;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>();
@@ -257,7 +257,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int_returns_str");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int_returns_str");
                 PyObject __underlyingPythonFunc = this.__func_test_int_returns_str;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>();
@@ -269,7 +269,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int_overflows");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int_overflows");
                 PyObject __underlyingPythonFunc = this.__func_test_int_overflows;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>();

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
@@ -43,18 +43,18 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_example_generator;
         private PyObject __func_test_normal_generator;
         private PyObject __func_test_generator_sequence;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_example_generator = module.GetAttr("example_generator");
                 this.__func_test_normal_generator = module.GetAttr("test_normal_generator");
@@ -64,7 +64,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -81,7 +81,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_example_generator.Dispose();
             this.__func_test_normal_generator.Dispose();
             this.__func_test_generator_sequence.Dispose();
@@ -92,7 +92,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "example_generator");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "example_generator");
                 PyObject __underlyingPythonFunc = this.__func_example_generator;
                 using PyObject length_pyObject = PyObject.From(length)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(length_pyObject);
@@ -105,7 +105,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_normal_generator");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_normal_generator");
                 PyObject __underlyingPythonFunc = this.__func_test_normal_generator;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
@@ -117,7 +117,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_generator_sequence");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_generator_sequence");
                 PyObject __underlyingPythonFunc = this.__func_test_generator_sequence;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
@@ -43,17 +43,17 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_keyword_only;
         private PyObject __func_test_named_keyword_only;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_keyword_only = module.GetAttr("test_keyword_only");
                 this.__func_test_named_keyword_only = module.GetAttr("test_named_keyword_only");
@@ -62,7 +62,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -77,7 +77,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_keyword_only.Dispose();
             this.__func_test_named_keyword_only.Dispose();
             module.Dispose();
@@ -87,7 +87,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_keyword_only");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_keyword_only");
                 PyObject __underlyingPythonFunc = this.__func_test_keyword_only;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
@@ -100,7 +100,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_named_keyword_only");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_named_keyword_only");
                 PyObject __underlyingPythonFunc = this.__func_test_named_keyword_only;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
@@ -43,17 +43,17 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_returns_none;
         private PyObject __func_test_none_result;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_returns_none = module.GetAttr("returns_none");
                 this.__func_test_none_result = module.GetAttr("test_none_result");
@@ -62,7 +62,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -77,7 +77,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_returns_none.Dispose();
             this.__func_test_none_result.Dispose();
             module.Dispose();
@@ -87,7 +87,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "returns_none");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "returns_none");
                 PyObject __underlyingPythonFunc = this.__func_returns_none;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 return __result_pyObject;
@@ -98,7 +98,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_none_result");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_none_result");
                 PyObject __underlyingPythonFunc = this.__func_test_none_result;
                 using PyObject arg_pyObject = PyObject.From(arg)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(arg_pyObject);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
@@ -43,18 +43,18 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_int;
         private PyObject __func_test_str;
         private PyObject __func_test_any;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_int = module.GetAttr("test_int");
                 this.__func_test_str = module.GetAttr("test_str");
@@ -64,7 +64,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -81,7 +81,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_int.Dispose();
             this.__func_test_str.Dispose();
             this.__func_test_any.Dispose();
@@ -92,7 +92,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_int");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_int");
                 PyObject __underlyingPythonFunc = this.__func_test_int;
                 using PyObject n_pyObject = PyObject.From(n)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(n_pyObject);
@@ -107,7 +107,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_str");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_str");
                 PyObject __underlyingPythonFunc = this.__func_test_str;
                 using PyObject s_pyObject = PyObject.From(s)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(s_pyObject);
@@ -122,7 +122,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_any");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_any");
                 PyObject __underlyingPythonFunc = this.__func_test_any;
                 using PyObject obj_pyObject = PyObject.From(obj)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(obj_pyObject);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
@@ -43,16 +43,16 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_pybind11_function;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_pybind11_function = module.GetAttr("test_pybind11_function");
             }
@@ -60,7 +60,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -73,7 +73,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_pybind11_function.Dispose();
             module.Dispose();
         }
@@ -82,7 +82,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_pybind11_function");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_pybind11_function");
                 PyObject __underlyingPythonFunc = this.__func_test_pybind11_function;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<bool, global::CSnakes.Runtime.Python.PyObjectImporters.Boolean>();

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
@@ -43,17 +43,17 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_number;
         private PyObject __func_reload_module;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_number = module.GetAttr("test_number");
                 this.__func_reload_module = module.GetAttr("reload_module");
@@ -62,7 +62,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -77,7 +77,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_number.Dispose();
             this.__func_reload_module.Dispose();
             module.Dispose();
@@ -87,7 +87,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_number");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_number");
                 PyObject __underlyingPythonFunc = this.__func_test_number;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>();
@@ -99,7 +99,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "reload_module");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "reload_module");
                 PyObject __underlyingPythonFunc = this.__func_reload_module;
                 PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 return __result_pyObject;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
@@ -43,16 +43,16 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_switch;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_switch = module.GetAttr("switch");
             }
@@ -60,7 +60,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -73,7 +73,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_switch.Dispose();
             module.Dispose();
         }
@@ -82,7 +82,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "switch");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "switch");
                 PyObject __underlyingPythonFunc = this.__func_switch;
                 using PyObject @new_pyObject = PyObject.From(@new)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(@new_pyObject);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
@@ -43,17 +43,17 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_sys_executable;
         private PyObject __func_test_sys_path;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_test_sys_executable = module.GetAttr("test_sys_executable");
                 this.__func_test_sys_path = module.GetAttr("test_sys_path");
@@ -62,7 +62,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -77,7 +77,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_sys_executable.Dispose();
             this.__func_test_sys_path.Dispose();
             module.Dispose();
@@ -87,7 +87,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_sys_executable");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_sys_executable");
                 PyObject __underlyingPythonFunc = this.__func_test_sys_executable;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
@@ -99,7 +99,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "test_sys_path");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_sys_path");
                 PyObject __underlyingPythonFunc = this.__func_test_sys_path;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
@@ -43,7 +43,7 @@ public static class TestClassExtensions
     private class TestClassInternal : ITestClass
     {
         private PyObject module;
-        private readonly ILogger<IPythonEnvironment> logger;
+        private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_tuple_1;
         private PyObject __func_tuple_2;
@@ -63,12 +63,12 @@ public static class TestClassExtensions
         private PyObject __func_tuple_16;
         private PyObject __func_tuple_17;
 
-        internal TestClassInternal(ILogger<IPythonEnvironment> logger)
+        internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
             this.logger = logger;
             using (GIL.Acquire())
             {
-                logger.LogDebug("Importing module {ModuleName}", "test");
+                logger?.LogDebug("Importing module {ModuleName}", "test");
                 module = Import.ImportModule("test");
                 this.__func_tuple_1 = module.GetAttr("tuple_1");
                 this.__func_tuple_2 = module.GetAttr("tuple_2");
@@ -92,7 +92,7 @@ public static class TestClassExtensions
 
         void IReloadableModuleImport.ReloadModule()
         {
-            logger.LogDebug("Reloading module {ModuleName}", "test");
+            logger?.LogDebug("Reloading module {ModuleName}", "test");
             using (GIL.Acquire())
             {
                 Import.ReloadModule(ref module);
@@ -137,7 +137,7 @@ public static class TestClassExtensions
 
         public void Dispose()
         {
-            logger.LogDebug("Disposing module {ModuleName}", "test");
+            logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_tuple_1.Dispose();
             this.__func_tuple_2.Dispose();
             this.__func_tuple_3.Dispose();
@@ -162,7 +162,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_1");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_1");
                 PyObject __underlyingPythonFunc = this.__func_tuple_1;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -175,7 +175,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_2");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_2");
                 PyObject __underlyingPythonFunc = this.__func_tuple_2;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -188,7 +188,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_3");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_3");
                 PyObject __underlyingPythonFunc = this.__func_tuple_3;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -201,7 +201,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_4");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_4");
                 PyObject __underlyingPythonFunc = this.__func_tuple_4;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -214,7 +214,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_5");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_5");
                 PyObject __underlyingPythonFunc = this.__func_tuple_5;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -227,7 +227,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_6");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_6");
                 PyObject __underlyingPythonFunc = this.__func_tuple_6;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -240,7 +240,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_7");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_7");
                 PyObject __underlyingPythonFunc = this.__func_tuple_7;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -253,7 +253,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_8");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_8");
                 PyObject __underlyingPythonFunc = this.__func_tuple_8;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -266,7 +266,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_9");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_9");
                 PyObject __underlyingPythonFunc = this.__func_tuple_9;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -279,7 +279,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_10");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_10");
                 PyObject __underlyingPythonFunc = this.__func_tuple_10;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -292,7 +292,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_11");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_11");
                 PyObject __underlyingPythonFunc = this.__func_tuple_11;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -305,7 +305,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_12");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_12");
                 PyObject __underlyingPythonFunc = this.__func_tuple_12;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -318,7 +318,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_13");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_13");
                 PyObject __underlyingPythonFunc = this.__func_tuple_13;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -331,7 +331,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_14");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_14");
                 PyObject __underlyingPythonFunc = this.__func_tuple_14;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -344,7 +344,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_15");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_15");
                 PyObject __underlyingPythonFunc = this.__func_tuple_15;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -357,7 +357,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_16");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_16");
                 PyObject __underlyingPythonFunc = this.__func_tuple_16;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
@@ -370,7 +370,7 @@ public static class TestClassExtensions
         {
             using (GIL.Acquire())
             {
-                logger.LogDebug("Invoking Python function: {FunctionName}", "tuple_17");
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "tuple_17");
                 PyObject __underlyingPythonFunc = this.__func_tuple_17;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);


### PR DESCRIPTION
This PR makes all loggers & logging optional:

- All `ILogger` instances across the codebase are made nullable.
- Logging calls are updated to handle `null` gracefully via the null-conditional operator (`?.`)
- Logging services are no longer required ([`GetRequiredService`] calls replaced with [`GetService`] where the requested service is a logger)

There are 3 reasons for this change:

- Logging should be optional
- Application should not break (via `GetRequiredService`) if logging isn't available as a service
- Logging should not incur any cost if no logger is given or available.

[`GetRequiredService`]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.getrequiredservice?view=net-9.0-pp
[`GetService`]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.getservice?view=net-9.0-pp
