### PR TITLE
Fix memory leak in `PythonRunString`

### DIFF
--- a/src/CSnakes.Runtime/CPython/Run.cs
+++ b/src/CSnakes.Runtime/CPython/Run.cs
@@ -1,5 +1,6 @@
 using CSnakes.Runtime.Python;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace CSnakes.Runtime.CPython;
 
@@ -14,6 +15,6 @@ internal unsafe partial class CPythonAPI
 
     internal static PyObject PyRun_String(string str, InputType start, PyObject globals, PyObject locals) => PyObject.Create(PyRun_String_(str, start, globals, locals));
 
-    [LibraryImport(PythonLibraryName, EntryPoint = "PyRun_String", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(NonFreeUtf8StringMarshaller))]
+    [LibraryImport(PythonLibraryName, EntryPoint = "PyRun_String", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Utf8StringMarshaller))]
     private static partial nint PyRun_String_(string str, InputType start, PyObject globals, PyObject locals);
 }


### PR DESCRIPTION
This PR fixes memory leaks in `PythonRunString` or anytime Python code strings are compiled for evaluation or execution (#290) . It adds to addressing #452.

The following code was used to prove the memory leak:

```diff
diff --git a/src/CSnakes.Runtime.Tests/Python/RunTests.cs b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
index 99d986f..c07dd9e 100644
--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -1,4 +1,5 @@
 using CSnakes.Runtime.Python;
+using System.Diagnostics;
 
 namespace CSnakes.Runtime.Tests.Python;
 public class RunTests : RuntimeTestBase
@@ -10,6 +11,23 @@ public class RunTests : RuntimeTestBase
         Assert.Equal("2", result.ToString());
     }
 
+    [Fact]
+    public void TestMemoryLeak()
+    {
+        var stars = $"'{new string('*', 1_000_000)}'";
+        using var process = Process.GetCurrentProcess();
+        var privateMemorySize64 = process.PrivateMemorySize64;
+        for (var i = 0; i < 1_000; i++)
+        {
+            using var result = env.ExecuteExpression(stars);
+            Assert.Equal(stars[1..^1], result.ToString());
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        process.Refresh();
+        var privateMemorySize64Delta = process.PrivateMemorySize64 - privateMemorySize64;
+    }
+
     [Fact]
     public void TestBadString()
     {
```

When run against `main` at db3ec2a1dd3bbfaa702f514e852bd864117b02db, one can see the process memory grow to almost 1 GB during the run of the test, with GC runs (yellow/amber zones) having no affect:

![Screenshot 2025-05-08 082758](https://github.com/user-attachments/assets/a11fe308-5c2c-4d65-a040-d1759435cfc9)

After the fix, the memory usage stays flat at around 68 MB and GC appears to be doing its job by taking out the trash:

![Screenshot 2025-05-08 082857](https://github.com/user-attachments/assets/639d5a52-2163-4b75-bf5a-5ebacc2505fb)

The values of `privateMemorySize64` and `privateMemorySize64Delta` from the test code were as follows:

| When        | `privateMemorySize64` | `privateMemorySize64Delta` |
| ----------- | --------------------: | -------------------------: |
| [Before PR] |            45,215,744 |              1,017,405,440 |
| After PR    |            45,547,520 |                  9,117,696 |

[Before PR]: https://github.com/tonybaloney/CSnakes/commit/db3ec2a1dd3bbfaa702f514e852bd864117b02db