### PR TITLE
Use by-ref initialisation of `Py_buffer`

### DIFF
--- a/src/CSnakes.Runtime/CPython/Buffer.cs
+++ b/src/CSnakes.Runtime/CPython/Buffer.cs
@@ -35,14 +35,12 @@ internal unsafe partial class CPythonAPI
 
     public static bool IsBuffer(PyObject p) => PyObject_CheckBuffer(p) == 1;
 
-    internal static Py_buffer GetBuffer(PyObject p)
+    internal static void GetBuffer(PyObject p, out Py_buffer buffer)
     {
-        Py_buffer view = default;
-        if (PyObject_GetBuffer(p, &view, (int)(PyBUF.Format | PyBUF.CContiguous)) != 0)
+        if (PyObject_GetBuffer(p, out buffer, (int)(PyBUF.Format | PyBUF.CContiguous)) != 0)
         {
             throw PyObject.ThrowPythonExceptionAsClrException();
         }
-        return view;
     }
 
     internal static void ReleaseBuffer(Py_buffer view) => PyBuffer_Release(&view);
@@ -51,7 +49,7 @@ internal unsafe partial class CPythonAPI
     private static partial int PyObject_CheckBuffer(PyObject ob);
 
     [LibraryImport(PythonLibraryName)]
-    private static partial int PyObject_GetBuffer(PyObject ob, Py_buffer* view, int flags);
+    private static partial int PyObject_GetBuffer(PyObject ob, out Py_buffer view, int flags);
 
     [LibraryImport(PythonLibraryName)]
     private static partial void PyBuffer_Release(Py_buffer* view);

--- a/src/CSnakes.Runtime/Python/PyBuffer.cs
+++ b/src/CSnakes.Runtime/Python/PyBuffer.cs
@@ -51,7 +51,7 @@ internal sealed class PyBuffer : IPyBuffer, IDisposable
     {
         using (GIL.Acquire())
         {
-            _buffer = CPythonAPI.GetBuffer(exporter);
+            CPythonAPI.GetBuffer(exporter, out _buffer);
         }
         _disposed = false;
         _isScalar = _buffer.ndim == 0 || _buffer.ndim == 1;


### PR DESCRIPTION
This PR optimizes the buffer initialisation by replacing the by-value buffer creation with a more efficient by-reference approach. It significantly reduces assembly instructions and improves performance.

## Design Changes

The primary design change converts the buffer handling from a return-value pattern to an out-parameter pattern:

1. Modified `GetBuffer` method signature from returning a `Py_buffer` to using an `out` parameter
2. Changed the P/Invoke signature of `PyObject_GetBuffer` to use `out` parameter instead of a pointer
3. Updated the caller in `PyBuffer.cs` to use the new pattern

This shift from by-value to by-reference parameter handling eliminates unnecessary memory operations and structure copying.

Before the changes, the `GetBuffer` method would:

1. Create a local `Py_buffer` on the stack
2. Pass its address to the native function
3. Return the structure by value, _causing a full copy of the structure_

This resulted in excessive assembly code that performed multiple vector moves to copy the structure:

```asm
; ...omitted for brevity
mov         rax,qword ptr [rbp+10h]  
vmovdqu     ymm0,ymmword ptr [rbp-50h]  
vmovdqu     ymmword ptr [rax],ymm0  
vmovdqu     ymm0,ymmword ptr [rbp-30h]  
vmovdqu     ymmword ptr [rax+20h],ymm0  
vmovdqu     xmm0,xmmword ptr [rbp-10h]  
vmovdqu     xmmword ptr [rax+40h],xmm0  
mov         rax,qword ptr [rbp+10h]  
vzeroupper  
add         rsp,80h  
pop         rbp  
ret  
```

With the updated approach:

- The `GetBuffer` method now takes an `out` parameter for the buffer
- The P/Invoke signature directly uses the `out` parameter

The resulting assembly code is dramatically simplified, removing all vector move operations:

```asm
; ...omitted for brevity
add         rsp,38h  
pop         rdi  
pop         rbp  
ret  
```

## Compatibility

All existing buffer tests continue to pass with the new implementation, confirming that the behavioral semantics remain unchanged despite the optimization.
