### PR TITLE
Use by-ref release of `Py_buffer`

### DIFF
--- a/src/CSnakes.Runtime/CPython/Buffer.cs
+++ b/src/CSnakes.Runtime/CPython/Buffer.cs
@@ -45,7 +45,7 @@ internal unsafe partial class CPythonAPI
         return view;
     }
 
-    internal static void ReleaseBuffer(Py_buffer view) => PyBuffer_Release(&view);
+    internal static void ReleaseBuffer(ref Py_buffer view) => PyBuffer_Release(ref view);
 
     [LibraryImport(PythonLibraryName)]
     private static partial int PyObject_CheckBuffer(PyObject ob);
@@ -54,5 +54,5 @@ internal unsafe partial class CPythonAPI
     private static partial int PyObject_GetBuffer(PyObject ob, Py_buffer* view, int flags);
 
     [LibraryImport(PythonLibraryName)]
-    private static partial void PyBuffer_Release(Py_buffer* view);
+    private static partial void PyBuffer_Release(ref Py_buffer view);
 }

--- a/src/CSnakes.Runtime/Python/PyBuffer.cs
+++ b/src/CSnakes.Runtime/Python/PyBuffer.cs
@@ -9,7 +9,7 @@ using System.Numerics.Tensors;
 namespace CSnakes.Runtime.Python;
 internal sealed class PyBuffer : IPyBuffer, IDisposable
 {
-    private readonly CPythonAPI.Py_buffer _buffer;
+    private CPythonAPI.Py_buffer _buffer;
     private bool _disposed;
     private readonly bool _isScalar;
     private readonly string _format;
@@ -65,7 +65,7 @@ internal sealed class PyBuffer : IPyBuffer, IDisposable
         {
             using (GIL.Acquire())
             {
-                CPythonAPI.ReleaseBuffer(_buffer);
+                CPythonAPI.ReleaseBuffer(ref _buffer);
             }
             _disposed = true;
         }


### PR DESCRIPTION
This PR is in the same spirit as PR #466. It avoids copies of `Py_buffer` by passing it by-reference for release. It therefore modifies the original field in `PyBuffer`, which is now correctly defined as mutable. It also means that `PyBuffer` can see the changes that CPython makes to `Py_buffer`, like setting the [`obj`](https://docs.python.org/3/c-api/buffer.html#c.Py_buffer.obj) field to a null pointer (which could be used to detect the disposed state in a future update):

<img width="524" alt="image" src="https://github.com/user-attachments/assets/d98ef822-034c-472c-8e3a-e549620d2c21" />

