### PR TITLE
Make `PyBuffer` constructor safe

### DIFF
--- a/src/CSnakes.Runtime/CPython/Buffer.cs
+++ b/src/CSnakes.Runtime/CPython/Buffer.cs
@@ -26,7 +26,7 @@ internal unsafe partial class CPythonAPI
         public nint itemsize;
         public int @readonly;
         public int ndim;
-        public byte* format;
+        public nint format;
         public nint* shape;
         public nint* strides;
         public nint* suboffsets;

--- a/src/CSnakes.Runtime/Python/PyBuffer.cs
+++ b/src/CSnakes.Runtime/Python/PyBuffer.cs
@@ -47,7 +47,7 @@ internal sealed class PyBuffer : IPyBuffer, IDisposable
         SSizeT = 'N', // C ssize_t
     }
 
-    public unsafe PyBuffer(PyObject exporter)
+    public PyBuffer(PyObject exporter)
     {
         using (GIL.Acquire())
         {
@@ -55,7 +55,7 @@ internal sealed class PyBuffer : IPyBuffer, IDisposable
         }
         _disposed = false;
         _isScalar = _buffer.ndim == 0 || _buffer.ndim == 1;
-        _format = Utf8StringMarshaller.ConvertToManaged(_buffer.format) ?? string.Empty;
+        _format = Marshal.PtrToStringUTF8(_buffer.format) ?? string.Empty;
         _byteOrder = GetByteOrder();
     }
 


### PR DESCRIPTION
This PR removes the need to mark the `PyBuffer` constructor as unsafe.