### PR TITLE
Fix leaks by making `IPyBuffer` disposable

### DIFF
--- a/src/CSnakes.Runtime/Python/IPyBuffer.cs
+++ b/src/CSnakes.Runtime/Python/IPyBuffer.cs
@@ -4,7 +4,7 @@ using System.Numerics.Tensors;
 #endif
 
 namespace CSnakes.Runtime.Python;
-public interface IPyBuffer
+public interface IPyBuffer : IDisposable
 {
     /// <summary>
     /// The bit length of the buffer.

--- a/src/CSnakes.Runtime/Python/PyBuffer.cs
+++ b/src/CSnakes.Runtime/Python/PyBuffer.cs
@@ -7,7 +7,7 @@ using System.Numerics.Tensors;
 #endif
 
 namespace CSnakes.Runtime.Python;
-internal sealed class PyBuffer : IPyBuffer, IDisposable
+internal sealed class PyBuffer : IPyBuffer
 {
     private CPythonAPI.Py_buffer _buffer;
     private bool _disposed;

--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -12,7 +12,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestBoolBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestBoolBuffer();
+        using var bufferObject = testModule.TestBoolBuffer();
         Assert.Equal(5, bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
 
@@ -27,7 +27,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt8Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt8Buffer();
+        using var bufferObject = testModule.TestInt8Buffer();
         Assert.Equal(5 * sizeof(sbyte), bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
 
@@ -42,7 +42,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt8Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint8Buffer();
+        using var bufferObject = testModule.TestUint8Buffer();
         Assert.Equal(5 * sizeof(byte), bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
 
@@ -57,7 +57,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt16Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt16Buffer();
+        using var bufferObject = testModule.TestInt16Buffer();
         Assert.Equal(5 * sizeof(short), bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
 
@@ -72,7 +72,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt16Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint16Buffer();
+        using var bufferObject = testModule.TestUint16Buffer();
         Assert.Equal(5 * sizeof(ushort), bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
 
@@ -87,7 +87,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt32Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt32Buffer();
+        using var bufferObject = testModule.TestInt32Buffer();
         Assert.Equal(20, bufferObject.Length); // 5 * sizeof(int)
         Assert.True(bufferObject.IsScalar);
 
@@ -102,7 +102,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt32Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint32Buffer();
+        using var bufferObject = testModule.TestUint32Buffer();
         Assert.Equal(20, bufferObject.Length); // 5 * sizeof(int)
         Assert.True(bufferObject.IsScalar);
 
@@ -117,7 +117,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt64Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt64Buffer();
+        using var bufferObject = testModule.TestInt64Buffer();
         Assert.Equal(sizeof(long) * 5, bufferObject.Length); // 5 * sizeof(int)
         Assert.True(bufferObject.IsScalar);
 
@@ -132,7 +132,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt64Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint64Buffer();
+        using var bufferObject = testModule.TestUint64Buffer();
         Assert.Equal(sizeof(long) * 5, bufferObject.Length); // 5 * sizeof(int)
         Assert.True(bufferObject.IsScalar);
 
@@ -147,7 +147,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestFloat32Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestFloat32Buffer();
+        using var bufferObject = testModule.TestFloat32Buffer();
         Assert.Equal(20, bufferObject.Length); // 5 * sizeof(int)
         Assert.True(bufferObject.IsScalar);
 
@@ -162,7 +162,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestFloat64Buffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestFloat64Buffer();
+        using var bufferObject = testModule.TestFloat64Buffer();
         Assert.Equal(sizeof(double) * 5, bufferObject.Length); // 5 * sizeof(int)
         Assert.True(bufferObject.IsScalar);
 
@@ -177,7 +177,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestBufferLargeFloatScalar()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestVectorBuffer();
+        using var bufferObject = testModule.TestVectorBuffer();
         Assert.Equal(1532 * sizeof(float), bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
 
@@ -191,7 +191,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt8MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt82dBuffer();
+        using var bufferObject = testModule.TestInt82dBuffer();
         Assert.Equal(sizeof(sbyte) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsSByteSpan2D();
@@ -204,7 +204,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt8MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint82dBuffer();
+        using var bufferObject = testModule.TestUint82dBuffer();
         Assert.Equal(sizeof(byte) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsByteSpan2D();
@@ -217,7 +217,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt16MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt162dBuffer();
+        using var bufferObject = testModule.TestInt162dBuffer();
         Assert.Equal(sizeof(short) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsInt16Span2D();
@@ -230,7 +230,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt16MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint162dBuffer();
+        using var bufferObject = testModule.TestUint162dBuffer();
         Assert.Equal(sizeof(ushort) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsUInt16Span2D();
@@ -243,7 +243,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt32MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt322dBuffer();
+        using var bufferObject = testModule.TestInt322dBuffer();
         Assert.Equal(sizeof(int) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsInt32Span2D();
@@ -256,7 +256,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt32MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint322dBuffer();
+        using var bufferObject = testModule.TestUint322dBuffer();
         Assert.Equal(sizeof(uint) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsUInt32Span2D();
@@ -269,7 +269,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestInt64MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestInt642dBuffer();
+        using var bufferObject = testModule.TestInt642dBuffer();
         Assert.Equal(sizeof(long) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsInt64Span2D();
@@ -282,7 +282,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestUInt64MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestUint642dBuffer();
+        using var bufferObject = testModule.TestUint642dBuffer();
         Assert.Equal(sizeof(ulong) * 3, 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsUInt64Span2D();
@@ -295,7 +295,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestFloat32MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestFloat322dBuffer();
+        using var bufferObject = testModule.TestFloat322dBuffer();
         Assert.Equal(sizeof(float) * 2 * 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsFloatSpan2D();
@@ -308,7 +308,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestFloat64MatrixBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestFloat642dBuffer();
+        using var bufferObject = testModule.TestFloat642dBuffer();
         Assert.Equal(sizeof(double) * 2 * 3, bufferObject.Length);
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsDoubleSpan2D();
@@ -321,7 +321,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestModificationViaSpan()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestGlobalBuffer();
+        using var bufferObject = testModule.TestGlobalBuffer();
         Assert.Equal(2, bufferObject.Dimensions);
         var matrix = bufferObject.AsInt32Span2D();
         Assert.Equal(0, matrix[0, 0]);
@@ -329,7 +329,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
         matrix[0, 0] = 42;
 
         // Fetch the object again
-        var bufferObject2 = testModule.TestGlobalBuffer();
+        using var bufferObject2 = testModule.TestGlobalBuffer();
         var matrix2 = bufferObject2.AsInt32Span2D();
         Assert.Equal(42, matrix2[0, 0]);
     }
@@ -338,7 +338,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestBytesAsBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestBytesAsBuffer();
+        using var bufferObject = testModule.TestBytesAsBuffer();
         Assert.Equal(5, bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
         var result = bufferObject.AsByteReadOnlySpan();
@@ -351,7 +351,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestByteArrayAsBuffer()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestBytearrayAsBuffer();
+        using var bufferObject = testModule.TestBytearrayAsBuffer();
         Assert.Equal(5, bufferObject.Length);
         Assert.True(bufferObject.IsScalar);
         var result = bufferObject.AsByteSpan();
@@ -371,7 +371,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestNonContiguousBuffer()
     {
         var testModule = Env.TestBuffer();
-        var array = testModule.TestNonContiguousBuffer();
+        using var array = testModule.TestNonContiguousBuffer();
         Assert.Equal(sizeof(int) * 3, array.Length);
         var result = array.AsInt32Span2D();
         Assert.Equal(typeof(int), array.GetItemType());
@@ -392,7 +392,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     {
         var testModule = Env.TestBuffer();
         List<Int32> list = new() { 1, 2, 3, 4, 5 };
-        var bufferGenerator = testModule.SumOf2dArray(5);
+        using var bufferGenerator = testModule.SumOf2dArray(5);
         bufferGenerator.MoveNext();
         var bufferObject = bufferGenerator.Current;
 
@@ -420,7 +420,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestNDim3Tensor()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestNdim3dBuffer();
+        using var bufferObject = testModule.TestNdim3dBuffer();
         Assert.Equal(3, bufferObject.Dimensions);
         var tensor = bufferObject.AsTensorSpan<int>();
         Assert.Equal(typeof(int), bufferObject.GetItemType());
@@ -431,7 +431,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     [Fact]
     public void TestNDim4Tensor(){
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestNdim4dBuffer();
+        using var bufferObject = testModule.TestNdim4dBuffer();
         Assert.Equal(4, bufferObject.Dimensions);
         var tensor = bufferObject.AsTensorSpan<int>();
         Assert.Equal(typeof(int), bufferObject.GetItemType());
@@ -443,7 +443,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestNDim3ReadOnlyTensor()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestNdim3dBuffer();
+        using var bufferObject = testModule.TestNdim3dBuffer();
         Assert.Equal(3, bufferObject.Dimensions);
         var tensor = bufferObject.AsReadOnlyTensorSpan<int>();
         Assert.Equal(typeof(int), bufferObject.GetItemType());
@@ -455,7 +455,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestNDim4ReadOnlyTensor()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestNdim4dBuffer();
+        using var bufferObject = testModule.TestNdim4dBuffer();
         Assert.Equal(4, bufferObject.Dimensions);
         var tensor = bufferObject.AsInt32ReadOnlyTensorSpan();
         Assert.Equal(typeof(int), bufferObject.GetItemType());


### PR DESCRIPTION
This PR fixes memory leaks from acquiring a buffer by making `IPyBuffer` inherit from `IDisposable`.

Up unit now, there was no way for user code to dispose an `IPyBuffer` object and so all memory backing a buffer leaks.

The leak can be observed with the following code:

```diff
diff --git a/src/Integration.Tests/BufferTests.cs b/src/Integration.Tests/BufferTests.cs
index 18cdbe4..795cc30 100644
--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -1,6 +1,7 @@
+using CSnakes.Runtime.Python;
 using System;
 using System.Collections.Generic;
-using CSnakes.Runtime.Python;
+using System.Diagnostics;
 using Xunit;
 
 namespace Integration.Tests;
@@ -177,14 +178,23 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
     public void TestBufferLargeFloatScalar()
     {
         var testModule = Env.TestBuffer();
-        var bufferObject = testModule.TestVectorBuffer();
-        Assert.Equal(1532 * sizeof(float), bufferObject.Length);
-        Assert.True(bufferObject.IsScalar);
-
-        // Check the buffer contents
-        Span<float> result = bufferObject.AsFloatSpan();
-        Assert.Equal(typeof(float), bufferObject.GetItemType());
-        Assert.Equal(1532, result.Length);
+        using var process = Process.GetCurrentProcess();
+        var privateMemorySize64 = process.PrivateMemorySize64;
+        for (var i = 0; i < 1_000_000; i++)
+        {
+            var bufferObject = testModule.TestVectorBuffer();
+            Assert.Equal(1532 * sizeof(float), bufferObject.Length);
+            Assert.True(bufferObject.IsScalar);
+
+            // Check the buffer contents
+            Span<float> result = bufferObject.AsFloatSpan();
+            Assert.Equal(typeof(float), bufferObject.GetItemType());
+            Assert.Equal(1532, result.Length);
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        process.Refresh();
+        var privateMemorySize64Delta = process.PrivateMemorySize64 - privateMemorySize64;
     }
 
     [Fact]
```

The memory growth can be observed in the debugger despite garbage collections (yellow/amber markers):

![Memory leak demo](https://github.com/user-attachments/assets/8050eb3b-0d21-4103-b232-b7b2b1734f81)

After this PR, if the leak test code above is changed to dispose the buffer:

```diff
diff --git a/src/Integration.Tests/BufferTests.cs b/src/Integration.Tests/BufferTests.cs
index 795cc30..cb4225a 100644
--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -182,7 +182,7 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
         var privateMemorySize64 = process.PrivateMemorySize64;
         for (var i = 0; i < 1_000_000; i++)
         {
-            var bufferObject = testModule.TestVectorBuffer();
+            using var bufferObject = testModule.TestVectorBuffer();
             Assert.Equal(1532 * sizeof(float), bufferObject.Length);
             Assert.True(bufferObject.IsScalar);
 
```

then the memory is recycled and consumption remains stable as expected:

![Memory leak fix](https://github.com/user-attachments/assets/cda7b6d6-f689-4afe-bb20-30eef438a06d)

A follow-up improvement would be to implement a finalizer so that the buffer is released even if `Dispose` isn't called explicitly.
