### PR TITLE
Change all spawned processes to use argument lists. Add `InstallPackage` to `IPythonPackageInstaller`

### DIFF
--- a/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
@@ -20,8 +20,8 @@ internal class VenvEnvironmentManagement(ILogger? logger, string path, bool ensu
         if (!Directory.Exists(path))
         {
             logger?.LogDebug("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
-            var (process1, _, _) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-VV");
-            var (process2, _, error) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, $"-m venv {fullPath}");
+            var (process1, _, _) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, "-VV");
+            var (process2, _, error) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, "-m", "venv",  fullPath);
 
             if (process1.ExitCode != 0 || process2.ExitCode != 0)
             {

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -17,7 +17,7 @@ internal class CondaLocator : PythonLocator
     {
         this.logger = logger;
         this.condaBinaryPath = condaBinaryPath;
-        var (process, result, errors) = ExecuteCondaCommand($"info --json");
+        var (process, result, errors) = ExecuteCondaCommand("info", "--json");
         if (process.ExitCode != 0)
         {
             logger?.LogError("Failed to determine Python version from Conda {Error}.", errors);
@@ -43,9 +43,9 @@ internal class CondaLocator : PythonLocator
         folder = basePrefix;
     }
 
-    internal (Process process, string? output, string? errors) ExecuteCondaCommand(string arguments) => ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
+    internal (Process process, string? output, string? errors) ExecuteCondaCommand(params string[] arguments) => ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
 
-    internal bool ExecuteCondaShellCommand(string arguments) => ProcessUtils.ExecuteShellCommand(logger, condaBinaryPath, arguments);
+    internal bool ExecuteCondaShellCommand(params string[] arguments) => ProcessUtils.ExecuteShellCommand(logger, condaBinaryPath, arguments);
 
     public override PythonLocationMetadata LocatePython() =>
         LocatePythonInternal(folder);

--- a/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
@@ -14,4 +14,13 @@ public interface IPythonPackageInstaller
     /// <param name="virtualEnvironmentLocation">The location of the virtual environment (optional).</param>
     /// <returns>A task representing the asynchronous package installation operation.</returns>
     Task InstallPackages(string home, IEnvironmentManagement? environmentManager);
+
+    /// <summary>
+    /// Install a single package.
+    /// </summary>
+    /// <param name="home"></param>
+    /// <param name="environmentManager"></param>
+    /// <param name="package"></param>
+    /// <returns></returns>
+    Task InstallPackage(string home, IEnvironmentManagement? environmentManager, string package);
 }

--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -14,7 +14,7 @@ internal class PipInstaller(ILogger<PipInstaller>? logger, string requirementsFi
         if (File.Exists(requirementsPath))
         {
             logger?.LogDebug("File {Requirements} was found.", requirementsPath);
-            InstallPackagesWithPip(home, environmentManager, $"-r {requirementsFileName}", logger);
+            InstallRequirementsTxtWithPip(home, environmentManager, requirementsFileName, logger);
         }
         else
         {
@@ -24,12 +24,26 @@ internal class PipInstaller(ILogger<PipInstaller>? logger, string requirementsFi
         return Task.CompletedTask;
     }
 
-    internal static void InstallPackagesWithPip(string home, IEnvironmentManagement? environmentManager, string requirements, ILogger? logger)
+    public Task InstallPackage(string home, IEnvironmentManagement? environmentManager, string package)
+    {
+        InstallPackageWithPip(home, environmentManager, package, logger);
+
+        return Task.CompletedTask;
+    }
+
+    static internal void InstallPackageWithPip(string home, IEnvironmentManagement? environmentManager, string requirement, ILogger? logger)
+        => RunPipInstall(home, environmentManager, [requirement], logger);
+
+    static internal void InstallRequirementsTxtWithPip(string home, IEnvironmentManagement? environmentManager, string requirementsFile, ILogger? logger)
+        => RunPipInstall(home, environmentManager, ["-r", requirementsFile], logger);
+
+
+    private static void RunPipInstall(string home, IEnvironmentManagement? environmentManager, string[] requirements, ILogger? logger)
     {
         string fileName = pipBinaryName;
         string workingDirectory = home;
         string path = "";
-        string arguments = $"install {requirements} --disable-pip-version-check";
+        string[] arguments = [ "install", .. requirements, "--disable-pip-version-check" ];
 
         if (environmentManager is not null)
         {

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -10,13 +10,9 @@ internal static class ProcessUtils
     internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger? logger, PythonLocationMetadata pythonLocation, params string[] arguments)
     {
 
-        ProcessStartInfo startInfo = new()
+        ProcessStartInfo startInfo = new(pythonLocation.PythonBinaryPath, arguments)
         {
             WorkingDirectory = pythonLocation.Folder,
-            FileName = pythonLocation.PythonBinaryPath,
-            ArgumentList = {
-                // TODO
-            },
             RedirectStandardError = true,
             RedirectStandardOutput = true,
             CreateNoWindow = true,
@@ -26,12 +22,8 @@ internal static class ProcessUtils
 
     internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger? logger, string fileName, params string[] arguments)
     {
-        ProcessStartInfo startInfo = new()
+        ProcessStartInfo startInfo = new(fileName, arguments)
         {
-            FileName = fileName,
-            ArgumentList = {
-                // TODO
-            },
             RedirectStandardError = true,
             RedirectStandardOutput = true,
             CreateNoWindow = true,
@@ -42,13 +34,8 @@ internal static class ProcessUtils
     internal static bool ExecuteShellCommand(ILogger? logger, string fileName, params string[] arguments)
     {
         logger?.LogDebug("Executing shell command {FileName} {Arguments}", fileName, arguments);
-        ProcessStartInfo startInfo = new()
+        ProcessStartInfo startInfo = new(fileName, arguments)
         {
-            FileName = fileName,
-            ArgumentList =
-            {
-                // TODO
-            },
             UseShellExecute = true,
             CreateNoWindow = true,
             WindowStyle = ProcessWindowStyle.Hidden,
@@ -90,15 +77,11 @@ internal static class ProcessUtils
         return (process, result, errors);
     }
 
-    internal static void ExecuteProcess(string fileName, string[] arguments, string workingDirectory, string path, ILogger? logger, IReadOnlyDictionary<string, string?>? extraEnv = null)
+    internal static void ExecuteProcess(string fileName, IEnumerable<string> arguments, string workingDirectory, string path, ILogger? logger, IReadOnlyDictionary<string, string?>? extraEnv = null)
     {
-        ProcessStartInfo startInfo = new()
+        ProcessStartInfo startInfo = new(fileName, arguments)
         {
             WorkingDirectory = workingDirectory,
-            FileName = fileName,
-            ArgumentList = {
-                // TODO
-            },
             CreateNoWindow = true,
         };
 

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -1,18 +1,22 @@
 using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.Logging;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 
 namespace CSnakes.Runtime;
 
 internal static class ProcessUtils
 {
-    internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger? logger, PythonLocationMetadata pythonLocation, string arguments)
+    internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger? logger, PythonLocationMetadata pythonLocation, params string[] arguments)
     {
+
         ProcessStartInfo startInfo = new()
         {
             WorkingDirectory = pythonLocation.Folder,
             FileName = pythonLocation.PythonBinaryPath,
-            Arguments = arguments,
+            ArgumentList = {
+                // TODO
+            },
             RedirectStandardError = true,
             RedirectStandardOutput = true,
             CreateNoWindow = true,
@@ -20,12 +24,14 @@ internal static class ProcessUtils
         return ExecuteCommand(logger, startInfo);
     }
 
-    internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger? logger, string fileName, string arguments)
+    internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger? logger, string fileName, params string[] arguments)
     {
         ProcessStartInfo startInfo = new()
         {
             FileName = fileName,
-            Arguments = arguments,
+            ArgumentList = {
+                // TODO
+            },
             RedirectStandardError = true,
             RedirectStandardOutput = true,
             CreateNoWindow = true,
@@ -33,13 +39,16 @@ internal static class ProcessUtils
         return ExecuteCommand(logger, startInfo);
     }
 
-    internal static bool ExecuteShellCommand(ILogger? logger, string fileName, string arguments)
+    internal static bool ExecuteShellCommand(ILogger? logger, string fileName, params string[] arguments)
     {
         logger?.LogDebug("Executing shell command {FileName} {Arguments}", fileName, arguments);
         ProcessStartInfo startInfo = new()
         {
             FileName = fileName,
-            Arguments = arguments,
+            ArgumentList =
+            {
+                // TODO
+            },
             UseShellExecute = true,
             CreateNoWindow = true,
             WindowStyle = ProcessWindowStyle.Hidden,
@@ -80,13 +89,16 @@ internal static class ProcessUtils
         process.WaitForExit();
         return (process, result, errors);
     }
-    internal static void ExecuteProcess(string fileName, string arguments, string workingDirectory, string path, ILogger? logger, IReadOnlyDictionary<string, string?>? extraEnv = null)
+
+    internal static void ExecuteProcess(string fileName, string[] arguments, string workingDirectory, string path, ILogger? logger, IReadOnlyDictionary<string, string?>? extraEnv = null)
     {
         ProcessStartInfo startInfo = new()
         {
             WorkingDirectory = workingDirectory,
             FileName = fileName,
-            Arguments = arguments,
+            ArgumentList = {
+                // TODO
+            },
             CreateNoWindow = true,
         };
 


### PR DESCRIPTION
This changes the ProcessUtils class to always use `ArgumentList` instead of `Arguments`.

This will reduce the risk of applications being vulnerable to shell injection, and it will also fix paths with spaces.

Fixes #465

This change also introduces another method to `IPythonPackageInstaller` called `InstallPackage` for installing a single package given a name. 