### PR TITLE
Run type checkers in CI

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -10,6 +10,22 @@ on:
     branches: ["main"]
 
 jobs:
+  validate-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        id: installpython
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Run pyright on test Python code
+        run: |
+          python -m pip install pyright
+          pyright src/*.Tests/**/*.py
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Run pyright on test Python code
         run: |
           python -m pip install pyright
+          python -m pip install -r src/Integration.Tests/python/requirements.txt
           pyright src/*.Tests/**/*.py
 
   build:

--- a/src/Integration.Tests/python/test_buffer.py
+++ b/src/Integration.Tests/python/test_buffer.py
@@ -86,7 +86,7 @@ def test_bytearray_as_buffer() -> Buffer:
     return bytearray(b"hello")
 
 def test_non_buffer() -> Buffer:
-    return "hello"
+    return "hello"  # type: ignore[return-value]
 
 def test_non_contiguous_buffer() -> Buffer:
     return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)[::2]

--- a/src/Integration.Tests/python/test_coroutines.py
+++ b/src/Integration.Tests/python/test_coroutines.py
@@ -2,7 +2,7 @@ from typing import Coroutine
 import asyncio
 
 
-async def test_coroutine(seconds: float = 0.1) -> Coroutine[int, None, None]:
+async def test_coroutine(seconds: float = 0.1) -> int:
     await asyncio.sleep(seconds)
     return 5
 
@@ -11,5 +11,5 @@ async def test_coroutine_raises_exception() -> Coroutine[int, None, None]:
     raise ValueError("This is a Python exception")
 
 
-async def test_coroutine_returns_nothing(seconds: float = 0.1) -> Coroutine[None, None, None]:
+async def test_coroutine_returns_nothing(seconds: float = 0.1) -> None:
     await asyncio.sleep(seconds)

--- a/src/Integration.Tests/python/test_dicts.py
+++ b/src/Integration.Tests/python/test_dicts.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import ItemsView, Iterator, Mapping
 
 def test_dict_str_int(a: dict[str, int]) -> dict[str, int]:
@@ -10,21 +9,21 @@ def test_dict_str_list_int(a: dict[str, list[int]]) -> dict[str, list[int]]:
 def test_dict_str_dict_int(a: dict[str, dict[str, int]]) -> dict[str, dict[str, int]]:
     return a
 
-class MyMappingType:
+class MyMappingType(Mapping[str, int]):
     def __init__(self, a):
         self.actual_dict = dict(a)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> int:
         return self.actual_dict[key]
 
-    def items(self) -> ItemsView:
-        return self.actual_dict.items()
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.actual_dict)
 
     def __len__(self) -> int:
-        return self.actual_dict.__len__()
+        return len(self.actual_dict)
 
-    def __iter__(self) -> Iterator:
-        return self.actual_dict.__iter__()
+    def items(self) -> ItemsView[str, int]:
+        return self.actual_dict.items()
 
 
 def test_mapping(a: Mapping[str, int]) -> Mapping[str, int]:

--- a/src/Integration.Tests/python/test_false_returns.py
+++ b/src/Integration.Tests/python/test_false_returns.py
@@ -1,35 +1,35 @@
 def test_str_actually_returns_int() -> str:
-    return 1
+    return 1  # type: ignore[return-value]
 
 def test_str_actually_returns_float() -> str:
-    return 1.0
+    return 1.0  # type: ignore[return-value]
 
 def test_str_actually_returns_list() -> str:
-    return [1, 2, 3]
+    return [1, 2, 3]  # type: ignore[return-value]
 
 def test_str_actually_returns_tuple() -> str:
-    return (1, 2, 3)
+    return (1, 2, 3)  # type: ignore[return-value]
 
 def test_tuple_actually_returns_int() -> tuple[int, int]:
-    return 1
+    return 1  # type: ignore[return-value]
 
 def test_tuple_actually_returns_float() -> tuple[float, float]:
-    return 1.0
+    return 1.0  # type: ignore[return-value]
 
 def test_tuple_actually_returns_list() -> tuple[list[int], list[int]]:
-    return [1, 2, 3]
+    return [1, 2, 3]  # type: ignore[return-value]
 
 def test_float_returns_int() -> float:
     return 1
 
 def test_float_returns_str() -> float:
-    return "1"
+    return "1"  # type: ignore[return-value]
 
 def test_int_returns_float() -> int:
-    return 1.0
+    return 1.0  # type: ignore[return-value]
 
 def test_int_returns_str() -> int:
-    return "1"
+    return "1"  # type: ignore[return-value]
 
 def test_int_overflows() -> int:
     return 2**64

--- a/src/Integration.Tests/python/test_pybind11.py
+++ b/src/Integration.Tests/python/test_pybind11.py
@@ -3,6 +3,6 @@ import pybind11_numpy_example as pne
 
 def test_pybind11_function() -> bool:
     n = 12
-    a = pne.vector_as_array(12)
+    a = pne.vector_as_array(12)  # type: ignore
     assert len(a) == n
     return True


### PR DESCRIPTION
Validate that the type annotations in our tests are actually correct.

Would have stopped #480 