### PR TITLE
Fix reload hashes in test snapshots

### DIFF
--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -24,7 +24,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "cabb6a0854c73088e04547b226cc6c79"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "2d5c6cef6c4434c2eff100860b982d7f"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
@@ -24,7 +24,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "8ea19c310b3c17facca0535bed6b4ec2"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "7f4ffa75d2d623a9f9a4b7eb71ae3c55"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
@@ -24,7 +24,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "f4b38aa4460ae1cf4b9b313e39886c85"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "844277a9031e4b4b7df402bd72b1b20d"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
@@ -24,7 +24,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "dd599dd46d004b81caef306dbd9dc329"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "957082c529003e202b09b8cb1995251f"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {


### PR DESCRIPTION
This PR fixes the reload hashes in test snapshots that were not updated as part of PR #480 and therefore was [breaking `main` branch build](https://github.com/tonybaloney/CSnakes/actions/runs/15388631928) (at commit 17fd40f166d2100469f93a73fb5ecdf0c77522ba).
