### PR TITLE
Enable simple runtime package installation

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run pyright on test Python code
         run: |
-          python -m pip install pyright
+          python -m pip install pyright attrs
           python -m pip install -r src/Integration.Tests/python/requirements.txt
           pyright src/*.Tests/**/*.py
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -76,3 +76,21 @@ Some other important notes about this implementation.
 - Must be used with `WithVirtualEnvironment()`, as pip requires a virtual environment to install packages into.
 - Will use the `UV_CACHE_DIR` environment variable to cache the packages in a directory if set.
 - Will disable the cache if the `UV_NO_CACHE` environment variable is set.
+
+## Installing a single package
+
+You can resolve the `IPythonPackageInstaller` service to install a single package in the virtual environment. This is useful if you want to install a package at runtime without having to modify the `requirements.txt` file.
+
+```csharp
+services // As existing (see above examples)
+    .WithPython()
+    .WithVirtualEnvironment(Path.Join(home, ".venv"))
+    .WithPipInstaller(); // Optional - installs packages listed in requirements.txt on startup
+
+// Environment/host builder setup
+
+var installer = serviceProvider.GetRequiredService<IPythonPackageInstaller>();
+await installer.InstallPackage("attrs==25.3.0");
+```
+
+This requires both an environment manager (UV or venv) and a package installer to be set up, as it uses the same mechanisms to install packages.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -77,9 +77,9 @@ Some other important notes about this implementation.
 - Will use the `UV_CACHE_DIR` environment variable to cache the packages in a directory if set.
 - Will disable the cache if the `UV_NO_CACHE` environment variable is set.
 
-## Installing a single package
+## Installing packages at runtime
 
-You can resolve the `IPythonPackageInstaller` service to install a single package in the virtual environment. This is useful if you want to install a package at runtime without having to modify the `requirements.txt` file.
+You can resolve the `IPythonPackageInstaller` service to install packages in the virtual environment. This is useful if you want to install a package at runtime without having to modify the `requirements.txt` file.
 
 ```csharp
 services // As existing (see above examples)
@@ -94,3 +94,15 @@ await installer.InstallPackage("attrs==25.3.0");
 ```
 
 This requires both an environment manager (UV or venv) and a package installer to be set up, as it uses the same mechanisms to install packages.
+
+Optionally, you can install multiple packages at once by passing a list of package names:
+
+```csharp
+await installer.InstallPackages(new[] { "attrs==25.3.0", "requests==2.31.0" });
+```
+
+Or, if the package names are in a file, you can use:
+
+```csharp
+await installer.InstallPackagesFromRequirements("requirements.txt");
+```

--- a/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
@@ -13,7 +13,7 @@ public interface IPythonPackageInstaller
     /// <param name="home">The home directory.</param>
     /// <param name="virtualEnvironmentLocation">The location of the virtual environment (optional).</param>
     /// <returns>A task representing the asynchronous package installation operation.</returns>
-    Task InstallPackages(string home, IEnvironmentManagement? environmentManager);
+    Task InstallPackages(string home);
 
     /// <summary>
     /// Install a single package.
@@ -22,5 +22,5 @@ public interface IPythonPackageInstaller
     /// <param name="environmentManager">The location of the virtual environment (optional).</param>
     /// <param name="package">Name of the package to install.</param>
     /// <returns>A task representing the asynchronous package installation operation.</returns>
-    Task InstallPackage(string home, IEnvironmentManagement? environmentManager, string package);
+    Task InstallPackage(string home, string package);
 }

--- a/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
@@ -16,9 +16,7 @@ public interface IPythonPackageInstaller
     /// <summary>
     /// Install a single package.
     /// </summary>
-    /// <param name="home">The home directory.</param>
-    /// <param name="environmentManager">The location of the virtual environment (optional).</param>
     /// <param name="package">Name of the package to install.</param>
     /// <returns>A task representing the asynchronous package installation operation.</returns>
-    Task InstallPackage(string home, string package);
+    Task InstallPackage(string package);
 }

--- a/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
@@ -6,12 +6,12 @@ namespace CSnakes.Runtime.PackageManagement;
 public interface IPythonPackageInstaller
 {
     /// <summary>
-    /// Installs the specified packages.
+    /// Install packages from a requirements file located in the specified home directory.
     /// </summary>
-    /// <param name="home">The home directory.</param>
-    /// <param name="virtualEnvironmentLocation">The location of the virtual environment (optional).</param>
+    /// <param name="home">The home directory where the requirements file is located.</param>
     /// <returns>A task representing the asynchronous package installation operation.</returns>
-    Task InstallPackages(string home);
+    Task InstallPackagesFromRequirements(string home);
+    Task InstallPackagesFromRequirements(string home, string file);
 
     /// <summary>
     /// Install a single package.
@@ -19,4 +19,11 @@ public interface IPythonPackageInstaller
     /// <param name="package">Name of the package to install.</param>
     /// <returns>A task representing the asynchronous package installation operation.</returns>
     Task InstallPackage(string package);
+
+    /// <summary>
+    /// Install multiple packages.
+    /// </summary>
+    /// <param name="packages">The packages to install.</param>
+    /// <returns>A task representing the asynchronous package installation operation.</returns>
+    Task InstallPackages(string[] packages);
 }

--- a/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/IPythonPackageInstaller.cs
@@ -1,5 +1,3 @@
-using CSnakes.Runtime.EnvironmentManagement;
-
 namespace CSnakes.Runtime.PackageManagement;
 
 /// <summary>

--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -8,13 +8,15 @@ internal class PipInstaller(ILogger<PipInstaller>? logger, IEnvironmentManagemen
 {
     static readonly string pipBinaryName = $"pip{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
 
-    public Task InstallPackages(string home)
+    public Task InstallPackagesFromRequirements(string home) => InstallPackagesFromRequirements(home, requirementsFileName);
+
+    public Task InstallPackagesFromRequirements(string home, string fileName)
     {
-        string requirementsPath = Path.GetFullPath(Path.Combine(home, requirementsFileName));
+        string requirementsPath = Path.GetFullPath(Path.Combine(home, fileName));
         if (File.Exists(requirementsPath))
         {
             logger?.LogDebug("File {Requirements} was found.", requirementsPath);
-            RunPipInstall(home, environmentManager, ["-r", requirementsFileName], logger);
+            RunPipInstall(home, environmentManager, ["-r", fileName], logger);
         }
         else
         {
@@ -24,10 +26,11 @@ internal class PipInstaller(ILogger<PipInstaller>? logger, IEnvironmentManagemen
         return Task.CompletedTask;
     }
 
-    public Task InstallPackage(string package)
-    {
-        RunPipInstall(Directory.GetCurrentDirectory(), environmentManager, [package], logger);
+    public Task InstallPackage(string package) => InstallPackages([package]);
 
+    public Task InstallPackages(string[] packages)
+    {
+        RunPipInstall(Directory.GetCurrentDirectory(), environmentManager, packages, logger);
         return Task.CompletedTask;
     }
 

--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -24,9 +24,9 @@ internal class PipInstaller(ILogger<PipInstaller>? logger, IEnvironmentManagemen
         return Task.CompletedTask;
     }
 
-    public Task InstallPackage(string home, string package)
+    public Task InstallPackage(string package)
     {
-        RunPipInstall(home, environmentManager, [package], logger);
+        RunPipInstall(Directory.GetCurrentDirectory(), environmentManager, [package], logger);
 
         return Task.CompletedTask;
     }

--- a/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs
@@ -4,11 +4,11 @@ using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.PackageManagement;
 
-internal class PipInstaller(ILogger<PipInstaller>? logger, string requirementsFileName) : IPythonPackageInstaller
+internal class PipInstaller(ILogger<PipInstaller>? logger, IEnvironmentManagement? environmentManager, string requirementsFileName) : IPythonPackageInstaller
 {
     static readonly string pipBinaryName = $"pip{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
 
-    public Task InstallPackages(string home, IEnvironmentManagement? environmentManager)
+    public Task InstallPackages(string home)
     {
         string requirementsPath = Path.GetFullPath(Path.Combine(home, requirementsFileName));
         if (File.Exists(requirementsPath))
@@ -24,7 +24,7 @@ internal class PipInstaller(ILogger<PipInstaller>? logger, string requirementsFi
         return Task.CompletedTask;
     }
 
-    public Task InstallPackage(string home, IEnvironmentManagement? environmentManager, string package)
+    public Task InstallPackage(string home, string package)
     {
         RunPipInstall(home, environmentManager, [package], logger);
 

--- a/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
@@ -8,32 +8,29 @@ internal class UVInstaller(ILogger<UVInstaller>? logger, IEnvironmentManagement?
 {
     static readonly string binaryName = $"uv{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
 
-    /// <summary>
-    /// Install packages from the configured requirements path.
-    /// </summary>
-    /// <param name="home">HOME directory</param>
-    /// <param name="environmentManager">Environment manager</param>
-    /// <returns>A task.</returns>
-    public Task InstallPackages(string home)
+    public Task InstallPackagesFromRequirements(string home) => InstallPackagesFromRequirements(home, requirementsFileName);
+
+    public Task InstallPackagesFromRequirements(string home, string fileName)
     {
-        string requirementsPath = Path.GetFullPath(Path.Combine(home, requirementsFileName));
+        string requirementsPath = Path.GetFullPath(Path.Combine(home, fileName));
         if (File.Exists(requirementsPath))
         {
-            logger?.LogDebug("File {Requirements} was found.", requirementsPath);
+            logger?.LogDebug("File {Requirements} was found.", fileName);
             RunUvPipInstall(home, environmentManager, ["-r", requirementsFileName], logger);
         }
         else
         {
-            logger?.LogWarning("File {Requirements} was not found.", requirementsPath);
+            logger?.LogWarning("File {Requirements} was not found.", fileName);
         }
 
         return Task.CompletedTask;
     }
 
-    public Task InstallPackage(string package)
-    {
-        RunUvPipInstall(Directory.GetCurrentDirectory(), environmentManager, [package], logger);
+    public Task InstallPackage(string package) => InstallPackages([package]);
 
+    public Task InstallPackages(string[] packages)
+    {
+        RunUvPipInstall(Directory.GetCurrentDirectory(), environmentManager, packages, logger);
         return Task.CompletedTask;
     }
 

--- a/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
@@ -30,9 +30,9 @@ internal class UVInstaller(ILogger<UVInstaller>? logger, IEnvironmentManagement?
         return Task.CompletedTask;
     }
 
-    public Task InstallPackage(string home, string package)
+    public Task InstallPackage(string package)
     {
-        RunUvPipInstall(home, environmentManager, [package], logger);
+        RunUvPipInstall(Directory.GetCurrentDirectory(), environmentManager, [package], logger);
 
         return Task.CompletedTask;
     }

--- a/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime.PackageManagement;
 
-internal class UVInstaller(ILogger<UVInstaller>? logger, string requirementsFileName) : IPythonPackageInstaller
+internal class UVInstaller(ILogger<UVInstaller>? logger, IEnvironmentManagement? environmentManager, string requirementsFileName) : IPythonPackageInstaller
 {
     static readonly string binaryName = $"uv{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
 
@@ -14,7 +14,7 @@ internal class UVInstaller(ILogger<UVInstaller>? logger, string requirementsFile
     /// <param name="home">HOME directory</param>
     /// <param name="environmentManager">Environment manager</param>
     /// <returns>A task.</returns>
-    public Task InstallPackages(string home, IEnvironmentManagement? environmentManager)
+    public Task InstallPackages(string home)
     {
         string requirementsPath = Path.GetFullPath(Path.Combine(home, requirementsFileName));
         if (File.Exists(requirementsPath))
@@ -30,7 +30,7 @@ internal class UVInstaller(ILogger<UVInstaller>? logger, string requirementsFile
         return Task.CompletedTask;
     }
 
-    public Task InstallPackage(string home, IEnvironmentManagement? environmentManager, string package)
+    public Task InstallPackage(string home, string package)
     {
         RunUvPipInstall(home, environmentManager, [package], logger);
 

--- a/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
+++ b/src/CSnakes.Runtime/PackageManagement/UVInstaller.cs
@@ -9,7 +9,7 @@ internal class UVInstaller(ILogger<UVInstaller>? logger, IEnvironmentManagement?
     static readonly string binaryName = $"uv{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "")}";
 
     /// <summary>
-    /// Install packages from a requirements path
+    /// Install packages from the configured requirements path.
     /// </summary>
     /// <param name="home">HOME directory</param>
     /// <param name="environmentManager">Environment manager</param>

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -78,7 +78,7 @@ internal class PythonEnvironment : IPythonEnvironment
 
         foreach (var installer in packageInstallers)
         {
-            installer.InstallPackages(home);
+            installer.InstallPackagesFromRequirements(home);
         }
 
         char sep = Path.PathSeparator;

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -78,7 +78,7 @@ internal class PythonEnvironment : IPythonEnvironment
 
         foreach (var installer in packageInstallers)
         {
-            installer.InstallPackages(home, environmentManager);
+            installer.InstallPackages(home);
         }
 
         char sep = Path.PathSeparator;

--- a/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
+++ b/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
@@ -259,7 +259,8 @@ public static partial class ServiceCollectionExtensions
             sp =>
             {
                 var logger = sp.GetService<ILogger<PipInstaller>>();
-                return new PipInstaller(logger, requirementsPath);
+                var environmentManager = sp.GetService<IEnvironmentManagement>();
+                return new PipInstaller(logger, environmentManager, requirementsPath);
             }
         );
         return builder;
@@ -277,7 +278,8 @@ public static partial class ServiceCollectionExtensions
             sp =>
             {
                 var logger = sp.GetService<ILogger<UVInstaller>>();
-                return new UVInstaller(logger, requirementsPath);
+                var environmentManager = sp.GetService<IEnvironmentManagement>();
+                return new UVInstaller(logger, environmentManager, requirementsPath);
             }
         );
         return builder;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
@@ -24,7 +24,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "4daf76cc633c1625633c79dee2d8e1f2"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "91cffef6971bf92c2bc792b335702f6c"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {
@@ -47,6 +47,7 @@ public static class TestClassExtensions
         private readonly ILogger<IPythonEnvironment>? logger;
 
         private PyObject __func_test_nothing;
+        private PyObject __func_test_attrs_function;
 
         internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
@@ -56,6 +57,7 @@ public static class TestClassExtensions
                 logger?.LogDebug("Importing module {ModuleName}", "test");
                 this.module = ThisModule.Import();
                 this.__func_test_nothing = module.GetAttr("test_nothing");
+                this.__func_test_attrs_function = module.GetAttr("test_attrs_function");
             }
         }
 
@@ -67,8 +69,10 @@ public static class TestClassExtensions
                 Import.ReloadModule(ref module);
                 // Dispose old functions
                 this.__func_test_nothing.Dispose();
+                this.__func_test_attrs_function.Dispose();
                 // Bind to new functions
                 this.__func_test_nothing = module.GetAttr("test_nothing");
+                this.__func_test_attrs_function = module.GetAttr("test_attrs_function");
             }
         }
 
@@ -76,6 +80,7 @@ public static class TestClassExtensions
         {
             logger?.LogDebug("Disposing module {ModuleName}", "test");
             this.__func_test_nothing.Dispose();
+            this.__func_test_attrs_function.Dispose();
             module.Dispose();
         }
 
@@ -85,6 +90,18 @@ public static class TestClassExtensions
             {
                 logger?.LogDebug("Invoking Python function: {FunctionName}", "test_nothing");
                 PyObject __underlyingPythonFunc = this.__func_test_nothing;
+                using PyObject __result_pyObject = __underlyingPythonFunc.Call();
+                var __return = __result_pyObject.BareImportAs<bool, global::CSnakes.Runtime.Python.PyObjectImporters.Boolean>();
+                return __return;
+            }
+        }
+
+        public bool TestAttrsFunction()
+        {
+            using (GIL.Acquire())
+            {
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_attrs_function");
+                PyObject __underlyingPythonFunc = this.__func_test_attrs_function;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
                 var __return = __result_pyObject.BareImportAs<bool, global::CSnakes.Runtime.Python.PyObjectImporters.Boolean>();
                 return __return;
@@ -105,6 +122,14 @@ public interface ITestClass : IReloadableModuleImport
     /// ]]></code>
     /// </summary>
     bool TestNothing();
+
+    /// <summary>
+    /// Invokes the Python function <c>test_attrs_function</c>:
+    /// <code><![CDATA[
+    /// def test_attrs_function()-> bool: ...
+    /// ]]></code>
+    /// </summary>
+    bool TestAttrsFunction();
 }
 
 file static class ThisModule

--- a/src/Integration.Tests/IntegrationTestBase.cs
+++ b/src/Integration.Tests/IntegrationTestBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using CSnakes.Runtime.PackageManagement;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,7 @@ public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvir
 public sealed class PythonEnvironmentFixture : IDisposable
 {
     private readonly IPythonEnvironment env;
+    private readonly IPythonPackageInstaller installer;
     private readonly IHost app;
 
     public PythonEnvironmentFixture()
@@ -45,6 +47,7 @@ public sealed class PythonEnvironmentFixture : IDisposable
             .Build();
 
         env = app.Services.GetRequiredService<IPythonEnvironment>();
+        installer = app.Services.GetRequiredService<IPythonPackageInstaller>();
     }
 
     public void Dispose()
@@ -56,10 +59,12 @@ public sealed class PythonEnvironmentFixture : IDisposable
     }
 
     public IPythonEnvironment Env => env;
+    public IPythonPackageInstaller Installer => installer;
 }
 
 [Collection(PythonEnvironmentCollection.Name)]
 public abstract class IntegrationTestBase(PythonEnvironmentFixture fixture)
 {
     public IPythonEnvironment Env { get; } = fixture.Env;
+    public IPythonPackageInstaller Installer { get; } = fixture.Installer;
 }

--- a/src/Integration.Tests/TestDependency.cs
+++ b/src/Integration.Tests/TestDependency.cs
@@ -20,7 +20,7 @@ public class TestDependency(PythonEnvironmentFixture fixture) : IntegrationTestB
     async public Task VerifyRuntimeDependency()
     {
         // attrs==25.3.0
-        await Installer.InstallPackage("", "attrs==25.3.0");
+        await Installer.InstallPackage("attrs==25.3.0");
         Assert.True(Env.TestDependency().TestAttrsFunction());
     }
 }

--- a/src/Integration.Tests/TestDependency.cs
+++ b/src/Integration.Tests/TestDependency.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Integration.Tests;
 
 public class TestDependency(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
@@ -12,5 +14,13 @@ public class TestDependency(PythonEnvironmentFixture fixture) : IntegrationTestB
     public void VerifyPyBind11Dependency()
     {
         Assert.True(Env.TestPybind11().TestPybind11Function());
+    }
+
+    [Fact]
+    async public Task VerifyRuntimeDependency()
+    {
+        // attrs==25.3.0
+        await Installer.InstallPackage("", "attrs==25.3.0");
+        Assert.True(Env.TestDependency().TestAttrsFunction());
     }
 }

--- a/src/Integration.Tests/python/test_dependency.py
+++ b/src/Integration.Tests/python/test_dependency.py
@@ -2,3 +2,12 @@ import httpx
 
 def test_nothing() -> bool:
     return True
+
+
+def test_attrs_function()-> bool:
+    from attrs import define
+    @define
+    class TestClass:
+        name: str = "test"
+    instance = TestClass()
+    return instance.name == "test"


### PR DESCRIPTION
Refactor the installer APIs so that you can install a `requirements.txt` file, _or_ a list of packages.

Also refactors the IPythonPackageInstaller so that environment manager comes from the DI at setup time