### PR TITLE
Discard result when function returns `None`

### DIFF
--- a/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
@@ -214,19 +214,20 @@ public static class MethodReflection
                                 IdentifierName($"__func_{function.Name}"))))))
             );
 
-        var callStatement = LocalDeclarationStatement(
-                VariableDeclaration(
-                        callResultTypeSyntax)
-                .WithVariables(
-                    SingletonSeparatedList(
-                        VariableDeclarator(
-                            Identifier("__result_pyObject"))
-                        .WithInitializer(
-                            EqualsValueClause(
-                                callExpression)))));
-
-        if (resultShouldBeDisposed)
-            callStatement = callStatement.WithUsingKeyword(Token(SyntaxKind.UsingKeyword));
+        StatementSyntax callStatement
+            = returnExpression.Expression is not null
+            ? LocalDeclarationStatement(
+                  VariableDeclaration(
+                          callResultTypeSyntax)
+                  .WithVariables(
+                      SingletonSeparatedList(
+                          VariableDeclarator(
+                              Identifier("__result_pyObject"))
+                          .WithInitializer(
+                              EqualsValueClause(
+                                  callExpression)))))
+                  .WithUsingKeyword(resultShouldBeDisposed ? Token(SyntaxKind.UsingKeyword) : Token(SyntaxKind.None))
+            : ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, IdentifierName("_"), callExpression));
 
         var logStatement = ExpressionStatement(
                 ConditionalAccessExpression(

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
@@ -87,7 +87,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_with_underscore;
                 using PyObject testx_pyObject = PyObject.From(testx)!;
                 using PyObject testy_pyObject = PyObject.From(testy)!;
-                using PyObject __result_pyObject = __underlyingPythonFunc.Call(testx_pyObject, testy_pyObject);
+                _ = __underlyingPythonFunc.Call(testx_pyObject, testy_pyObject);
                 return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -274,7 +274,7 @@ public static class TestClassExtensions
             {
                 logger?.LogDebug("Invoking Python function: {FunctionName}", "test_none_result");
                 PyObject __underlyingPythonFunc = this.__func_test_none_result;
-                using PyObject __result_pyObject = __underlyingPythonFunc.Call();
+                _ = __underlyingPythonFunc.Call();
                 return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
@@ -92,7 +92,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_keyword_only;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
-                using PyObject __result_pyObject = __underlyingPythonFunc.CallWithKeywordArguments([a_pyObject, ..args ?? []], ["b"], [b_pyObject], null);
+                _ = __underlyingPythonFunc.CallWithKeywordArguments([a_pyObject, ..args ?? []], ["b"], [b_pyObject], null);
                 return;
             }
         }
@@ -105,7 +105,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_named_keyword_only;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject b_pyObject = PyObject.From(b)!;
-                using PyObject __result_pyObject = __underlyingPythonFunc.CallWithKeywordArguments([a_pyObject, ..args ?? []], ["b"], [b_pyObject], null);
+                _ = __underlyingPythonFunc.CallWithKeywordArguments([a_pyObject, ..args ?? []], ["b"], [b_pyObject], null);
                 return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
@@ -86,7 +86,7 @@ public static class TestClassExtensions
                 logger?.LogDebug("Invoking Python function: {FunctionName}", "switch");
                 PyObject __underlyingPythonFunc = this.__func_switch;
                 using PyObject @new_pyObject = PyObject.From(@new)!;
-                using PyObject __result_pyObject = __underlyingPythonFunc.Call(@new_pyObject);
+                _ = __underlyingPythonFunc.Call(@new_pyObject);
                 return;
             }
         }


### PR DESCRIPTION
This PR was forked from PR #488.

It simply discards the result of a Python function that returns `None` (mapped to `void` in C#) instead of disposing it because [`None` is immortal](https://github.com/tonybaloney/CSnakes/blob/490ab6adc39fbdb00585cc9c6eec57a4cd1f2cd6/src/CSnakes.Runtime/Python/Interns/PyNoneObject.cs#L5) and [disposing it has no effect](https://github.com/tonybaloney/CSnakes/blob/490ab6adc39fbdb00585cc9c6eec57a4cd1f2cd6/src/CSnakes.Runtime/Python/Interns/ImmortalPyObject.cs#L12-L15). Discarding helps to remove any costs associated with try-finally setup.
