### PR TITLE
Mention `T | None` in support types doc

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,6 +19,7 @@ CSnakes supports the following typed scenarios:
 | `typing.Mapping[K, V]` | `IReadOnlyDictionary<K, V>` |
 | `typing.Tuple[T1, T2, ...]` | `(T1, T2, ...)` |
 | `typing.Optional[T]`   | `T?`              |
+| `T \| None`            | `T?`              |
 | `typing.Generator[TYield, TSend, TReturn]` | `IGeneratorIterator<TYield, TSend, TReturn>` [1](#generators) |
 | `typing.Buffer`        | `IPyBuffer` [2](buffers.md) |
 | `typing.Coroutine[TYield, TSend, TReturn]` | `Task<TYield>` [3](async_support.md) |


### PR DESCRIPTION
This is a follow-up PR to #502 that mentions the new support in the documentation.