### PR TITLE
Support octal constants and render them as hexidecimal values in generated code

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonTokenizer.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonTokenizer.cs
@@ -31,6 +31,7 @@ public static class PythonTokenizer
         .Match(PythonParser.DecimalConstantToken, PythonToken.Decimal, requireDelimiters: true)
         .Match(PythonParser.HexidecimalConstantToken, PythonToken.HexidecimalInteger, requireDelimiters: true)
         .Match(PythonParser.BinaryConstantToken, PythonToken.BinaryInteger, requireDelimiters: true)
+        .Match(PythonParser.OctalConstantToken, PythonToken.OctalInteger, requireDelimiters: true)
         .Match(PythonParser.DoubleQuotedStringConstantToken, PythonToken.DoubleQuotedString)
         .Match(PythonParser.SingleQuotedStringConstantToken, PythonToken.SingleQuotedString)
         .Build();

--- a/src/CSnakes.SourceGeneration/Parser/PythonTokens.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonTokens.cs
@@ -50,6 +50,7 @@ public enum PythonToken
     Decimal,
     HexidecimalInteger,
     BinaryInteger,
+    OctalInteger,
     DoubleQuotedString,
     SingleQuotedString,
     True,

--- a/src/CSnakes.Tests/TokenizerTests.cs
+++ b/src/CSnakes.Tests/TokenizerTests.cs
@@ -503,7 +503,11 @@ if __name__ == '__main__':
     [InlineData("0b10", 0b10)]
     [InlineData("0b10101101", 0b10101101)]
     [InlineData("0b1010_1101", 0b10101101)]
-    // [InlineData("0o123", 0o123)] Octal literals are not supported in C#
+    [InlineData("0o1234", 0x29C)]
+    [InlineData("0o777", 0x1FF)]
+    [InlineData("0o0", 0x0)]
+    [InlineData("0o1234567", 0x53977)]
+    [InlineData("0o123_456_7", 0x53977)]
     [InlineData("1234567", 1234567)]
     [InlineData("-1234567", -1234567)]
     [InlineData("0xdeadbeef", 0xdeadbeef)]


### PR DESCRIPTION
Implements #508 

This pull request introduces support for parsing and tokenizing octal literals in the Python parser. The changes include adding new constants, tokenizers, and helper methods to handle octal literals, as well as updating the tokenizer and test cases to ensure proper functionality.

### Support for Octal Literals:

* Added `OctalConstantToken` to define the parsing rules for octal literals in `PythonParser.Constants.cs`.
* Introduced `OctalIntegerConstantTokenizer` to tokenize octal integer literals and convert them into `PythonConstant.HexidecimalInteger`.
* Updated the `PythonConstantTokenizer` to include support for `OctalIntegerConstantTokenizer` as part of the parsing pipeline.
* Added the `ParseOctal` helper method in the new `PythonParserConstants` class to convert octal strings into long integers while ignoring underscores.

### Tokenizer and Enum Updates:

* Updated `PythonTokenizer` to match octal constants and associate them with the `PythonToken.OctalInteger` token.
* Added `OctalInteger` to the `PythonToken` enum to represent octal literals.

### Test Cases:

* Added test cases for octal literals in `TokenizerTests.cs`, verifying correct parsing and conversion of octal literals into hexadecimal equivalents.