### PR TITLE
Don't generate parameter defaults on unsupported types

### DIFF
--- a/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
@@ -51,6 +51,13 @@ public class ArgumentReflection
             _ => SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)
         };
 
+        // If the default value is a literal expression, but we could not resolve the type to a builtin type,
+        // avoid CS1750 (no standard conversion to PyObject)
+        if (literalExpressionSyntax is not null && reflectedType is not PredefinedTypeSyntax)
+        {
+            literalExpressionSyntax = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+        }
+
         return SyntaxFactory
             .Parameter(SyntaxFactory.Identifier(Keywords.ValidIdentifier(parameter.Name.ToLowerPascalCase())))
             .WithType(reflectedType)

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -46,7 +46,7 @@ public class GeneratedSignatureTests
     [InlineData("def hello() -> Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> typing.Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> Buffer:\n ...\n", "IPyBuffer Hello()")]
-    [InlineData("def hello(a: Union[int, str] = 5) -> Any:\n ...\n", "PyObject Hello(PyObject a = 5)")]
+    [InlineData("def hello(a: Union[int, str] = 5) -> Any:\n ...\n", "PyObject Hello(PyObject a = null)")]
     public void TestGeneratedSignature(string code, string expected)
     {
         SourceText sourceText = SourceText.From(code);

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -46,7 +46,7 @@ public class GeneratedSignatureTests
     [InlineData("def hello() -> Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> typing.Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> Buffer:\n ...\n", "IPyBuffer Hello()")]
-    [InlineData("def hello(a: Union[int, str] = 5) -> Any:\n ...\n", "PyObject Hello(PyObject? a = null)")]
+    [InlineData("def hello(a: Union[int, str] = 5) -> Any:\n ...\n", "PyObject Hello(PyObject a = 5)")]
     public void TestGeneratedSignature(string code, string expected)
     {
         SourceText sourceText = SourceText.From(code);

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -46,6 +46,7 @@ public class GeneratedSignatureTests
     [InlineData("def hello() -> Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> typing.Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> Buffer:\n ...\n", "IPyBuffer Hello()")]
+    [InlineData("def hello(a: Union[int, str] = 5) -> Any:\n ...\n", "PyObject Hello(PyObject? a = null)")]
     public void TestGeneratedSignature(string code, string expected)
     {
         SourceText sourceText = SourceText.From(code);

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
@@ -224,7 +224,7 @@ public static class TestClassExtensions
             }
         }
 
-        public string TestUnionWithDefaultConstant(PyObject a = 42)
+        public string TestUnionWithDefaultConstant(PyObject a = null)
         {
             using (GIL.Acquire())
             {
@@ -314,7 +314,7 @@ public interface ITestClass : IReloadableModuleImport
     /// def test_union_with_default_constant(a: Union[int, str] = 42) -> str: ...
     /// ]]></code>
     /// </summary>
-    string TestUnionWithDefaultConstant(PyObject a = 42);
+    string TestUnionWithDefaultConstant(PyObject a = null);
 }
 
 file static class ThisModule

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
@@ -24,7 +24,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "1848cdfa4c35d7dd55e968358f065089"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "491b6747b2808297ba36f2ca3f5dc245"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {
@@ -54,6 +54,7 @@ public static class TestClassExtensions
         private PyObject __func_test_optional_str;
         private PyObject __func_test_optional_list;
         private PyObject __func_test_optional_any;
+        private PyObject __func_test_union_with_default_constant;
 
         internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
@@ -70,6 +71,7 @@ public static class TestClassExtensions
                 this.__func_test_optional_str = module.GetAttr("test_optional_str");
                 this.__func_test_optional_list = module.GetAttr("test_optional_list");
                 this.__func_test_optional_any = module.GetAttr("test_optional_any");
+                this.__func_test_union_with_default_constant = module.GetAttr("test_union_with_default_constant");
             }
         }
 
@@ -88,6 +90,7 @@ public static class TestClassExtensions
                 this.__func_test_optional_str.Dispose();
                 this.__func_test_optional_list.Dispose();
                 this.__func_test_optional_any.Dispose();
+                this.__func_test_union_with_default_constant.Dispose();
                 // Bind to new functions
                 this.__func_test_default_str_arg = module.GetAttr("test_default_str_arg");
                 this.__func_test_default_int_arg = module.GetAttr("test_default_int_arg");
@@ -97,6 +100,7 @@ public static class TestClassExtensions
                 this.__func_test_optional_str = module.GetAttr("test_optional_str");
                 this.__func_test_optional_list = module.GetAttr("test_optional_list");
                 this.__func_test_optional_any = module.GetAttr("test_optional_any");
+                this.__func_test_union_with_default_constant = module.GetAttr("test_union_with_default_constant");
             }
         }
 
@@ -111,6 +115,7 @@ public static class TestClassExtensions
             this.__func_test_optional_str.Dispose();
             this.__func_test_optional_list.Dispose();
             this.__func_test_optional_any.Dispose();
+            this.__func_test_union_with_default_constant.Dispose();
             module.Dispose();
         }
 
@@ -218,6 +223,19 @@ public static class TestClassExtensions
                 return __return;
             }
         }
+
+        public string TestUnionWithDefaultConstant(PyObject a = 42)
+        {
+            using (GIL.Acquire())
+            {
+                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_union_with_default_constant");
+                PyObject __underlyingPythonFunc = this.__func_test_union_with_default_constant;
+                using PyObject a_pyObject = PyObject.From(a)!;
+                using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
+                var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
+                return __return;
+            }
+        }
     }
 }
 
@@ -289,6 +307,14 @@ public interface ITestClass : IReloadableModuleImport
     /// ]]></code>
     /// </summary>
     bool TestOptionalAny(PyObject? a = null);
+
+    /// <summary>
+    /// Invokes the Python function <c>test_union_with_default_constant</c>:
+    /// <code><![CDATA[
+    /// def test_union_with_default_constant(a: Union[int, str] = 42) -> str: ...
+    /// ]]></code>
+    /// </summary>
+    string TestUnionWithDefaultConstant(PyObject a = 42);
 }
 
 file static class ThisModule

--- a/src/Integration.Tests/python/test_defaults.py
+++ b/src/Integration.Tests/python/test_defaults.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 def test_default_str_arg(a: str = "hello") -> str:
     return a
@@ -26,3 +26,7 @@ def test_optional_list(a: Optional[list[int]] = None) -> bool:
 
 def test_optional_any(a: Optional[Any] = None) -> bool:
     return a is None
+
+
+def test_union_with_default_constant(a: Union[int, str] = 42) -> str:
+    return "foo"


### PR DESCRIPTION
Fixes #512 

Catch default values for parameters which have no standard conversion.

This does not catch invalid conversions, e.g. `def foo(x: str = 42) -> int`.