### PR TITLE
Fix overload test to reflect what's generated

### DIFF
--- a/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
+++ b/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
@@ -69,7 +69,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
 
             if (result)
             {
-                var methods = ModuleReflection.MethodsFromFunctionDefinitions(functions, fileName).Distinct(new MethodDefinitionComparator()).ToImmutableArray();
+                var methods = ModuleReflection.MethodsFromFunctionDefinitions(functions, fileName).ToImmutableArray();
                 string source = FormatClassFromMethods(@namespace, pascalFileName, methods, fileName, functions, code, embedSourceSwitch);
                 sourceContext.AddSource($"{pascalFileName}.py.cs", source);
                 sourceContext.ReportDiagnostic(Diagnostic.Create(new DiagnosticDescriptor("PSG002", "PythonStaticGenerator", $"Generated {pascalFileName}.py.cs", "PythonStaticGenerator", DiagnosticSeverity.Info, true), Location.None));

--- a/src/CSnakes.SourceGeneration/Reflection/ModuleReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/ModuleReflection.cs
@@ -9,7 +9,8 @@ public static class ModuleReflection
 {
     public static IEnumerable<MethodDefinition> MethodsFromFunctionDefinitions(IEnumerable<PythonFunctionDefinition> functions, string moduleName)
     {
-        return functions.Select(function => MethodReflection.FromMethod(function, moduleName));
+        return functions.Select(function => MethodReflection.FromMethod(function, moduleName))
+                        .Distinct(new MethodDefinitionComparator());
     }
 
     public static string Compile(this IEnumerable<MethodDeclarationSyntax> methods)

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_overload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_overload.approved.txt
@@ -134,32 +134,6 @@ public static class TestClassExtensions
                 return __return;
             }
         }
-
-        public string TestOverloadUnsupportedType(PyObject x)
-        {
-            using (GIL.Acquire())
-            {
-                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_overload_unsupported_type");
-                PyObject __underlyingPythonFunc = this.__func_test_overload_unsupported_type;
-                using PyObject x_pyObject = PyObject.From(x)!;
-                using PyObject __result_pyObject = __underlyingPythonFunc.Call(x_pyObject);
-                var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
-                return __return;
-            }
-        }
-
-        public string TestOverloadUnsupportedType(PyObject x)
-        {
-            using (GIL.Acquire())
-            {
-                logger?.LogDebug("Invoking Python function: {FunctionName}", "test_overload_unsupported_type");
-                PyObject __underlyingPythonFunc = this.__func_test_overload_unsupported_type;
-                using PyObject x_pyObject = PyObject.From(x)!;
-                using PyObject __result_pyObject = __underlyingPythonFunc.Call(x_pyObject);
-                var __return = __result_pyObject.BareImportAs<string, global::CSnakes.Runtime.Python.PyObjectImporters.String>();
-                return __return;
-            }
-        }
     }
 }
 
@@ -196,22 +170,6 @@ public interface ITestClass : IReloadableModuleImport
     /// Invokes the Python function <c>test_overload_unsupported_type</c>:
     /// <code><![CDATA[
     /// def test_overload_unsupported_type(x: StrType) -> str: ...
-    /// ]]></code>
-    /// </summary>
-    string TestOverloadUnsupportedType(PyObject x);
-
-    /// <summary>
-    /// Invokes the Python function <c>test_overload_unsupported_type</c>:
-    /// <code><![CDATA[
-    /// def test_overload_unsupported_type(x: Any) -> str: ...
-    /// ]]></code>
-    /// </summary>
-    string TestOverloadUnsupportedType(PyObject x);
-
-    /// <summary>
-    /// Invokes the Python function <c>test_overload_unsupported_type</c>:
-    /// <code><![CDATA[
-    /// def test_overload_unsupported_type(x: AnyStr) -> str: ...
     /// ]]></code>
     /// </summary>
     string TestOverloadUnsupportedType(PyObject x);


### PR DESCRIPTION
This PR fixes the test snapshots added in PR #511 to reflect what's actually generated otherwise the code in there still contains duplicate method definitions and wouldn't normally compile. The integration tests compile still because the code path it touches had the distinct selection of methods, but not the tests.