### PR TITLE
Allow parsing of PEP586 Literal types

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
@@ -58,7 +58,6 @@ public static partial class PythonParser
                     from literals in
                         ConstantValueTokenizer.AtLeastOnceDelimitedBy(Token.EqualTo(PythonToken.Comma))
                                               .Subscript()
-                                              .OptionalOrDefault([])
                     select ImmutableArray.CreateRange([PythonTypeSpec.Literal([.. literals])]),
                 _ =>
                     from subscript in

--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
@@ -50,6 +50,16 @@ public static partial class PythonParser
                                                              select (Parameters: ps, Return: r))
                                                  .Subscript()
                     select ImmutableArray.CreateRange(callable.Parameters.Append(callable.Return)),
+                "Literal" =>
+                    // Literal can contain any PythonConstant, or a list of them.
+                    // See PEP586 https://peps.python.org/pep-0586/
+                    // It can also contain an expression, like a typedef but we don't support that yet.
+                    // It could also contain another Literal, but we don't support that yet either.
+                    from literals in
+                        ConstantValueTokenizer.AtLeastOnceDelimitedBy(Token.EqualTo(PythonToken.Comma))
+                                              .Subscript()
+                                              .OptionalOrDefault([])
+                    select ImmutableArray.CreateRange([PythonTypeSpec.Literal([.. literals])]),
                 _ =>
                     from subscript in
                         typeDefinitionParser.AtLeastOnceDelimitedBy(Token.EqualTo(PythonToken.Comma))

--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
@@ -16,4 +16,6 @@ public sealed class PythonTypeSpec(string name, ImmutableArray<PythonTypeSpec> a
     public static readonly PythonTypeSpec None = new("None");
 
     public static PythonTypeSpec Optional(PythonTypeSpec type) => new("Optional", [type]);
+    public static PythonTypeSpec Literal(ImmutableArray<PythonConstant> values) =>
+        new("Literal") /* TODO: Capture literal values */;
 }

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -48,6 +48,7 @@ public class GeneratedSignatureTests
     [InlineData("def hello() -> typing.Generator[int, str, bool]:\n ...\n", "IGeneratorIterator<long, string, bool> Hello()")]
     [InlineData("def hello() -> Buffer:\n ...\n", "IPyBuffer Hello()")]
     [InlineData("def hello(a: Union[int, str] = 5) -> Any:\n ...\n", "PyObject Hello(PyObject a = null)")]
+    [InlineData("def hello(data: Literal[1, 'two', 3.0]) -> None:\n ...\n", "void Hello(PyObject data)")]
     public void TestGeneratedSignature(string code, string expected)
     {
         SourceText sourceText = SourceText.From(code);

--- a/src/CSnakes.Tests/TokenizerTests.cs
+++ b/src/CSnakes.Tests/TokenizerTests.cs
@@ -103,6 +103,9 @@ public class TokenizerTests
     [InlineData("nest: list[tuple[int, int]]", "nest", "list[tuple[int, int]]")]
     [InlineData("max_length: int", "max_length", "int")]
     [InlineData("max_length: int = 50", "max_length", "int")]
+    [InlineData("temp: Literal[10]", "temp", "Literal[Literal]")]
+    [InlineData("value: Literal[1, 2, 3]", "value", "Literal[Literal]")]
+    [InlineData("value: Literal[1, 'two', 3.0]", "value", "Literal[Literal]")]
     public void ParseFunctionParameter(string code, string expectedName, string expectedType)
     {
         var tokens = PythonTokenizer.Instance.Tokenize(code);
@@ -451,6 +454,10 @@ public class TokenizerTests
     [InlineData("def format_name(name: str, max_length: int = 50) -> str:")]
     [InlineData("def calculate_kmeans_interia(data: list[tuple[int, int]], n_clusters: int) -> float:")]
     [InlineData("def invoke_mistral_inference(messages: list[str], lang: str = \"en-US\", temperature=0.0) -> str:")]
+    // Literal expressions
+    [InlineData("def process_data(data: Literal[1]) -> None:")]
+    [InlineData("def process_data(data: Literal[1, 2, 3]) -> None:")]
+    [InlineData("def process_data(data: Literal[1, 'two', 3.0]) -> None:")]
     public void ParseFunctionDefinitionComplex(string code)
     {
         var tokens = PythonTokenizer.Instance.Tokenize(code);

--- a/src/CSnakes.Tests/TypeReflectionTests.cs
+++ b/src/CSnakes.Tests/TypeReflectionTests.cs
@@ -52,6 +52,8 @@ public class TypeReflectionTests
     [InlineData("Optional[str]", "string?")]
     [InlineData("Optional[int]", "long?")]
     [InlineData("Callable[[str], int]", "PyObject")]
+    [InlineData("Literal['foo']", "PyObject")]
+    [InlineData("Literal['bar', 1, 0x0, 3.14]", "PyObject")]
     public void AsPredefinedTypeOldTypeNames(string pythonType, string expectedType) =>
         ParsingTestInternal(pythonType, expectedType);
 
@@ -100,6 +102,8 @@ public class TypeReflectionTests
     [InlineData("Callable[int, int]")]
     [InlineData("Callable[int, int, int]")]
     [InlineData("Callable[int, [int, int]]")]
+    [InlineData("Literal")] // Literal must have arguments
+    [InlineData("Literal[]")]
     public void InvalidParsingTest(string pythonType)
     {
         var tokens = PythonTokenizer.Instance.Tokenize(pythonType);


### PR DESCRIPTION
This PR goes part of the way to implement #24 

It implements the tokenization and parsing of basic PEP586 literals including mixed types.

The reflected type will still be `PyObject`. A second follow-up PR will look at the constants and if they are all the same type, add a type conversion or use an enum.

Currently, any type signature with `Literal[1, "two", 3.0]` will fail to parse and the function won't be included at all in the generated Class. 