### PR TITLE
Retry generated code snapshot match up to 3 times (ARM flakiness)

### DIFF
--- a/src/CSnakes.Tests/PythonStaticGeneratorTests.cs
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests.cs
@@ -43,6 +43,10 @@ public class PythonStaticGeneratorTests
         string compiledCode = PythonStaticGenerator.FormatClassFromMethods("Python.Generated.Tests", "TestClass", module, "test", functions, sourceText,
                                                                            embedSourceText: nameDiscriminator.Equals("test_source", StringComparison.OrdinalIgnoreCase));
 
+        const int maxMatchRetries = 3;
+        var matchAttempt = 1;
+        retryMatch:
+
         try
         {
             compiledCode.ShouldMatchApproved(options =>
@@ -50,6 +54,17 @@ public class PythonStaticGeneratorTests
                        .SubFolder(GetType().Name)
                        .WithFilenameGenerator((info, d, type, ext) => $"{info.MethodName}{d}.{type}.{ext}")
                        .NoDiff());
+        }
+        catch (ShouldMatchApprovedException) when (matchAttempt < maxMatchRetries)
+        {
+            // `ShouldMatchApproved` has been observed to be flaky (the received file is empty)
+            // on some platforms (particularly on ARM-based CI runners) so retry a few times
+            // before giving up.
+
+            TestContext.Current.TestOutputHelper?.WriteLine($"Warning! Attempt #{matchAttempt} failed.");
+            Thread.Sleep(TimeSpan.FromSeconds(1));
+            matchAttempt++;
+            goto retryMatch; // Retry the match
         }
         catch (FileNotFoundException ex) when (ex.FileName is { } fn
                                                && fn.Contains(".received.", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Snapshot tests have been pretty flaky on CI ARM runners and give false negatives, which has been pretty annoying. See [actions/runs/15582844855/job/43881977909](https://github.com/tonybaloney/CSnakes/actions/runs/15582844855/job/43881977909), for example. Usually, when a test fails, it's because the received file is completely empty.

I've looked into the code for [`ShouldMatchApproved`](https://github.com/shouldly/shouldly/blob/2dabbeffd9a470528343eb39da646291065b3527/src/Shouldly/ShouldMatchApprovedTestExtensions.cs) and cannot imagine a race condition for what's being observed.

This PR introduces a workaround retry mechanism around the `ShouldMatchApproved` retry with a maximum of three attempts. Ideally, we could use something like [xRetry](https://github.com/JoshKeegan/xRetry), but that's [not ready for xUnit.net v3](https://github.com/JoshKeegan/xRetry/issues/265).