### PR TITLE
Add support for `Union` types, including pipe syntax

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
@@ -27,9 +27,7 @@ public static partial class PythonParser
     {
         var typeDefinitionParser = Parse.Ref(() => PythonTypeDefinitionParser);
 
-        // Parser for anything but "None"
-
-        var someParser =
+        var parser =
             from name in Parse.OneOf(Token.EqualTo(PythonToken.None),
                                      Token.EqualTo(PythonToken.Identifier),
                                      Token.EqualTo(PythonToken.QualifiedIdentifier))
@@ -74,7 +72,7 @@ public static partial class PythonParser
             }
             select type;
 
-        return from ts in someParser.AtLeastOnceDelimitedBy(Token.EqualTo(PythonToken.Pipe))
+        return from ts in parser.AtLeastOnceDelimitedBy(Token.EqualTo(PythonToken.Pipe))
                select ts switch
                {
                    [var single] => single,

--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
@@ -58,9 +58,8 @@ public sealed class PythonTypeSpec(string name, ImmutableArray<PythonTypeSpec> a
                             case "Optional": Flatten([t.Arguments[0], None]); break;
                             default:
                             {
-                                if (set?.Add(t) ?? list?.Contains(t) is null or false)
+                                if (set?.Add(t) ?? !list.Contains(t))
                                 {
-                                    list ??= ImmutableArray.CreateBuilder<PythonTypeSpec>();
                                     list.Add(t);
                                     if (list.Count == setThreshold)
                                         set = [..list];

--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
@@ -1,8 +1,11 @@
 using System.Collections.Immutable;
 
 namespace CSnakes.Parser.Types;
-public sealed class PythonTypeSpec(string name, ImmutableArray<PythonTypeSpec> arguments = default)
+public sealed class PythonTypeSpec(string name, ImmutableArray<PythonTypeSpec> arguments = default) :
+    IEquatable<PythonTypeSpec>
 {
+    private int? cachedHashCode;
+
     public string Name { get; } = name;
 
     public ImmutableArray<PythonTypeSpec> Arguments { get; } = !arguments.IsDefault ? arguments : [];
@@ -18,4 +21,96 @@ public sealed class PythonTypeSpec(string name, ImmutableArray<PythonTypeSpec> a
     public static PythonTypeSpec Optional(PythonTypeSpec type) => new("Optional", [type]);
     public static PythonTypeSpec Literal(ImmutableArray<PythonConstant> values) =>
         new("Literal") /* TODO: Capture literal values */;
+
+    public static PythonTypeSpec Union(ReadOnlySpan<PythonTypeSpec> arguments)
+    {
+        if (arguments.IsEmpty)
+            throw new ArgumentException("Union must have at least one type argument.", nameof(arguments));
+
+        switch (arguments)
+        {
+            // Union of a single type is just that type
+            case [{ Name: not "Union" } arg]: return arg;
+            // Union of a single type with None is Optional of that type
+            case [{ Name: not "None" and not "Union" and not "Optional" } arg, { Name: "None" }]: return Optional(arg);
+            // Union of None with a single type is Optional of that type
+            case [{ Name: "None" }, { Name: not "None" and not "Union" and not "Optional" } arg]: return Optional(arg);
+            // Optimise for common cases of Union with two...
+            case [{ Name: not "Union" and not "Optional" } a, { Name: not "Union" and not "Optional" } b]
+                when a != b: return new("Union", [a, b]);
+            // ...or three different types
+            case [{ Name: not "Union" and not "Optional" } a, { Name: not "Union" and not "Optional" } b, { Name: not "Union" and not "Optional" } c]
+                when a != b && a != c && b != c:
+                return new("Union", [a, b, c]);
+            default:
+            {
+                var list = ImmutableArray.CreateBuilder<PythonTypeSpec>(); // unique in order of appearance
+                const int setThreshold = 8; // # of argument after which to switch to a set for performance
+                HashSet<PythonTypeSpec>? set = null; // set used for containment tests for large unions
+
+                void Flatten(ReadOnlySpan<PythonTypeSpec> args)
+                {
+                    foreach (var t in args)
+                    {
+                        switch (t.Name)
+                        {
+                            case "Union": Flatten(t.Arguments.AsSpan()); break;
+                            case "Optional": Flatten([t.Arguments[0], None]); break;
+                            default:
+                            {
+                                if (set?.Add(t) ?? list?.Contains(t) is null or false)
+                                {
+                                    list ??= ImmutableArray.CreateBuilder<PythonTypeSpec>();
+                                    list.Add(t);
+                                    if (list.Count == setThreshold)
+                                        set = [..list];
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                Flatten(arguments);
+
+                return list switch
+                {
+                    // A type and None, is Optional of that type
+                    [{ Name: not "None" } arg, { Name: "None" }] => Optional(arg),
+                    // None and a type, is Optional of that type
+                    [{ Name: "None" }, { Name: not "None" } arg] => Optional(arg),
+                    // A single type, is just that type
+                    [var arg] => arg,
+                    var args => new("Union", args.ToImmutable())
+                };
+            }
+        }
+    }
+
+    public bool Equals(PythonTypeSpec? other) =>
+        other is not null && (ReferenceEquals(this, other) || Name == other.Name && Arguments.SequenceEqual(other.Arguments));
+
+    public override bool Equals(object? obj) =>
+        Equals(obj as PythonTypeSpec);
+
+    public static bool operator ==(PythonTypeSpec? left, PythonTypeSpec? right) =>
+        left?.Equals(right) ?? right is null;
+
+    public static bool operator !=(PythonTypeSpec? left, PythonTypeSpec? right) =>
+        !(left == right);
+
+    public override int GetHashCode()
+    {
+        if (this.cachedHashCode is { } someHashCode)
+            return someHashCode;
+
+        unchecked
+        {
+            var hash = Name.GetHashCode() * 397;
+            foreach (var argument in Arguments)
+                hash ^= argument.GetHashCode();
+            this.cachedHashCode = hash;
+            return hash;
+        }
+    }
 }

--- a/src/CSnakes.Tests/ParameterListParserTests.cs
+++ b/src/CSnakes.Tests/ParameterListParserTests.cs
@@ -81,10 +81,7 @@ public class ParameterListParserTests
     [InlineData("a,,", "Syntax error (line 1, column 4): unexpected `,)`, expected Parameter.")]
     [InlineData("a,, b", "Syntax error (line 1, column 4): unexpected `,`, expected Parameter.")]
     [InlineData("a: | None", "Syntax error (line 1, column 5): unexpected `|`, expected Type Definition.")]
-    [InlineData("a: None |", "Syntax error (line 1, column 10): unexpected `|`, expected `)`.")]
-    [InlineData("a: None | None", "Syntax error (line 1, column 10): unexpected `|`, expected `)`.")]
-    // Technically, the following is valid syntax Python, but unions are not fully supported by the parser yet:
-    [InlineData("a: int | str | None", "Syntax error (line 1, column 9): unexpected `|`, expected `)`.")]
+    [InlineData("a: None |", "Syntax error (line 1, column 11): unexpected `)`, expected none, identifier or qualifiedidentifier.")]
     // The following test cases were taken directly from the CPython test suite:
     // https://github.com/python/cpython/blob/ffc2f1dd1c023b44b488311511db790a96d757db/Lib/test/test_syntax.py#L385-L537
     [InlineData("None=1", "Syntax error (line 1, column 2): unexpected none `None`, expected `)`.")]                // invalid syntax


### PR DESCRIPTION
This PR closes #520. It significantly improves the Python type parser by implementing comprehensive support for Union types, including both the traditional `Union[...]` syntax and modern pipe syntax (`A | B`). The changes introduce type normalization, de-duplication, and optimization strategies.

It should help with efforts like #499.

The implementation is optimized for up to 3 unions and then takes a slower path for more esoteric expressions of a Union that requires normalization of sorts.


## Design Changes

The core design philosophy shifts from treating Union types as edge cases to handling them as first-class citizens in the type system.

1. **Unified Type Parsing**: Consolidates the handling of different type syntaxes (None, Union, pipe syntax) into a single, coherent parsing strategy
2. **Normalization**: Automatically optimizes Union types by flattening nested unions, deduplicating types, and converting common patterns to their canonical forms
3. **Equality and Hashing**: Implements proper value equality and hash code caching for `PythonTypeSpec` to support de-duplication and performance optimization

## Technical Implementation Details

### Union Type Normalization

The new `Union` static method implements sophisticated normalization rules:

- **Single Type Optimization**: `Union[int]` → `int`
- **Optional Type Recognition**: `Union[int, None]` → `Optional[int]`
- **Nested Union Flattening**: `Union[Union[int, str], bool]` → `Union[int, str, bool]`
- **Deduplication**: `Union[int, int, str]` → `Union[int, str]`
- **Performance Optimization**: Uses HashSet for large unions (>8 types) to improve containment checking

### Equality and Hashing Implementation

- Two `PythonTypeSpec` instances are considered equal if they have the same name and arguments
- `PythonTypeSpec` hash code computation is cached since the type is fully immutable

### Test Coverage Expansion

The test suite has been significantly expanded to cover:

- **Union Normalization**: 20+ test cases covering various union scenarios
- **Pipe Syntax Support**: Tests for the modern `A | B` syntax
- **Edge Cases**: Complex nested unions, large unions with duplicates, mixed syntax patterns

## Breaking Changes

This is a **non-breaking change** for end users.

The parser now accepts more valid Python type syntax and produces more normalized output, but all previously supported syntax continues to work.

## Limitations and Further Work

Qualified forms like `typing.Union` and `typing.Optional` are not currently recognised, but this can be addressed in the future through a better re-modeling of `PythonTypeSpec` so that it can also be addressed for `Literal`.