### PR TITLE
Run approval tests sequentially to prevent file race conditions

### DIFF
--- a/src/CSnakes.Tests/CSnakes.Tests.csproj
+++ b/src/CSnakes.Tests/CSnakes.Tests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests.cs
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests.cs
@@ -43,27 +43,10 @@ public class PythonStaticGeneratorTests
         string compiledCode = PythonStaticGenerator.FormatClassFromMethods("Python.Generated.Tests", "TestClass", module, "test", functions, sourceText,
                                                                            embedSourceText: nameDiscriminator.Equals("test_source", StringComparison.OrdinalIgnoreCase));
 
-        try
-        {
-            compiledCode.ShouldMatchApproved(options =>
-                options.WithDiscriminator(nameDiscriminator)
-                       .SubFolder(GetType().Name)
-                       .WithFilenameGenerator((info, d, type, ext) => $"{info.MethodName}{d}.{type}.{ext}")
-                       .NoDiff());
-        }
-        catch (FileNotFoundException ex) when (ex.FileName is { } fn
-                                               && fn.Contains(".received.", StringComparison.OrdinalIgnoreCase))
-        {
-            // `ShouldMatchApproved` deletes the received file when the condition is met:
-            // https://github.com/shouldly/shouldly/blob/4.2.1/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs#L70
-            //
-            // `File.Delete` is documented to never throw an exception if the file doesn't exist:
-            //
-            // > If the file to be deleted does not exist, no exception is thrown. Source:
-            // > https://learn.microsoft.com/en-us/dotnet/api/system.io.file.delete?view=net-8.0#remarks
-            //
-            // However, `FileNotFoundException` has been observed on some platforms during CI runs
-            // so we catch it and should be harmless to ignore.
-        }
+        compiledCode.ShouldMatchApproved(options =>
+            options.WithDiscriminator(nameDiscriminator)
+                   .SubFolder(GetType().Name)
+                   .WithFilenameGenerator((info, d, type, ext) => $"{info.MethodName}{d}.{type}.{ext}")
+                   .NoDiff());
     }
 }


### PR DESCRIPTION
This PR reverts changes from PR #521 and #280 and instead uses the [`TestTfmsInParallel` settings (introduced with .NET 9 SDK)](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/sdk#run-tests-in-parallel) to disable parallel testing across target frameworks.

The hacks in PR #521 and #280 were incorrect because the problem wasn't potential flakiness of approval tests on ARM, but rather inherent to the fact that tests for each target framework (.NET 8 and 9) were running in parallel and caused race conditions for _received files_ on disk. The symptoms would manifest as the received file disappearing, violating locks or seeing an empty file. As an example of this, if a .NET 8 approval test case passed, it would delete the received file, but if the same test case were running for .NET 9 in parallel, it would throw a `FileNotFoundException` ([`ShouldMatchApproved` writes the received file first](https://github.com/shouldly/shouldly/blob/2dabbeffd9a470528343eb39da646291065b3527/src/Shouldly/ShouldMatchApprovedTestExtensions.cs#L50) and [read it back later](https://github.com/shouldly/shouldly/blob/2dabbeffd9a470528343eb39da646291065b3527/src/Shouldly/ShouldMatchApprovedTestExtensions.cs#L66)).

Unfortunately, setting `TestTfmsInParallel` to `false` does mean that the tests will run slower. We could work around this in one of two ways:

1. Maintain per framework approval files
2. Separate the approval tests into a separate test project where `TestTfmsInParallel` is set to `false` so that all other tests in `CSnakes.Tests` can continue to run in parallel.

I would go with option 2 since option 1 would double the number of files to maintain and approve for very little benefit.
