### PR TITLE
Upgrade to Aspire 9.3 and dependency cleanup

### DIFF
--- a/samples/Aspire/CSnakesAspire.ApiService/CSnakesAspire.ApiService.csproj
+++ b/samples/Aspire/CSnakesAspire.ApiService/CSnakesAspire.ApiService.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -26,17 +26,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0-rc.2.24551.3" />
+        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.3.*" />
         <PackageReference Include="CSnakes.Runtime" Version="1.*" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.*" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.*">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -45,7 +41,6 @@
 
     <ItemGroup>
         <PackageReference Include="python" Version="$(PythonVersion)" Condition="'$(IsWindows)' == 'true'" />
-        <PackageReference Include="System.Text.Json" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Aspire/CSnakesAspire.ApiService/Program.cs
+++ b/samples/Aspire/CSnakesAspire.ApiService/Program.cs
@@ -81,4 +81,4 @@ app.MapGet("/weatherforecast", (
 
 app.MapDefaultEndpoints();
 
-app.Run();
+await app.RunAsync();

--- a/samples/Aspire/CSnakesAspire.AppHost/CSnakesAspire.AppHost.csproj
+++ b/samples/Aspire/CSnakesAspire.AppHost/CSnakesAspire.AppHost.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>eafad395-89c5-4f84-932d-5cf82e3eb607</UserSecretsId>
   </PropertyGroup>
 
@@ -15,9 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.*" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.3.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/Aspire/CSnakesAspire.ServiceDefaults/CSnakesAspire.ServiceDefaults.csproj
+++ b/samples/Aspire/CSnakesAspire.ServiceDefaults/CSnakesAspire.ServiceDefaults.csproj
@@ -4,19 +4,18 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsAspireSharedProject>true</IsAspireSharedProject>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.*" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.*" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/Aspire/CSnakesAspire.ServiceDefaults/Extensions.cs
+++ b/samples/Aspire/CSnakesAspire.ServiceDefaults/Extensions.cs
@@ -7,7 +7,9 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Microsoft.Extensions.Hosting;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 
 // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.

--- a/samples/Aspire/CSnakesAspire.Web/CSnakesAspire.Web.csproj
+++ b/samples/Aspire/CSnakesAspire.Web/CSnakesAspire.Web.csproj
@@ -7,13 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\CSnakesAspire.ServiceDefaults\CSnakesAspire.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/samples/Aspire/CSnakesAspire.Web/Program.cs
+++ b/samples/Aspire/CSnakesAspire.Web/Program.cs
@@ -40,4 +40,4 @@ app.MapRazorComponents<App>()
 
 app.MapDefaultEndpoints();
 
-app.Run();
+await app.RunAsync();

--- a/samples/Aspire/python/weather.py
+++ b/samples/Aspire/python/weather.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any, Optional
-from datetime import datetime, timedelta, date
+from datetime import timedelta, date
 from otlp_tracing import configure_oltp_grpc_tracing, get_span_context
 
 import psycopg2
@@ -10,7 +10,6 @@ from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
 import csv
 import pathlib
 import pandas as pd
-import numpy as np
 
 logging.basicConfig(level=logging.INFO)
 tracer = configure_oltp_grpc_tracing()
@@ -81,4 +80,3 @@ def seed_database() -> None:
             logger.info(f"Database seeded with {counter} records")
             cursor.close()
             cnx.commit()
-


### PR DESCRIPTION
Removed all references to System.Text.Json as it is provided by the .net9.0 runtime
Removed unused references from weather.py
Removed all references that are inherited from project dependencies
Changed all dependences to floating at the minor level but Aspire dependencies float at the patch level

The reason for the latter is the AppHost project must have the Aspire SDK listed in full ex: 9.3.0 and so we only want patches within that release cycle.