### PR TITLE
Fix bug in TensorSpan<T> and ReadOnlyTensorSpan<T> Length correctly as item length not byte length

### DIFF
--- a/src/CSnakes.Runtime/Python/PyBuffer.cs
+++ b/src/CSnakes.Runtime/Python/PyBuffer.cs
@@ -2,6 +2,8 @@ using CommunityToolkit.HighPerformance;
 using CSnakes.Runtime.CPython;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
+using System.Diagnostics;
+
 #if NET9_0_OR_GREATER
 using System.Numerics.Tensors;
 #endif
@@ -265,7 +267,7 @@ internal sealed class PyBuffer : IPyBuffer
         }
         return new TensorSpan<T>(
             (T*)_buffer.buf,
-            _buffer.len,
+            _buffer.len / sizeof(T),
             Shape,
             strides
         );
@@ -280,10 +282,9 @@ internal sealed class PyBuffer : IPyBuffer
         {
             strides[i] = _buffer.strides[i] / sizeof(T);
         }
-
         return new ReadOnlyTensorSpan<T>(
             (T*)_buffer.buf,
-            _buffer.len,
+            _buffer.len / sizeof(T),
             Shape,
             strides
         );

--- a/src/Integration.Tests/BufferTests.cs
+++ b/src/Integration.Tests/BufferTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+#if NET9_0_OR_GREATER
+using System.Numerics.Tensors;
+#endif
 using CSnakes.Runtime.Python;
-using Xunit;
 
 namespace Integration.Tests;
 
@@ -426,6 +428,21 @@ public class BufferTests(PythonEnvironmentFixture fixture) : IntegrationTestBase
         Assert.Equal(typeof(int), bufferObject.GetItemType());
         Assert.Equal(1, tensor[0, 0, 0]);
         Assert.Equal(3, tensor[1, 2, 3]);
+    }
+
+    [Fact]
+    public void TestNDim3Float32TensorProductPrimitive()
+    {
+        var testModule = Env.TestBuffer();
+        using var bufferObject = testModule.TestNdim3dFloat32Buffer();
+        var tensor = bufferObject.AsTensorSpan<float>();
+        Assert.Equal(sizeof(int) * 3 * 4 * 5, bufferObject.Length);
+#pragma warning disable SYSLIB5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        var tmpTensor = Tensor.Create<float>(tensor.Lengths);
+        var shapeProduct = (long)TensorPrimitives.Product(tensor.Lengths);
+        Assert.Equal(shapeProduct, tensor.FlattenedLength);
+        var result = Tensor.Multiply(tensor, 255.0f, tmpTensor);
+#pragma warning restore SYSLIB5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     [Fact]

--- a/src/Integration.Tests/python/test_buffer.py
+++ b/src/Integration.Tests/python/test_buffer.py
@@ -101,6 +101,10 @@ def test_ndim_3d_buffer() -> Buffer:
     arr[1, 2, 3] = 3
     return arr
 
+def test_ndim_3d_float32_buffer() -> Buffer:
+    arr = np.ones((3, 4, 5), dtype=np.float32)
+    return arr
+
 def test_ndim_4d_buffer() -> Buffer:
     arr = np.zeros((2, 3, 4, 5), dtype=np.int32)
     arr[0, 0, 0, 0] = 1


### PR DESCRIPTION
Fixes #550 