### PR TITLE
Fix bug when positional args with defaults are following by a * then a keyword-only parameter without a default

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
@@ -2,7 +2,6 @@ using CSnakes.Parser.Types;
 using Superpower;
 using Superpower.Model;
 using Superpower.Parsers;
-using System.Collections.Immutable;
 
 namespace CSnakes.Parser;
 public static partial class PythonParser

--- a/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/MethodReflection.cs
@@ -263,6 +263,12 @@ public static class MethodReflection
             from p in ps
             select p;
 
+        // Sort parameters to move all optional parameters to the end
+        // CS1737: Optional parameters must appear after all required parameters
+        methodParameters = methodParameters.OrderBy(
+            p => p.Default is null ? 0 : 1
+        );
+
         if (cancellationTokenParameterSyntax is { } someCancellationTokenParameterSyntax)
             methodParameters = methodParameters.Append(someCancellationTokenParameterSyntax);
 

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -53,6 +53,7 @@ public class GeneratedSignatureTests
     [InlineData("async def hello() -> None:\n ...\n", "Task Hello(CancellationToken cancellationToken = default)")]
     [InlineData("async def hello():\n ...\n", "Task<PyObject> Hello(CancellationToken cancellationToken = default)")]
     [InlineData("def hello(n: Foo = ...) -> None:\n ...\n", "void Hello(PyObject? n = null)")]
+    [InlineData("def hello(a: str, b: int = 4, *, kw: str) -> None:\n ...\n", "void Hello(string a, string kw, long b = 4)")]
     public void TestGeneratedSignature(string code, string expected)
     {
         SourceText sourceText = SourceText.From(code);
@@ -62,7 +63,6 @@ public class GeneratedSignatureTests
         Assert.Empty(errors);
         var module = ModuleReflection.MethodsFromFunctionDefinitions(functions, "test").ToImmutableArray();
         var method = Assert.Single(module);
-        Assert.Equal($"public {expected}", method.Syntax.WithBody(null).NormalizeWhitespace().ToString());
 
         // Check that the sample C# code compiles
         string compiledCode = PythonStaticGenerator.FormatClassFromMethods("Python.Generated.Tests", "TestClass", module, "test", functions, sourceText);
@@ -82,6 +82,8 @@ public class GeneratedSignatureTests
         // TODO : Log compiler warnings.
         result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList().ForEach(d => Assert.Fail(d.ToString()));
         Assert.True(result.Success, compiledCode + "\n" + string.Join("\n", result.Diagnostics));
+
+        Assert.Equal($"public {expected}", method.Syntax.WithBody(null).NormalizeWhitespace().ToString());
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #541 

```python
def foo(a: int, b: int = 2, *, kw: str) -> None:
    pass
```

Something like this would fail to compile. 