### PR TITLE
Fix shipped API list

### DIFF
--- a/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -12,6 +12,7 @@ CSnakes.Runtime.IPythonEnvironment.IsDisposed() -> bool
 CSnakes.Runtime.IPythonEnvironment.Logger.get -> Microsoft.Extensions.Logging.ILogger<CSnakes.Runtime.IPythonEnvironment!>?
 CSnakes.Runtime.IPythonEnvironment.Version.get -> string!
 CSnakes.Runtime.IPythonEnvironmentBuilder
+CSnakes.Runtime.IPythonEnvironmentBuilder.DisableSignalHandlers() -> CSnakes.Runtime.IPythonEnvironmentBuilder!
 CSnakes.Runtime.IPythonEnvironmentBuilder.GetOptions() -> CSnakes.Runtime.PythonEnvironmentOptions!
 CSnakes.Runtime.IPythonEnvironmentBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 CSnakes.Runtime.IPythonEnvironmentBuilder.WithCondaEnvironment(string! name, string? environmentSpecPath = null, bool ensureEnvironment = false, string? pythonVersion = null) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
@@ -48,7 +49,10 @@ CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_13 = 4 -> CSnakes.
 CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_14 = 5 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
 CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 = 0 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
 CSnakes.Runtime.PackageManagement.IPythonPackageInstaller
-CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackages(string! home, CSnakes.Runtime.EnvironmentManagement.IEnvironmentManagement? environmentManager) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackage(string! package) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackages(string![]! packages) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackagesFromRequirements(string! home) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackagesFromRequirements(string! home, string! file) -> System.Threading.Tasks.Task!
 CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
 CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.AsTask(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TYield>!
 CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
@@ -101,13 +105,15 @@ CSnakes.Runtime.Python.PyObject.ImportAs<T, TImporter>() -> T
 CSnakes.Runtime.Python.PyObject.NotEquals(object? obj) -> bool
 CSnakes.Runtime.Python.PyObject.PyObject(nint pyObject, bool ownsHandle = true) -> void
 CSnakes.Runtime.PythonEnvironmentOptions
-CSnakes.Runtime.PythonEnvironmentOptions.Deconstruct(out string! Home, out string![]! ExtraPaths) -> void
+CSnakes.Runtime.PythonEnvironmentOptions.Deconstruct(out string! Home, out string![]! ExtraPaths, out bool InstallSignalHandlers) -> void
 CSnakes.Runtime.PythonEnvironmentOptions.ExtraPaths.get -> string![]!
 CSnakes.Runtime.PythonEnvironmentOptions.ExtraPaths.init -> void
 CSnakes.Runtime.PythonEnvironmentOptions.Home.get -> string!
 CSnakes.Runtime.PythonEnvironmentOptions.Home.init -> void
+CSnakes.Runtime.PythonEnvironmentOptions.InstallSignalHandlers.get -> bool
+CSnakes.Runtime.PythonEnvironmentOptions.InstallSignalHandlers.init -> void
 CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(CSnakes.Runtime.PythonEnvironmentOptions! original) -> void
-CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(string! Home, string![]! ExtraPaths) -> void
+CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(string! Home, string![]! ExtraPaths, bool InstallSignalHandlers = true) -> void
 CSnakes.Runtime.PythonInvocationException
 CSnakes.Runtime.PythonInvocationException.PythonExceptionType.get -> string!
 CSnakes.Runtime.PythonInvocationException.PythonInvocationException(string! exceptionType, CSnakes.Runtime.Python.PyObject? exception, CSnakes.Runtime.Python.PyObject? pythonStackTrace) -> void

--- a/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -12,6 +12,7 @@ CSnakes.Runtime.IPythonEnvironment.IsDisposed() -> bool
 CSnakes.Runtime.IPythonEnvironment.Logger.get -> Microsoft.Extensions.Logging.ILogger<CSnakes.Runtime.IPythonEnvironment!>?
 CSnakes.Runtime.IPythonEnvironment.Version.get -> string!
 CSnakes.Runtime.IPythonEnvironmentBuilder
+CSnakes.Runtime.IPythonEnvironmentBuilder.DisableSignalHandlers() -> CSnakes.Runtime.IPythonEnvironmentBuilder!
 CSnakes.Runtime.IPythonEnvironmentBuilder.GetOptions() -> CSnakes.Runtime.PythonEnvironmentOptions!
 CSnakes.Runtime.IPythonEnvironmentBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 CSnakes.Runtime.IPythonEnvironmentBuilder.WithCondaEnvironment(string! name, string? environmentSpecPath = null, bool ensureEnvironment = false, string? pythonVersion = null) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
@@ -48,7 +49,10 @@ CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_13 = 4 -> CSnakes.
 CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_14 = 5 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
 CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 = 0 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
 CSnakes.Runtime.PackageManagement.IPythonPackageInstaller
-CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackages(string! home, CSnakes.Runtime.EnvironmentManagement.IEnvironmentManagement? environmentManager) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackage(string! package) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackages(string![]! packages) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackagesFromRequirements(string! home) -> System.Threading.Tasks.Task!
+CSnakes.Runtime.PackageManagement.IPythonPackageInstaller.InstallPackagesFromRequirements(string! home, string! file) -> System.Threading.Tasks.Task!
 CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
 CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.AsTask(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TYield>!
 CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
@@ -103,13 +107,15 @@ CSnakes.Runtime.Python.PyObject.ImportAs<T, TImporter>() -> T
 CSnakes.Runtime.Python.PyObject.NotEquals(object? obj) -> bool
 CSnakes.Runtime.Python.PyObject.PyObject(nint pyObject, bool ownsHandle = true) -> void
 CSnakes.Runtime.PythonEnvironmentOptions
-CSnakes.Runtime.PythonEnvironmentOptions.Deconstruct(out string! Home, out string![]! ExtraPaths) -> void
+CSnakes.Runtime.PythonEnvironmentOptions.Deconstruct(out string! Home, out string![]! ExtraPaths, out bool InstallSignalHandlers) -> void
 CSnakes.Runtime.PythonEnvironmentOptions.ExtraPaths.get -> string![]!
 CSnakes.Runtime.PythonEnvironmentOptions.ExtraPaths.init -> void
 CSnakes.Runtime.PythonEnvironmentOptions.Home.get -> string!
 CSnakes.Runtime.PythonEnvironmentOptions.Home.init -> void
+CSnakes.Runtime.PythonEnvironmentOptions.InstallSignalHandlers.get -> bool
+CSnakes.Runtime.PythonEnvironmentOptions.InstallSignalHandlers.init -> void
 CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(CSnakes.Runtime.PythonEnvironmentOptions! original) -> void
-CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(string! Home, string![]! ExtraPaths) -> void
+CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(string! Home, string![]! ExtraPaths, bool InstallSignalHandlers = true) -> void
 CSnakes.Runtime.PythonInvocationException
 CSnakes.Runtime.PythonInvocationException.PythonExceptionType.get -> string!
 CSnakes.Runtime.PythonInvocationException.PythonInvocationException(string! exceptionType, CSnakes.Runtime.Python.PyObject? exception, CSnakes.Runtime.Python.PyObject? pythonStackTrace) -> void

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,24 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <WarningsAsErrors>
+      <!-- https://github.com/dotnet/roslyn/blob/a8287cc3de7fcb65645413c5d6a089d2a2db4061/src/RoslynAnalyzers/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.md -->
+      RS0016; <!-- Add public types and members to the declared API -->
+      RS0017; <!-- Remove deleted types and members from the declared API -->
+      RS0022; <!-- Constructor make noninheritable base class inheritable -->
+      RS0024; <!-- The contents of the public API files are invalid -->
+      RS0025; <!-- Do not duplicate symbols in public API files -->
+      RS0026; <!-- Do not add multiple public overloads with optional parameters -->
+      RS0027; <!-- API with optional parameter(s) should have the most parameters amongst its public overloads -->
+      RS0036; <!-- Annotate nullability of public types and members in the declared API -->
+      RS0037; <!-- Enable tracking of nullability of reference types in the declared API -->
+      RS0041; <!-- Public members should not use oblivious types -->
+      RS0048; <!-- Missing shipped or unshipped public API file -->
+      RS0050; <!-- API is marked as removed but it exists in source code -->
+      RS0059; <!-- Do not add multiple public overloads with optional parameters -->
+      RS0060; <!-- API with optional parameter(s) should have the most parameters amongst its public overloads -->
+      RS0061; <!-- Constructor make noninheritable base class inheritable -->
+    </WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), '17.12.0.0'))">


### PR DESCRIPTION
Public API control was added with PR #530 to help with #453, but unfortunately, the tracking was getting outdated since warnings were being ignored. The following setting in `Directory.Build.props` is actually incorrect as it doesn't have the desired effect of treating warnings as error:

https://github.com/tonybaloney/CSnakes/blob/7a19e9ad4244219409dbe4a59bde50c0aa1927bc/src/Directory.Build.props#L7

The setting is called [`TreatWarningsAsErrors`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errors-warnings#treatwarningsaserrors).

In this PR, most warnings from **Microsoft.CodeAnalysis.PublicApiAnalyzers** are configured as errors so that the tracking is kept fresh and breaking changes can be caught when introduced. It also updates the shipped API list. The `WarningsAsErrors` can be removed we're ready to add `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`.

To test the effect of `WarningsAsErrors`, revert the `PublicAPI.Shipped.txt` files to those from [v1.1.0](https://github.com/tonybaloney/CSnakes/releases/tag/v1.1.0) and re-build:

```sh
git checkout fix/shipped-api-list # branch of this PR
git checkout v1.1.0 -- '*/PublicAPI.Shipped.txt'
dotnet build src
```

The build should fail with 24 errors (RS0016 + RS0017). Undo with:

```sh
git checkout fix/shipped-api-list -- .
```
