### PR TITLE
Lower symlink error to warnings

### DIFF
--- a/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
@@ -301,9 +301,10 @@ internal class RedistributableLocator(ILogger<RedistributableLocator>? logger, R
             {
                 File.CreateSymbolicLink(path, link);
             }
-            catch (Exception ex)
+            catch (System.IO.DirectoryNotFoundException ex)
             {
-                logger?.LogError(ex, "Failed to create symlink: {Path} -> {Link}", path, link);
+                // This is common in the packages
+                logger?.LogWarning(ex, "Failed to create symlink: {Path} -> {Link}", path, link);
             }
         }
     }


### PR DESCRIPTION
The redistributable packages have complex/invalid symlinks in the directory tree. This lowers the error level to warning since they can be ignored