### PR TITLE
Align Python Exec

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -346,6 +346,7 @@ using var result = env.ExecuteExpression("a+1", locals); // 102
 ```
 
 To execute a series of statements, you can use the `Execute` method, which also takes globals and locals:
+
 ```csharp
 var c = """
 a = 101
@@ -360,4 +361,7 @@ var globals = new Dictionary<string, PyObject>
     ["d"] = PyObject.From(100)
 };
 using var result = env.Execute(c, locals, globals);
+Console.WriteLine(locals["b"].ToString()); // 202
 ```
+
+The `locals` and `globals` dictionaries are mutable, so any changes to their values will be updated after the execution of the code.

--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -60,4 +60,22 @@ b = c + a
         using var result = env.Execute(c, locals, globals);
         Assert.Equal("None", result.ToString());
     }
+
+    [Fact]
+    public void TestExecuteWithLocalsUpdatesDict()
+    {
+        var code = """c = a * 2; b += 1""";
+        var locals = new Dictionary<string, PyObject>
+        {
+            ["a"] = PyObject.From(101)
+        };
+        var globals = new Dictionary<string, PyObject>
+        {
+            ["b"] = PyObject.From(100)
+        };
+        using var result = env.Execute(code, locals, globals);
+        Assert.Equal("None", result.ToString());
+        Assert.Equal(202, locals["c"].As<long>());
+        Assert.Equal(101, locals["b"].As<long>());
+    }
 }


### PR DESCRIPTION
Addresses #582 by converting the marshalled dictionaries used in Py_RunString back to the C# Dictionary<string, PyObject> and explicitly updating the globals and locals passed to the CSnakes functions.