### PR TITLE
Remove unused python reference from "Profile" project

### DIFF
--- a/src/Profile/Profile.csproj
+++ b/src/Profile/Profile.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" />
-    <PackageReference Include="python" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a follow-up to PR #649 that removes the unused python package reference from the **Profile** project.