### PR TITLE
Refactor `RedistributablePythonVersion` to remove reflection

### DIFF
--- a/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,23 @@
 #nullable enable
+CSnakes.Runtime.Locators.RedistributablePythonVersion.<Clone>$() -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+CSnakes.Runtime.Locators.RedistributablePythonVersion.Equals(CSnakes.Runtime.Locators.RedistributablePythonVersion? other) -> bool
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.Equals(object? obj) -> bool
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.GetHashCode() -> int
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.ToString() -> string!
+static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator !=(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
+static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator ==(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
 static CSnakes.Runtime.Python.PyObject.From(System.ReadOnlySpan<byte> value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, CSnakes.Runtime.Locators.RedistributablePythonVersion! version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_10 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_11 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_12 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_13 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_14 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_10 = 1 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_11 = 2 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_12 = 3 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_13 = 4 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_14 = 5 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 = 0 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, CSnakes.Runtime.Locators.RedistributablePythonVersion version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!

--- a/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,23 @@
 #nullable enable
+CSnakes.Runtime.Locators.RedistributablePythonVersion.<Clone>$() -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+CSnakes.Runtime.Locators.RedistributablePythonVersion.Equals(CSnakes.Runtime.Locators.RedistributablePythonVersion? other) -> bool
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.Equals(object? obj) -> bool
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.GetHashCode() -> int
+override CSnakes.Runtime.Locators.RedistributablePythonVersion.ToString() -> string!
+static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator !=(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
+static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator ==(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
 static CSnakes.Runtime.Python.PyObject.From(System.ReadOnlySpan<byte> value) -> CSnakes.Runtime.Python.PyObject!
+static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, CSnakes.Runtime.Locators.RedistributablePythonVersion! version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_10 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_11 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_12 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_13 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_14 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 -> CSnakes.Runtime.Locators.RedistributablePythonVersion!
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_10 = 1 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_11 = 2 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_12 = 3 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_13 = 4 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_14 = 5 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 = 0 -> CSnakes.Runtime.Locators.RedistributablePythonVersion
+*REMOVED*static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, CSnakes.Runtime.Locators.RedistributablePythonVersion version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!

--- a/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
+++ b/src/CSnakes.Runtime/ServiceCollectionExtensions.cs
@@ -209,7 +209,9 @@ public static partial class ServiceCollectionExtensions
     /// <param name="freeThreaded">Free Threaded Python (3.13+ only)</param>
     /// <param name="timeout">Timeout in seconds for the download and installation process.</param>
     /// <returns></returns>
+#pragma warning disable RS0026 // TODO Do not add multiple public overloads with optional parameters
     public static IPythonEnvironmentBuilder FromRedistributable(this IPythonEnvironmentBuilder builder, RedistributablePythonVersion version, bool debug = false, bool freeThreaded = false, int timeout = 360)
+#pragma warning restore RS0026
     {
         builder.Services.AddSingleton<PythonLocator>(
             sp =>


### PR DESCRIPTION
This PR propose to refactor the enum-based + attributes + reflection to represent redistributable Python versions with a reflection-free and static one. It should be faster, more type-safe and friendlier for Native AOT scenarios.

Since this is a **breaking change** (that should be mostly source-compatible), it should be noted for #631.

