### PR TITLE
Fix CS8603 + CS8604 warnings in setup of parsers

### DIFF
--- a/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj
+++ b/src/CSnakes.SourceGeneration/CSnakes.SourceGeneration.csproj
@@ -4,6 +4,7 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS1035</NoWarn>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
@@ -130,7 +130,9 @@ public static partial class PythonParser
         .Named("Ellipsis (unspecified) Constant");
 
     // Any constant value
-    public static TokenListParser<PythonToken, PythonConstant> ConstantValueTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant> ConstantValueParser { get; }
+
+    private static TokenListParser<PythonToken, PythonConstant> CreateConstantValueParser() =>
         DecimalConstantTokenizer.AsBase()
         .Or(IntegerConstantTokenizer.AsBase())
         .Or(HexadecimalIntegerConstantTokenizer.AsBase())

--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Function.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Function.cs
@@ -9,7 +9,9 @@ using ParsedTokens = Superpower.Model.TokenList<CSnakes.Parser.PythonToken>;
 namespace CSnakes.Parser;
 public static partial class PythonParser
 {
-    public static TokenListParser<PythonToken, PythonFunctionDefinition> PythonFunctionDefinitionParser { get; } =
+    public static TokenListParser<PythonToken, PythonFunctionDefinition> PythonFunctionDefinitionParser { get; }
+
+    static TokenListParser<PythonToken, PythonFunctionDefinition> CreatePythonFunctionDefinitionParser() =>
         (from async in Token.EqualTo(PythonToken.Async).OptionalOrDefault()
          from def in Token.EqualTo(PythonToken.Def)
          from name in Token.EqualTo(PythonToken.Identifier)

--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Parameters.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Parameters.cs
@@ -7,8 +7,9 @@ using Superpower.Parsers;
 namespace CSnakes.Parser;
 public static partial class PythonParser
 {
-    private static TokenListParser<PythonToken, PythonFunctionParameter>
-        PythonParameterParser { get; } =
+    private static TokenListParser<PythonToken, PythonFunctionParameter> PythonParameterParser { get; }
+
+    private static TokenListParser<PythonToken, PythonFunctionParameter> CreatePythonParameterParser() =>
             (from name in Token.EqualTo(PythonToken.Identifier)
              from type in Token.EqualTo(PythonToken.Colon)
                                .IgnoreThen(PythonTypeDefinitionParser.AsNullable())
@@ -16,17 +17,17 @@ public static partial class PythonParser
              select new PythonFunctionParameter(name.ToStringValue(), type, null))
            .Named("Parameter");
 
-    public static TokenListParser<PythonToken, PythonFunctionParameter>
-        OptionalPythonParameterParser { get; } =
+    public static TokenListParser<PythonToken, PythonFunctionParameter> OptionalPythonParameterParser { get; }
+
+    static TokenListParser<PythonToken, PythonFunctionParameter> CreateOptionalPythonParameterParser() =>
             (from param in PythonParameterParser
              from defaultValue in Token.EqualTo(PythonToken.Equal)
-                                       .IgnoreThen(ConstantValueTokenizer.AsNullable())
+                                       .IgnoreThen(ConstantValueParser.AsNullable())
                                        .OptionalOrDefault()
              select param.WithDefaultValue(defaultValue))
             .Named("Parameter");
 
-    public static TokenListParser<PythonToken, PythonFunctionParameterList> PythonParameterListParser { get; } =
-        CreatePythonParameterListParser();
+    public static TokenListParser<PythonToken, PythonFunctionParameterList> PythonParameterListParser { get; }
 
     private static TokenListParser<PythonToken, PythonFunctionParameterList> CreatePythonParameterListParser()
     {

--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.cs
@@ -1,0 +1,14 @@
+namespace CSnakes.Parser;
+
+partial class PythonParser
+{
+    static PythonParser()
+    {
+        ConstantValueParser = CreateConstantValueParser();
+        PythonTypeDefinitionParser = CreatePythonTypeDefinitionParser();
+        PythonParameterParser = CreatePythonParameterParser();
+        OptionalPythonParameterParser = CreateOptionalPythonParameterParser();
+        PythonParameterListParser = CreatePythonParameterListParser();
+        PythonFunctionDefinitionParser = CreatePythonFunctionDefinitionParser();
+    }
+}

--- a/src/CSnakes.Tests/TokenizerTests.cs
+++ b/src/CSnakes.Tests/TokenizerTests.cs
@@ -723,7 +723,7 @@ if __name__ == '__main__':
     {
         var tokens = PythonTokenizer.Instance.Tokenize(code);
         Assert.Single(tokens);
-        var result = PythonParser.ConstantValueTokenizer.TryParse(tokens);
+        var result = PythonParser.ConstantValueParser.TryParse(tokens);
 
         Assert.True(result.HasValue);
         Assert.NotNull(result.Value);


### PR DESCRIPTION
This PR addressed the following warnings in the **CSnakes.SourceGeneration** project:

    src\CSnakes.SourceGeneration\Parser\PythonParser.Function.cs(16,29): warning CS8603: Possible null reference return.
    src\CSnakes.SourceGeneration\Parser\PythonParser.Function.cs(18,43): warning CS8604: Possible null reference argument for parameter 'second' in 'TokenListParser<PythonToken, PythonTypeSpec> Combinators.IgnoreThen<PythonToken, Token<PythonToken>, PythonTypeSpec>(TokenListParser<PythonToken, Token<PythonToken>> first, TokenListParser<PythonToken, PythonTypeSpec> second)'.
    src\CSnakes.SourceGeneration\Parser\PythonParser.Parameters.cs(14,44): warning CS8604: Possible null reference argument for parameter 'parser' in 'TokenListParser<PythonToken, PythonTypeSpec?> Combinators.AsNullable<PythonToken, PythonTypeSpec>(TokenListParser<PythonToken, PythonTypeSpec> parser)'.

These warnings occur due to the field initialisation order being affected by the partial definitions of `PythonParser` being spread across different files and the order in which the compiler sees and process them.

The initialisation of the parser fields is moved to the static constructor for `PythonParser` with a deterministic order.
