### PR TITLE
Improvement to logging bridge prototype

### DIFF
--- a/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -8,7 +8,7 @@ override CSnakes.Runtime.Locators.RedistributablePythonVersion.ToString() -> str
 static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator !=(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
 static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator ==(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
 static CSnakes.Runtime.Python.PyObject.From(System.ReadOnlySpan<byte> value) -> CSnakes.Runtime.Python.PyObject!
-static CSnakes.Runtime.PythonLogger.WithPythonLogging(this CSnakes.Runtime.IPythonEnvironment! env, Microsoft.Extensions.Logging.ILogger! logger) -> void
+static CSnakes.Runtime.PythonLogger.WithPythonLogging(this CSnakes.Runtime.IPythonEnvironment! env, Microsoft.Extensions.Logging.ILogger! logger) -> System.IDisposable!
 CSnakes.Runtime.Python.KeywordArg
 CSnakes.Runtime.Python.KeywordArg.Deconstruct(out string! Name, out CSnakes.Runtime.Python.PyObject! Value) -> void
 CSnakes.Runtime.Python.KeywordArg.Equals(CSnakes.Runtime.Python.KeywordArg other) -> bool

--- a/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -8,7 +8,7 @@ override CSnakes.Runtime.Locators.RedistributablePythonVersion.ToString() -> str
 static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator !=(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
 static CSnakes.Runtime.Locators.RedistributablePythonVersion.operator ==(CSnakes.Runtime.Locators.RedistributablePythonVersion? left, CSnakes.Runtime.Locators.RedistributablePythonVersion? right) -> bool
 static CSnakes.Runtime.Python.PyObject.From(System.ReadOnlySpan<byte> value) -> CSnakes.Runtime.Python.PyObject!
-static CSnakes.Runtime.PythonLogger.WithPythonLogging(this CSnakes.Runtime.IPythonEnvironment! env, Microsoft.Extensions.Logging.ILogger! logger) -> void
+static CSnakes.Runtime.PythonLogger.WithPythonLogging(this CSnakes.Runtime.IPythonEnvironment! env, Microsoft.Extensions.Logging.ILogger! logger) -> System.IDisposable!
 CSnakes.Runtime.Python.KeywordArg
 CSnakes.Runtime.Python.KeywordArg.Deconstruct(out string! Name, out CSnakes.Runtime.Python.PyObject! Value) -> void
 CSnakes.Runtime.Python.KeywordArg.Equals(CSnakes.Runtime.Python.KeywordArg other) -> bool

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -75,19 +75,19 @@ public static class PythonLogger
         switch (level)
         {
             // https://docs.python.org/3/library/logging.html#levels
-            case >= 50:
+            case >= 50 when logger.IsEnabled(LogLevel.Critical):
                 logger.LogCritical(message);
                 break;
-            case >= 40:
+            case >= 40 when logger.IsEnabled(LogLevel.Error):
                 logger.LogError(message);
                 break;
-            case >= 30:
+            case >= 30 when logger.IsEnabled(LogLevel.Warning):
                 logger.LogWarning(message);
                 break;
-            case >= 20:
+            case >= 20 when logger.IsEnabled(LogLevel.Information):
                 logger.LogInformation(message);
                 break;
-            case >= 10:
+            case >= 10 when logger.IsEnabled(LogLevel.Error):
                 logger.LogDebug(message);
                 break;
             default:

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -1,5 +1,6 @@
 using CSnakes.Runtime.Python;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace CSnakes.Runtime;
 
@@ -9,112 +10,147 @@ namespace CSnakes.Runtime;
 /// </summary>
 public static class PythonLogger
 {
-    // TODO : Handle Close request via a destructor or IDisposable pattern.
-    // It should call the handlers' .close() method
-
-    public static void WithPythonLogging(this IPythonEnvironment env, ILogger logger)
+    public static IDisposable WithPythonLogging(this IPythonEnvironment env, ILogger logger)
     {
-        using var handler = CreateHandler();
-        RecordListener(handler, logger);
+        return Bridge.Create(logger);
     }
 
-    internal static PyObject CreateHandler(string? loggerName = null)
+    private sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler) : IDisposable
     {
-        const string handlerPythonCode = """
-            import logging
-            import queue
-            import time
+        internal static Bridge Create(ILogger logger, string? loggerName = null)
+        {
+            const string handlerPythonCode = """
+                import logging
+                import queue
+                import time
 
 
-            class __csnakesMemoryHandler(logging.Handler):
-                def __init__(self):
-                    logging.Handler.__init__(self)
-                    self.queue = queue.Queue()
+                class __csnakesMemoryHandler(logging.Handler):
+                    def __init__(self):
+                        logging.Handler.__init__(self)
+                        self.queue = queue.Queue()
 
-                def emit(self, record):
-                    try:
-                        self.queue.put(record)
-                    except queue.ShutDown:
-                        pass
-
-                def get_records(self):  # equivalent to flush()
-                    while True:
+                    def emit(self, record):
                         try:
-                            record = self.queue.get()
+                            self.queue.put(record)
                         except queue.ShutDown:
-                            break
-                        else:
+                            pass
+
+                    def get_records(self):  # equivalent to flush()
+                        while True:
+                            record = self.queue.get()
                             self.queue.task_done()
+                            if record is None:
+                                break
                             yield (record.levelno, record.msg)
 
-                def close(self):
-                    self.queue.shutdown()
-                    logging.Handler.close(self)
+                    def close(self):
+                        self.queue.put(None)
+                        logging.Handler.close(self)
 
-            def installCSnakesHandler(handler, name = None):
-                logging.getLogger(name).addHandler(handler)
 
-            """;
+                def installCSnakesHandler(handler, name = None):
+                    logging.getLogger(name).addHandler(handler)
 
-        using (GIL.Acquire())
-        {
-            using var module = Import.ImportModule("_csnakesLoggingBridge", handlerPythonCode, "_csnakesLoggingBridge.py");
-            using var __csnakesMemoryHandlerCls = module.GetAttr("__csnakesMemoryHandler");
-            var handler = __csnakesMemoryHandlerCls.Call();
-            using var __installCSnakesHandler = module.GetAttr("installCSnakesHandler");
-            using var loggerNameStr = PyObject.From(loggerName);
-            __installCSnakesHandler.Call(handler, loggerNameStr);
 
-            return handler;
-        }
-    }
+                def uninstallCSnakesHandler(handler, name = None):
+                    handler.close()
+                    logging.getLogger(name).removeHandler(handler)
 
-    private static void HandleRecord(ILogger logger, long level, string message)
-    {
-        // TODO: Handle Attributes and other useful things.
-        // Look at the LogRecord class for details.
-        switch (level)
-        {
-            // https://docs.python.org/3/library/logging.html#levels
-            case >= 50 when logger.IsEnabled(LogLevel.Critical):
-                logger.LogCritical(message);
-                break;
-            case >= 40 when logger.IsEnabled(LogLevel.Error):
-                logger.LogError(message);
-                break;
-            case >= 30 when logger.IsEnabled(LogLevel.Warning):
-                logger.LogWarning(message);
-                break;
-            case >= 20 when logger.IsEnabled(LogLevel.Information):
-                logger.LogInformation(message);
-                break;
-            case >= 10 when logger.IsEnabled(LogLevel.Error):
-                logger.LogDebug(message);
-                break;
-            default:
-                // NOTSET
-                break;
-        }
-    }
+                """;
 
-    internal static void RecordListener(PyObject handler, ILogger logger)
-    {
-        IGeneratorIterator<(long, string), PyObject, PyObject> generator;
-        using (GIL.Acquire())
-        {
-            using PyObject getRecordsMethod = handler.GetAttr("get_records");
-            using PyObject __result_pyObject = getRecordsMethod.Call();
-            generator = __result_pyObject.BareImportAs<IGeneratorIterator<(long, string), PyObject, PyObject>, PyObjectImporters.Generator<(long, string), PyObject, PyObject, PyObjectImporters.Tuple<long, string, PyObjectImporters.Int64, PyObjectImporters.String>, PyObjectImporters.Runtime<PyObject>>>();
-        }
-
-        // Wait for the generator to finish
-        var task = Task.Run(() =>
-        {
-            while (generator.MoveNext())
+            using (GIL.Acquire())
             {
-                var (level, message) = generator.Current;
-                HandleRecord(logger, (int)level, message);
+                using var module = Import.ImportModule("_csnakesLoggingBridge", handlerPythonCode, "_csnakesLoggingBridge.py");
+                using var __csnakesMemoryHandlerCls = module.GetAttr("__csnakesMemoryHandler");
+                using var __installCSnakesHandler = module.GetAttr("installCSnakesHandler");
+                PyObject? handler = null;
+                PyObject? uninstallCSnakesHandler = null;
+                Task task;
+
+                try
+                {
+                    handler = __csnakesMemoryHandlerCls.Call();
+                    uninstallCSnakesHandler = module.GetAttr("uninstallCSnakesHandler");
+
+                    using var loggerNameStr = PyObject.From(loggerName);
+                    __installCSnakesHandler.Call(handler, loggerNameStr).Dispose();
+
+                    RecordListener(handler, logger);
+                }
+                catch
+                {
+                    handler?.Dispose();
+                    uninstallCSnakesHandler?.Dispose();
+                    throw;
+                }
+
+                return new(handler, uninstallCSnakesHandler);
             }
-        });
+        }
+
+        private static void HandleRecord(ILogger logger, long level, string message)
+        {
+            // TODO: Handle Attributes and other useful things.
+            // Look at the LogRecord class for details.
+            switch (level)
+            {
+                // https://docs.python.org/3/library/logging.html#levels
+                case >= 50 when logger.IsEnabled(LogLevel.Critical):
+                    logger.LogCritical(message);
+                    break;
+                case >= 40 when logger.IsEnabled(LogLevel.Error):
+                    logger.LogError(message);
+                    break;
+                case >= 30 when logger.IsEnabled(LogLevel.Warning):
+                    logger.LogWarning(message);
+                    break;
+                case >= 20 when logger.IsEnabled(LogLevel.Information):
+                    logger.LogInformation(message);
+                    break;
+                case >= 10 when logger.IsEnabled(LogLevel.Error):
+                    logger.LogDebug(message);
+                    break;
+                default:
+                    // NOTSET
+                    break;
+            }
+        }
+
+        internal static void RecordListener(PyObject handler, ILogger logger)
+        {
+            IGeneratorIterator<(long, string), PyObject, PyObject> generator;
+            using (GIL.Acquire())
+            {
+                using PyObject getRecordsMethod = handler.GetAttr("get_records");
+                using PyObject __result_pyObject = getRecordsMethod.Call();
+                generator = __result_pyObject.BareImportAs<IGeneratorIterator<(long, string), PyObject, PyObject>, PyObjectImporters.Generator<(long, string), PyObject, PyObject, PyObjectImporters.Tuple<long, string, PyObjectImporters.Int64, PyObjectImporters.String>, PyObjectImporters.Runtime<PyObject>>>();
+            }
+
+            // Wait for the generator to finish
+            _ = Task.Run(() =>
+            {
+                while (generator.MoveNext())
+                {
+                    var (level, message) = generator.Current;
+                    HandleRecord(logger, (int)level, message);
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                uninstallCSnakesHandler.Call(handler).Dispose();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error during uninstallation of handler: {ex}");
+            }
+
+            handler.Dispose();
+            uninstallCSnakesHandler.Dispose();
+        }
     }
 }

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -62,7 +62,8 @@ public static class PythonLogger
             using var __csnakesMemoryHandlerCls = module.GetAttr("__csnakesMemoryHandler");
             var handler = __csnakesMemoryHandlerCls.Call();
             using var __installCSnakesHandler = module.GetAttr("installCSnakesHandler");
-            __installCSnakesHandler.Call(handler, PyObject.From(loggerName));
+            using var loggerNameStr = PyObject.From(loggerName);
+            __installCSnakesHandler.Call(handler, loggerNameStr);
 
             return handler;
         }

--- a/src/Integration.Tests/LoggingTests.cs
+++ b/src/Integration.Tests/LoggingTests.cs
@@ -42,14 +42,15 @@ public class LoggingTests : IntegrationTestBase
     public void TestLogging_TestDebug()
     {
         var testModule = Env.TestLogging();
-        Env.WithPythonLogging(this.logger);
-
-        testModule.TestLogDebug();
-        var entry = TryTake();
-        Assert.NotNull(entry);
-        Assert.Equal(LogLevel.Debug, entry.Level);
-        Assert.Equal("Hello world", entry.Message);
-        Assert.Null(TryTake());
+        using (Env.WithPythonLogging(this.logger))
+        {
+            testModule.TestLogDebug();
+            var entry = TryTake();
+            Assert.NotNull(entry);
+            Assert.Equal(LogLevel.Debug, entry.Level);
+            Assert.Equal("Hello world", entry.Message);
+            Assert.Null(TryTake());
+        }
     }
 
     // TODO : Test lots of log messages

--- a/src/Integration.Tests/LoggingTests.cs
+++ b/src/Integration.Tests/LoggingTests.cs
@@ -1,66 +1,55 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Integration.Tests;
 
-public class LoggingTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(fixture)
+public class LoggingTests : IntegrationTestBase
 {
-    // Credit Ben ABT's blog https://benjamin-abt.com/blog/2025/09/03/dotnet-unit-test-ilogger-inmemory/
+    private sealed record LogEntry(LogLevel Level, EventId Id, Exception? Exception, string Message);
 
-    private class InMemoryLogger : ILogger
+    private class ObservableLogger : ILogger
     {
-        // Lock used to synchronize writes and snapshot reads. Kept internal to avoid external locking mistakes.
-        private readonly object _lock = new();
-
-        public List<(LogLevel Level, EventId Id, Exception? Ex, string Message)> Entries = [];
+        public event EventHandler<LogEntry>? Logged;
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => default!;
 
         public bool IsEnabled(LogLevel logLevel) => true;
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-          Func<TState, Exception?, string> formatter)
-        {
-            // Keep the append atomic with the lock so snapshots can be taken reliably without race conditions.
-            lock (_lock)
-            {
-                Entries.Add(new(logLevel, eventId, exception, formatter(state, exception)));
-            }
-        }
-
-        public bool Has(LogLevel logLevel, EventId id)
-        {
-            lock (_lock)
-            {
-                return Entries.Exists(x => x.Level == logLevel && x.Id == id);
-            }
-        }
-
-        public IReadOnlyList<(LogLevel Level, EventId Id, Exception? Ex, string Message)> GetEntriesSnapshot()
-        {
-            lock (_lock)
-            {
-                return [.. Entries];
-            }
-        }
+                                Func<TState, Exception?, string> formatter) =>
+            Logged?.Invoke(this, new(logLevel, eventId, exception, formatter(state, exception)));
     }
+
+    private readonly ObservableLogger logger;
+    private readonly BlockingCollection<LogEntry> entries = new();
+
+    public LoggingTests(PythonEnvironmentFixture fixture) : base(fixture)
+    {
+        logger = new ObservableLogger();
+        logger.Logged += (_, entry) => entries.Add(entry);
+    }
+
+    private LogEntry? TryTake() =>
+        entries.TryTake(out var entry, millisecondsTimeout: 3_000, TestContext.Current.CancellationToken) ? entry : null;
 
     [Fact]
     public void TestLogging_TestDebug()
     {
         var testModule = Env.TestLogging();
-        var testLogger = new InMemoryLogger();
-        Env.WithPythonLogging(testLogger);
+        Env.WithPythonLogging(this.logger);
+
         testModule.TestLogDebug();
-        // records
-        // Wait a bit
-        Thread.Sleep(200); // TODO: Work out a better way of handling this.
-        var entries = testLogger.GetEntriesSnapshot();
-        Assert.Single(entries);
-        Assert.Equal(LogLevel.Debug, entries[0].Level);
-        Assert.Equal("Hello world", entries[0].Message);
+        var entry = TryTake();
+        Assert.NotNull(entry);
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        Assert.Equal("Hello world", entry.Message);
+        Assert.Null(TryTake());
     }
 
     // TODO : Test lots of log messages


### PR DESCRIPTION
This PR builds on top of PR #680 and makes the following improvements:

- All sleeps are gone, both on the Python and the .NET side
- To-do comment about closing is addressed (although lifetime in general is unclear)
- Logger name is disposed
- Log record level and message is marshaled efficiently as a tuple
- Addition of log level guards
