### PR TITLE
Add DisableDiscoveryEnumeration to MemberData attributes in ConverterTestBase

### DIFF
--- a/src/CSnakes.Runtime.Tests/Converter/ConverterTestBase.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/ConverterTestBase.cs
@@ -22,7 +22,7 @@ public abstract class ConverterTestBase<T, TTestCases> : RuntimeTestBase
     }
 
     [Theory]
-    [MemberData(nameof(SubTestCases))]
+    [MemberData(nameof(SubTestCases), DisableDiscoveryEnumeration = true)]
     public void RoundtripViaAs(T input) =>
         TestRoundtrip(input, static obj => obj.As<T>());
 }
@@ -33,7 +33,7 @@ public abstract class ConverterTestBase<T, TImporter, TTestCases> :
     where TTestCases : IConverterTestCasesContainer<T>
 {
     [Theory]
-    [MemberData(nameof(SubTestCases))]
+    [MemberData(nameof(SubTestCases),DisableDiscoveryEnumeration = true)]
     public void RoundtripViaImport(T input) =>
         TestRoundtrip(input, static obj => obj.ImportAs<T, TImporter>());
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the test discovery behavior in the `ConverterTestBase` test classes. The key change is the addition of the `DisableDiscoveryEnumeration = true` parameter to the `[MemberData]` attribute, which can improve test performance and reliability in certain scenarios.


Test attribute adjustments:

* Added `DisableDiscoveryEnumeration = true` to the `[MemberData]` attribute in `RoundtripViaAs` and `RoundtripViaImport` test methods in `ConverterTestBase`. This can help avoid issues with test discovery and enumeration, especially for large or complex data sets. [[1]](diffhunk://#diff-c8e299876bd053d2fc73b953d70bbe9d2c9693dc0add9dbb90f5b0be31d6e5deL25-R25) [[2]](diffhunk://#diff-c8e299876bd053d2fc73b953d70bbe9d2c9693dc0add9dbb90f5b0be31d6e5deL36-R36)
Investigate broken build on xUnit 3.0.1 upgrade
Fixes #678