### PR TITLE
Use build-time conversions for `None` & `Any`

### DIFF
--- a/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -20,6 +20,7 @@ CSnakes.Runtime.Python.PyObject.Call(params System.ReadOnlySpan<CSnakes.Runtime.
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, params System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargv) -> CSnakes.Runtime.Python.PyObject!
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.None
 override CSnakes.Runtime.Python.KeywordArg.GetHashCode() -> int
 static CSnakes.Runtime.Python.KeywordArg.operator !=(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
 static CSnakes.Runtime.Python.KeywordArg.operator ==(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool

--- a/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -20,6 +20,7 @@ CSnakes.Runtime.Python.PyObject.Call(params System.ReadOnlySpan<CSnakes.Runtime.
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, params System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargv) -> CSnakes.Runtime.Python.PyObject!
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.None
 override CSnakes.Runtime.Python.KeywordArg.GetHashCode() -> int
 static CSnakes.Runtime.Python.KeywordArg.operator !=(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
 static CSnakes.Runtime.Python.KeywordArg.operator ==(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool

--- a/src/CSnakes.Runtime/Python/PyObjectImporters.cs
+++ b/src/CSnakes.Runtime/Python/PyObjectImporters.cs
@@ -22,6 +22,17 @@ public static partial class PyObjectImporters
         }
     }
 
+    public sealed class None : IPyObjectImporter<PyObject>
+    {
+        private None() { }
+
+        static PyObject IPyObjectImporter<PyObject>.BareImport(PyObject obj)
+        {
+            GIL.Require();
+            return obj.IsNone() ? PyObject.None : throw InvalidCastException("None", obj);
+        }
+    }
+
     public sealed class Runtime<T> : IPyObjectImporter<T>
     {
         private Runtime() { }

--- a/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
+++ b/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
@@ -18,6 +18,8 @@ internal interface IResultConversionCodeGenerator
 
 internal static class ResultConversionCodeGenerator
 {
+    private static readonly IResultConversionCodeGenerator None = ScalarConversionGenerator(ParseTypeName("PyObject"), "None");
+    private static readonly IResultConversionCodeGenerator Any = ScalarConversionGenerator(ParseTypeName("PyObject"), "Clone");
     private static readonly IResultConversionCodeGenerator Long = ScalarConversionGenerator(SyntaxKind.LongKeyword, "Int64");
     private static readonly IResultConversionCodeGenerator String = ScalarConversionGenerator(SyntaxKind.StringKeyword, "String");
     private static readonly IResultConversionCodeGenerator Boolean = ScalarConversionGenerator(SyntaxKind.BoolKeyword, "Boolean");
@@ -37,6 +39,8 @@ internal static class ResultConversionCodeGenerator
     {
         switch (pythonTypeSpec)
         {
+            case NoneType: return None;
+            case AnyType: return Any;
             case IntType: return Long;
             case StrType: return String;
             case FloatType: return Double;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -266,7 +266,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_bytes_async;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<byte[], PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<byte[], PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.ByteArray, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<byte[], PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<byte[], PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.ByteArray, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -97,7 +97,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }
@@ -109,7 +109,7 @@ public static class TestClassExtensions
                 this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_raises_exception");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_raises_exception;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
-                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }
@@ -122,7 +122,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_returns_nothing;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<PyObject, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<PyObject, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<PyObject, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<PyObject, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.None, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
@@ -109,7 +109,7 @@ public static class TestClassExtensions
                 this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_normal_generator");
                 PyObject __underlyingPythonFunc = this.__func_test_normal_generator;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
-                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
+                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.None>>();
                 return __return;
             }
         }
@@ -121,7 +121,7 @@ public static class TestClassExtensions
                 this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_generator_sequence");
                 PyObject __underlyingPythonFunc = this.__func_test_generator_sequence;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
-                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
+                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.None>>();
                 return __return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
@@ -129,7 +129,7 @@ public static class TestClassExtensions
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(obj_pyObject);
                 if (__result_pyObject.IsNone())
                     return null;
-                var __return = __result_pyObject.BareImportAs<PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>();
+                var __return = __result_pyObject.BareImportAs<PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Clone>();
                 return __return;
             }
         }


### PR DESCRIPTION
The `None` and `Any` types were mapped by the source generator to use the [run-time improter](https://github.com/tonybaloney/CSnakes/blob/9becb1ac776a9a651c62b03676943dc0f4e30dcd/src/CSnakes.Runtime/Python/PyObjectImporters.cs#L25-L34), which relies on `PyObject.As<T>()`. This PR improves the mapping to use more statically bound importers like the new `PyObjectImporters.None` for `None` and `PyObjectImporters.Clone` for `Any`.

This helps with the following issues related to supporting more Native AOT scenarios:

- #381
- #679
- #671

While the use of `PyObject.As<T>()` was harmless for these two particular cases, the less it's used, the better.
