### PR TITLE
Dispose processes in helpers, returning exit code

### DIFF
--- a/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
+++ b/src/CSnakes.Runtime/EnvironmentManagement/VenvEnvironmentManagement.cs
@@ -20,18 +20,14 @@ internal class VenvEnvironmentManagement(ILogger? logger, string path, bool ensu
         if (!Directory.Exists(path))
         {
             logger?.LogDebug("Creating virtual environment at {VirtualEnvPath} using {PythonBinaryPath}", fullPath, pythonLocation.PythonBinaryPath);
-            var (process1, _, _) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, "-VV");
-            var (process2, _, error) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, "-m", "venv",  fullPath);
+            var (exitCode1, _, _) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, "-VV");
+            var (exitCode2, _, error) = ProcessUtils.ExecutePythonCommand(logger, pythonLocation, "-m", "venv",  fullPath);
 
-            if (process1.ExitCode != 0 || process2.ExitCode != 0)
+            if (exitCode1 != 0 || exitCode2 != 0)
             {
                 logger?.LogError("Failed to create virtual environment.");
-                process1.Dispose();
-                process2.Dispose();
                 throw new InvalidOperationException($"Could not create virtual environment. {error}");
             }
-            process1.Dispose();
-            process2.Dispose();
         }
         else
         {

--- a/src/CSnakes.Runtime/Locators/CondaLocator.cs
+++ b/src/CSnakes.Runtime/Locators/CondaLocator.cs
@@ -17,13 +17,12 @@ internal class CondaLocator : PythonLocator
     {
         this.logger = logger;
         this.condaBinaryPath = condaBinaryPath;
-        var (process, result, errors) = ExecuteCondaCommand("info", "--json");
-        if (process.ExitCode != 0)
+        var (exitCode, result, errors) = ExecuteCondaCommand("info", "--json");
+        if (exitCode != 0)
         {
             logger?.LogError("Failed to determine Python version from Conda {Error}.", errors);
             throw new InvalidOperationException("Could not determine Python version from Conda.");
         }
-        process.Dispose();
         // Parse JSON output to get the version
         var json = JsonNode.Parse(result ?? "")!;
         var versionAttribute = json["python_version"]?.GetValue<string>() ?? string.Empty;
@@ -43,7 +42,7 @@ internal class CondaLocator : PythonLocator
         folder = basePrefix;
     }
 
-    internal (Process process, string? output, string? errors) ExecuteCondaCommand(params string[] arguments) => ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
+    internal (int exitCode, string? output, string? errors) ExecuteCondaCommand(params string[] arguments) => ProcessUtils.ExecuteCommand(logger, condaBinaryPath, arguments);
 
     internal bool ExecuteCondaShellCommand(params string[] arguments) => ProcessUtils.ExecuteShellCommand(logger, condaBinaryPath, arguments);
 

--- a/src/CSnakes.Runtime/ProcessUtils.cs
+++ b/src/CSnakes.Runtime/ProcessUtils.cs
@@ -7,7 +7,7 @@ namespace CSnakes.Runtime;
 
 internal static class ProcessUtils
 {
-    internal static (Process proc, string? result, string? errors) ExecutePythonCommand(ILogger? logger, PythonLocationMetadata pythonLocation, params string[] arguments)
+    internal static (int exitCode, string? result, string? errors) ExecutePythonCommand(ILogger? logger, PythonLocationMetadata pythonLocation, params string[] arguments)
     {
 
         ProcessStartInfo startInfo = new(pythonLocation.PythonBinaryPath, arguments)
@@ -20,7 +20,7 @@ internal static class ProcessUtils
         return ExecuteCommand(logger, startInfo);
     }
 
-    internal static (Process proc, string? result, string? errors) ExecuteCommand(ILogger? logger, string fileName, params string[] arguments)
+    internal static (int exitCode, string? result, string? errors) ExecuteCommand(ILogger? logger, string fileName, params string[] arguments)
     {
         ProcessStartInfo startInfo = new(fileName, arguments)
         {
@@ -40,16 +40,16 @@ internal static class ProcessUtils
             CreateNoWindow = true,
             WindowStyle = ProcessWindowStyle.Hidden,
         };
-        Process process = new() { StartInfo = startInfo };
+        using Process process = new() { StartInfo = startInfo };
         process.Start();
         process.WaitForExit();
         return process.ExitCode == 0;
     }
 
 
-    private static (Process proc, string? result, string? errors) ExecuteCommand(ILogger? logger, ProcessStartInfo startInfo)
+    private static (int exitCode, string? result, string? errors) ExecuteCommand(ILogger? logger, ProcessStartInfo startInfo)
     {
-        Process process = new() { StartInfo = startInfo };
+        using Process process = new() { StartInfo = startInfo };
         string? result = null;
         string? errors = null;
         process.OutputDataReceived += (sender, e) =>
@@ -74,7 +74,7 @@ internal static class ProcessUtils
         process.BeginErrorReadLine();
         process.BeginOutputReadLine();
         process.WaitForExit();
-        return (process, result, errors);
+        return (process.ExitCode, result, errors);
     }
 
     internal static void ExecuteProcess(string fileName, IEnumerable<string> arguments, string workingDirectory, string path, ILogger? logger, IReadOnlyDictionary<string, string?>? extraEnv = null)


### PR DESCRIPTION
This PR refactors the process execution utilities to contain the resource management and simplify usage. The main change is to return only the process exit code (instead of the `Process` object) from command execution methods and dispose the `Process` before returning instead of making it the responsibility of the caller. The `Process` object returned up to now was never used for any other purpose except to query the exit code.