### PR TITLE
🚧 Add dynamic code attributes for flagging Native AOT compatibility

### DIFF
--- a/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -20,6 +20,7 @@ CSnakes.Runtime.Python.PyObject.Call(params System.ReadOnlySpan<CSnakes.Runtime.
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, params System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargv) -> CSnakes.Runtime.Python.PyObject!
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.None
 override CSnakes.Runtime.Python.KeywordArg.GetHashCode() -> int
 static CSnakes.Runtime.Python.KeywordArg.operator !=(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
 static CSnakes.Runtime.Python.KeywordArg.operator ==(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool

--- a/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -20,6 +20,7 @@ CSnakes.Runtime.Python.PyObject.Call(params System.ReadOnlySpan<CSnakes.Runtime.
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, params System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargv) -> CSnakes.Runtime.Python.PyObject!
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.None
 override CSnakes.Runtime.Python.KeywordArg.GetHashCode() -> int
 static CSnakes.Runtime.Python.KeywordArg.operator !=(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
 static CSnakes.Runtime.Python.KeywordArg.operator ==(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.Coroutine.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.Coroutine.cs
@@ -1,11 +1,13 @@
 using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.Python;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace CSnakes.Runtime;
 internal partial class PyObjectTypeConverter
 {
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     internal static object ConvertToCoroutine(PyObject pyObject, Type destinationType)
     {
         Debug.Assert(destinationType.IsGenericType);

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.Dictionary.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.Dictionary.cs
@@ -1,10 +1,12 @@
 using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.Python;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSnakes.Runtime;
 internal partial class PyObjectTypeConverter
 {
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     private static object ConvertToDictionary(PyObject pyObject, Type destinationType, bool useMappingProtocol = false)
     {
         Type keyType = destinationType.GetGenericArguments()[0];

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.Generator.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.Generator.cs
@@ -1,11 +1,13 @@
 using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.Python;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace CSnakes.Runtime;
 internal partial class PyObjectTypeConverter
 {
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     internal static object ConvertToGeneratorIterator(PyObject pyObject, Type destinationType)
     {
         Debug.Assert(destinationType.IsGenericType);

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.List.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.List.cs
@@ -1,10 +1,12 @@
 using CSnakes.Runtime.Python;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace CSnakes.Runtime;
 internal partial class PyObjectTypeConverter
 {
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     private static object ConvertToList(PyObject pyObject, Type destinationType)
     {
         Type genericArgument = destinationType.GetGenericArguments()[0];

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.Tuple.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.Tuple.cs
@@ -1,5 +1,6 @@
 using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.Python;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -18,7 +19,8 @@ internal partial class PyObjectTypeConverter
         return Pack.CreateTuple(pyObjects);
     }
 
-    internal static ITuple ConvertToTuple(PyObject pyObj, Type destinationType)
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
+    internal static ITuple ConvertToTuple(PyObject pyObj, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type destinationType)
     {
         if (!CPythonAPI.IsPyTuple(pyObj))
         {

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.Utils.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.Utils.cs
@@ -1,11 +1,12 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSnakes.Runtime;
 internal partial class PyObjectTypeConverter
 {
     private static readonly ConcurrentDictionary<(Type, Type), bool> assignableGenericsMap = [];
 
-    public static bool IsAssignableToGenericType(Type givenType, Type genericType)
+    public static bool IsAssignableToGenericType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type givenType, Type genericType)
     {
         if (assignableGenericsMap.TryGetValue((givenType, genericType), out bool result))
             return result;

--- a/src/CSnakes.Runtime/PyObjectTypeConverter.cs
+++ b/src/CSnakes.Runtime/PyObjectTypeConverter.cs
@@ -1,6 +1,7 @@
 using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.Python;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace CSnakes.Runtime;
@@ -8,7 +9,10 @@ internal partial class PyObjectTypeConverter
 {
     private static readonly ConcurrentDictionary<Type, DynamicTypeInfo> knownDynamicTypes = [];
 
-    public static object PyObjectToManagedType(PyObject pyObject, Type destinationType)
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
+    public static object PyObjectToManagedType(PyObject pyObject,
+                                               [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+                                               Type destinationType)
     {
         if (CPythonAPI.IsPyDict(pyObject) && IsAssignableToGenericType(destinationType, dictionaryType))
         {

--- a/src/CSnakes.Runtime/Python/Coroutine.cs
+++ b/src/CSnakes.Runtime/Python/Coroutine.cs
@@ -1,7 +1,9 @@
 using CSnakes.Runtime.CPython;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSnakes.Runtime.Python;
 
+[RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
 public sealed class Coroutine<TYield, TSend, TReturn>(PyObject coroutine) :
     Coroutine<TYield, TSend, TReturn,
               PyObjectImporters.Runtime<TYield>,

--- a/src/CSnakes.Runtime/Python/GeneratorIterator.cs
+++ b/src/CSnakes.Runtime/Python/GeneratorIterator.cs
@@ -1,7 +1,9 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSnakes.Runtime.Python;
 
+[RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
 public sealed class GeneratorIterator<TYield, TSend, TReturn>(PyObject coroutine) :
     GeneratorIterator<TYield, TSend, TReturn,
                       PyObjectImporters.Runtime<TYield>,

--- a/src/CSnakes.Runtime/Python/PyDictionary.cs
+++ b/src/CSnakes.Runtime/Python/PyDictionary.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace CSnakes.Runtime.Python;
 
+[RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
 internal class PyDictionary<TKey, TValue>(PyObject dictionary) :
     PyDictionary<TKey, TValue, PyObjectImporters.Runtime<TKey>, PyObjectImporters.Runtime<TValue>>(dictionary)
     where TKey : notnull;

--- a/src/CSnakes.Runtime/Python/PyList.cs
+++ b/src/CSnakes.Runtime/Python/PyList.cs
@@ -1,8 +1,10 @@
 using CSnakes.Runtime.CPython;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSnakes.Runtime.Python;
 
+[RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
 internal sealed class PyList<T>(PyObject listObject) :
     PyList<T, PyObjectImporters.Runtime<T>>(listObject);
 

--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -164,6 +164,7 @@ public partial class PyObject : SafeHandle, ICloneable
     /// This method does not check if the object is iterable until <see
     /// cref="IEnumerable{T}.GetEnumerator"/> is called on the result.
     /// </remarks>
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     public IEnumerable<T> AsEnumerable<T>() =>
         AsEnumerable<T, PyObjectImporters.Runtime<T>>();
 
@@ -638,8 +639,10 @@ public partial class PyObject : SafeHandle, ICloneable
         }
     }
 
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     public T As<T>() => (T)As(typeof(T));
 
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     internal object As(Type type)
     {
         using (GIL.Acquire())

--- a/src/CSnakes.Runtime/Python/PyObjectImporters.cs
+++ b/src/CSnakes.Runtime/Python/PyObjectImporters.cs
@@ -33,6 +33,12 @@ public static partial class PyObjectImporters
         }
     }
 
+    /// <remarks>
+    /// This importer delegates to run-time conversion via <see cref="PyObject.As{T}"/>, which is
+    /// annotated with <see cref="RequiresDynamicCodeAttribute"/>. It should be avoided in code that
+    /// wishes to support Native AOT scenarios and publishing. Any explicit use of this should be
+    /// carefully reviewed and marked with <see cref="RequiresDynamicCodeAttribute"/>.
+    /// </remarks>
     public sealed class Runtime<T> : IPyObjectImporter<T>
     {
         private Runtime() { }
@@ -40,7 +46,9 @@ public static partial class PyObjectImporters
         static T IPyObjectImporter<T>.BareImport(PyObject obj)
         {
             GIL.Require();
+#pragma warning disable IL3050 // Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
             return obj.As<T>();
+#pragma warning restore IL3050 // Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
         }
     }
 

--- a/src/CSnakes.Runtime/Python/PyObjectImporters.cs
+++ b/src/CSnakes.Runtime/Python/PyObjectImporters.cs
@@ -22,6 +22,17 @@ public static partial class PyObjectImporters
         }
     }
 
+    public sealed class None : IPyObjectImporter<PyObject>
+    {
+        private None() { }
+
+        static PyObject IPyObjectImporter<PyObject>.BareImport(PyObject obj)
+        {
+            GIL.Require();
+            return obj.IsNone() ? PyObject.None : throw InvalidCastException("None", obj);
+        }
+    }
+
     public sealed class Runtime<T> : IPyObjectImporter<T>
     {
         private Runtime() { }

--- a/src/CSnakes.Runtime/PythonRunString.cs
+++ b/src/CSnakes.Runtime/PythonRunString.cs
@@ -1,4 +1,3 @@
-
 using CSnakes.Runtime.CPython;
 using CSnakes.Runtime.Python;
 
@@ -6,6 +5,9 @@ namespace CSnakes.Runtime;
 
 public static class PythonRunString
 {
+    private static void Merge(this IDictionary<string, PyObject> left, PyObject variablesDict) =>
+        left.Merge(variablesDict.BareImportAs<IReadOnlyDictionary<string, PyObject>, PyObjectImporters.Dictionary<string, PyObject, PyObjectImporters.String, PyObjectImporters.Clone>>());
+
     private static void Merge(this IDictionary<string, PyObject> left, IReadOnlyDictionary<string, PyObject> right)
     {
         foreach (var entry in right)
@@ -44,7 +46,7 @@ public static class PythonRunString
             using var localsPyDict = PyObject.From(locals);
             using var globalsPyDict = PyObject.Create(CPythonAPI.PyDict_New());
             var result = CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
-            locals.Merge(localsPyDict.As<IReadOnlyDictionary<string, PyObject>>());
+            locals.Merge(localsPyDict);
             return result;
         }
     }
@@ -64,8 +66,8 @@ public static class PythonRunString
             using var localsPyDict = PyObject.From(locals);
             using var globalsPyDict = PyObject.From(globals);
             var result = CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_eval_input, globalsPyDict, localsPyDict);
-            locals.Merge(localsPyDict.As<IReadOnlyDictionary<string, PyObject>>());
-            globals.Merge(globalsPyDict.As<IReadOnlyDictionary<string, PyObject>>());
+            locals.Merge(localsPyDict);
+            globals.Merge(globalsPyDict);
             return result;
         }
     }
@@ -84,8 +86,8 @@ public static class PythonRunString
             using var localsPyDict = PyObject.From(locals);
             using var globalsPyDict = PyObject.From(globals);
             var result = CPythonAPI.PyRun_String(code, CPythonAPI.InputType.Py_file_input, globalsPyDict, localsPyDict);
-            locals.Merge(localsPyDict.As<IReadOnlyDictionary<string, PyObject>>());
-            globals.Merge(globalsPyDict.As<IReadOnlyDictionary<string, PyObject>>());
+            locals.Merge(localsPyDict);
+            globals.Merge(globalsPyDict);
             return result;
         }
     }

--- a/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
+++ b/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
@@ -18,6 +18,8 @@ internal interface IResultConversionCodeGenerator
 
 internal static class ResultConversionCodeGenerator
 {
+    private static readonly IResultConversionCodeGenerator None = ScalarConversionGenerator(ParseTypeName("PyObject"), "None");
+    private static readonly IResultConversionCodeGenerator Any = ScalarConversionGenerator(ParseTypeName("PyObject"), "Clone");
     private static readonly IResultConversionCodeGenerator Long = ScalarConversionGenerator(SyntaxKind.LongKeyword, "Int64");
     private static readonly IResultConversionCodeGenerator String = ScalarConversionGenerator(SyntaxKind.StringKeyword, "String");
     private static readonly IResultConversionCodeGenerator Boolean = ScalarConversionGenerator(SyntaxKind.BoolKeyword, "Boolean");
@@ -37,6 +39,8 @@ internal static class ResultConversionCodeGenerator
     {
         switch (pythonTypeSpec)
         {
+            case NoneType: return None;
+            case AnyType: return Any;
             case IntType: return Long;
             case StrType: return String;
             case FloatType: return Double;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -266,7 +266,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_bytes_async;
                 using PyObject a_pyObject = PyObject.From(a)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<byte[], PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<byte[], PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.ByteArray, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<byte[], PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<byte[], PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.ByteArray, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -97,7 +97,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }
@@ -109,7 +109,7 @@ public static class TestClassExtensions
                 this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_coroutine_raises_exception");
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_raises_exception;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
-                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<long, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<long, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }
@@ -122,7 +122,7 @@ public static class TestClassExtensions
                 PyObject __underlyingPythonFunc = this.__func_test_coroutine_returns_nothing;
                 using PyObject seconds_pyObject = PyObject.From(seconds)!;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
-                var __return = __result_pyObject.BareImportAs<ICoroutine<PyObject, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<PyObject, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>().AsTask(cancellationToken);
+                var __return = __result_pyObject.BareImportAs<ICoroutine<PyObject, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Coroutine<PyObject, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.None, global::CSnakes.Runtime.Python.PyObjectImporters.None>>().AsTask(cancellationToken);
                 return __return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
@@ -109,7 +109,7 @@ public static class TestClassExtensions
                 this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_normal_generator");
                 PyObject __underlyingPythonFunc = this.__func_test_normal_generator;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
-                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
+                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.None>>();
                 return __return;
             }
         }
@@ -121,7 +121,7 @@ public static class TestClassExtensions
                 this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_generator_sequence");
                 PyObject __underlyingPythonFunc = this.__func_test_generator_sequence;
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call();
-                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>>();
+                var __return = __result_pyObject.BareImportAs<IGeneratorIterator<string, PyObject, PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.Generator<string, PyObject, PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.String, global::CSnakes.Runtime.Python.PyObjectImporters.None>>();
                 return __return;
             }
         }

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
@@ -129,7 +129,7 @@ public static class TestClassExtensions
                 using PyObject __result_pyObject = __underlyingPythonFunc.Call(obj_pyObject);
                 if (__result_pyObject.IsNone())
                     return null;
-                var __return = __result_pyObject.BareImportAs<PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Runtime<PyObject>>();
+                var __return = __result_pyObject.BareImportAs<PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Clone>();
                 return __return;
             }
         }


### PR DESCRIPTION
This PR enhances CSnakes' compatibility with Native AOT scenarios by adding appropriate `[RequiresDynamicCode]` and `[DynamicallyAccessedMembers]` attributes throughout the type conversion system. The changes ensure that code paths requiring dynamic type creation are properly annotated, helping developers understand AOT limitations and enabling better tooling support.

All ILXXXX warnings should disappear with this PR. It effectively closes #679.

The core idea is to clearly demarcate code that requires dynamic capabilities from code that can work in AOT scenarios. This is achieved through:

1. **Explicit Dynamic Code Annotations**: Adding `[RequiresDynamicCode]` attributes to methods that use `Type.MakeGenericType()` or similar dynamic operations
2. **Member Access Annotations**: Using `[DynamicallyAccessedMembers]` to indicate which type members need to be preserved for reflection
3. **Importer Stratification**: Introducing specialized importers that avoid dynamic code where possible

## Technical Details

### Type Converter Annotations

The `PyObjectTypeConverter` class and its partial implementations now carry `[RequiresDynamicCode]` attributes on methods that perform dynamic type construction:

- `ConvertToCoroutine()` - Creates generic coroutine types dynamically
- `ConvertToDictionary()` - Constructs generic dictionary types
- `ConvertToGeneratorIterator()` - Builds generic generator iterator types
- `ConvertToList()` - Creates generic list types
- `ConvertToTuple()` - Constructs tuple types with dynamic member access

### PyObject API Enhancements

The `PyObject.As<T>()` methods are now properly annotated with `[RequiresDynamicCode]` since they delegate to the dynamic type conversion system. This provides clear guidance to developers about which APIs require dynamic capabilities.

### Importer System Improvements

#### New `None` Importer

A new `PyObjectImporters.None` class has been introduced to handle `None` values without requiring dynamic code generation. This provides a AOT-compatible path for handling Python's `None` type.

This change has been forked into PR #690 and can be merged independently, thus reducing the delta here.

#### Runtime Importer Documentation

The `PyObjectImporters.Runtime<T>` class now includes comprehensive documentation explaining its dynamic code requirements and recommending careful review when used in AOT scenarios.

### Generated Code Optimizations

The source generator now produces more AOT-friendly code by:

- Using `PyObjectImporters.None` instead of `PyObjectImporters.Runtime<PyObject>` for return types that should be `None`
- Using `PyObjectImporters.Clone` instead of `PyObjectImporters.Runtime<PyObject>` for generic `PyObject` handling

These changes has been forked into PR #690 and can be merged independently, thus reducing the delta here.

### String Execution Optimizations

The `PythonRunString` class has been optimized to avoid unnecessary dynamic type conversions by introducing a specialized `Merge()` overload that uses statically-typed importers instead of the runtime conversion system.

This PR introduces new attributes and type annotations but maintains full backward compatibility. The only visible changes are:

- Additional compiler warnings in AOT scenarios (which is the intended behavior)
- Updated generated code that uses more specific importers (but maintains the same runtime behavior)
