### PR TITLE
Log & test logging queue buffer overflow

### DIFF
--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -147,7 +147,7 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
                     // this loop isn't keeping up due to the logger being slow or blocking. Adding
                     // to the misery wouldn't be helpful so issue a debug message instead.
 
-                    Debug.WriteLine($"Dropped {dropCount} log messages due to buffer overflow.");
+                    Debug.WriteLine($"Dropped {dropCount} log messages due to log buffer overflow.");
                 }
 
                 try

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -23,12 +23,15 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
     const string ModuleCode = """
         import logging
         import queue
+        import threading
 
 
         class __csnakesMemoryHandler(logging.Handler):
             def __init__(self):
                 logging.Handler.__init__(self)
                 self.queue = queue.Queue(200)
+                self.stats_lock = threading.Lock()
+                self.drop_count = 0
 
             def emit(self, record):
                 _ = self._put(record)
@@ -42,6 +45,8 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
                         try:
                             _ = self.queue.get_nowait()  # drop the oldest record
                             self.queue.task_done()
+                            with self.stats_lock:
+                                self.drop_count += 1
                         except queue.Empty:
                             pass
                 return False  # all attempts to put failed
@@ -52,7 +57,10 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
                     self.queue.task_done()
                     if record is None:
                         break
-                    yield (record.levelno, record.getMessage(), record.exc_info)
+                    with self.stats_lock:
+                        drop_count = self.drop_count
+                        self.drop_count = 0
+                    yield (drop_count, record.levelno, record.getMessage(), record.exc_info)
 
             def close(self):
                 _ = self._put(None)
@@ -109,10 +117,11 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
     {
         using PyObject getRecords = handler.GetAttr("get_records");
         using PyObject getRecordsResult = getRecords.Call();
-        IGeneratorIterator<(long, string, ExceptionInfo?), PyObject, PyObject> generator =
-            getRecordsResult.ImportAs<IGeneratorIterator<(long, string, ExceptionInfo?), PyObject, PyObject>,
-                                                         PyObjectImporters.Generator<(long, string, ExceptionInfo?), PyObject, PyObject,
-                                                                                     PyObjectImporters.Tuple<long, string, ExceptionInfo?,
+        IGeneratorIterator<(long, long, string, ExceptionInfo?), PyObject, PyObject> generator =
+            getRecordsResult.ImportAs<IGeneratorIterator<(long, long, string, ExceptionInfo?), PyObject, PyObject>,
+                                                         PyObjectImporters.Generator<(long, long, string, ExceptionInfo?), PyObject, PyObject,
+                                                                                     PyObjectImporters.Tuple<long, long, string, ExceptionInfo?,
+                                                                                                             PyObjectImporters.Int64,
                                                                                                              PyObjectImporters.Int64,
                                                                                                              PyObjectImporters.String,
                                                                                                              NoneValueImporter<ExceptionInfo,
@@ -126,7 +135,20 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
         {
             while (generator.MoveNext()) // TODO Restart log records reading loop on failure
             {
-                var (level, message, exceptionInfo) = generator.Current;
+                var (dropCount, level, message, exceptionInfo) = generator.Current;
+
+                if (dropCount > 0)
+                {
+                    // One could log a warning here:
+                    //
+                    //   logger.LogWarning("Dropped {DropCount} log messages due to buffer overflow.", dropCount);
+                    //
+                    // but the reason the messages are getting dropped in the first place is because
+                    // this loop isn't keeping up due to the logger being slow or blocking. Adding
+                    // to the misery wouldn't be helpful so issue a debug message instead.
+
+                    Debug.WriteLine($"Dropped {dropCount} log messages due to buffer overflow.");
+                }
 
                 try
                 {

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_logging.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_logging.approved.txt
@@ -24,7 +24,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "af72fbfe705de69613d284222513e091"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "23de8055a8d335ac4f27b8f0d169a839"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {
@@ -50,7 +50,7 @@ public static class TestClassExtensions
         private PyObject __func_test_log_info;
         private PyObject __func_test_params_message;
         private PyObject __func_test_log_exception;
-        private PyObject __func_test_fifty_entries;
+        private PyObject __func_test_many_entries;
         private PyObject __func_test_named_logger;
 
         internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
@@ -64,7 +64,7 @@ public static class TestClassExtensions
                 this.__func_test_log_info = module.GetAttr("test_log_info");
                 this.__func_test_params_message = module.GetAttr("test_params_message");
                 this.__func_test_log_exception = module.GetAttr("test_log_exception");
-                this.__func_test_fifty_entries = module.GetAttr("test_fifty_entries");
+                this.__func_test_many_entries = module.GetAttr("test_many_entries");
                 this.__func_test_named_logger = module.GetAttr("test_named_logger");
             }
         }
@@ -80,14 +80,14 @@ public static class TestClassExtensions
                 this.__func_test_log_info.Dispose();
                 this.__func_test_params_message.Dispose();
                 this.__func_test_log_exception.Dispose();
-                this.__func_test_fifty_entries.Dispose();
+                this.__func_test_many_entries.Dispose();
                 this.__func_test_named_logger.Dispose();
                 // Bind to new functions
                 this.__func_test_log_debug = module.GetAttr("test_log_debug");
                 this.__func_test_log_info = module.GetAttr("test_log_info");
                 this.__func_test_params_message = module.GetAttr("test_params_message");
                 this.__func_test_log_exception = module.GetAttr("test_log_exception");
-                this.__func_test_fifty_entries = module.GetAttr("test_fifty_entries");
+                this.__func_test_many_entries = module.GetAttr("test_many_entries");
                 this.__func_test_named_logger = module.GetAttr("test_named_logger");
             }
         }
@@ -99,7 +99,7 @@ public static class TestClassExtensions
             this.__func_test_log_info.Dispose();
             this.__func_test_params_message.Dispose();
             this.__func_test_log_exception.Dispose();
-            this.__func_test_fifty_entries.Dispose();
+            this.__func_test_many_entries.Dispose();
             this.__func_test_named_logger.Dispose();
             module.Dispose();
         }
@@ -148,13 +148,14 @@ public static class TestClassExtensions
             }
         }
 
-        public void TestFiftyEntries()
+        public void TestManyEntries(long count)
         {
             using (GIL.Acquire())
             {
-                this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_fifty_entries");
-                PyObject __underlyingPythonFunc = this.__func_test_fifty_entries;
-                _ = __underlyingPythonFunc.Call();
+                this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_many_entries");
+                PyObject __underlyingPythonFunc = this.__func_test_many_entries;
+                using PyObject count_pyObject = PyObject.From(count)!;
+                _ = __underlyingPythonFunc.Call(count_pyObject);
                 return;
             }
         }
@@ -211,12 +212,12 @@ public interface ITestClass : IReloadableModuleImport
     void TestLogException();
 
     /// <summary>
-    /// Invokes the Python function <c>test_fifty_entries</c>:
+    /// Invokes the Python function <c>test_many_entries</c>:
     /// <code><![CDATA[
-    /// def test_fifty_entries() -> None: ...
+    /// def test_many_entries(count: int) -> None: ...
     /// ]]></code>
     /// </summary>
-    void TestFiftyEntries();
+    void TestManyEntries(long count);
 
     /// <summary>
     /// Invokes the Python function <c>test_named_logger</c>:

--- a/src/Integration.Tests/python/test_logging.py
+++ b/src/Integration.Tests/python/test_logging.py
@@ -22,8 +22,8 @@ def test_log_exception() -> None:
         logging.exception("An error message occurred")
 
 
-def test_fifty_entries() -> None:
-    for i in range(0, 50):
+def test_many_entries(count: int) -> None:
+    for i in range(0, count):
         logger.warning("Error %d", i)
 
 


### PR DESCRIPTION
This PR enhances the Python logging bridge to track and report dropped messages instead of silently losing them. Previously, when the logging queue overflowed, messages would be silently lost. Now the system provides clear indication of how many messages were dropped, enabling better monitoring and debugging.

The generator now yields a 4-tuple instead of a 3-tuple:

```python
# Before: (level, message, exception_info)
# After:  (drop_count, level, message, exception_info)
```

The drop count represents messages lost since the last successful yield, and is reset to zero after being reported.

The bridge now processes drop counts and issues debug messages when drops are detected.

`test_many_entries(count: int)` replaces the hardcoded `test_fifty_entries()` to allow configurable test scenarios.

**Overflow Test**: A comprehensive test that deliberately creates a slow logger scenario to verify drop count functionality:

- Uses barriers and countdown events for precise synchronization
- Blocks the first log message to fill the buffer
- Verifies that exactly 200 messages (buffer size) are preserved
- Confirms older messages are properly dropped

**Performance Impact**: The overhead of drop counting is fairly minimal:

- An atomic increment protected by a lock that's only acquired during overflow conditions.
- An additional `long` is marshaled as a tuple element.