### PR TITLE
Coroutine issuing stop iteration is raised instead of returning null

### DIFF
--- a/src/CSnakes.Runtime/Python/Coroutine.cs
+++ b/src/CSnakes.Runtime/Python/Coroutine.cs
@@ -31,7 +31,7 @@ public class Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(
         try
         {
             using (GIL.Acquire())
-                return this.current = TYieldImporter.BareImport(result);
+                return current = TYieldImporter.BareImport(result);
         }
         catch (PythonInvocationException ex)
         {
@@ -40,9 +40,8 @@ public class Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(
                 using var @return = stopIteration.TakeValue();
                 this.@return = @return.ImportAs<TReturn, TReturnImporter>();
 
-                // Coroutine has finished
-                // TODO: define behavior for this case
-                return default;
+                // Coroutine has been issued stop iteration, not the same as an async function returning a value.
+                throw stopIteration;
             }
 
             throw;


### PR DESCRIPTION
```python
import types
from typing import Coroutine

@types.coroutine
def example() -> Coroutine[str, int, float]:
    # yields strings, expects ints sent in, returns a float
    received = yield "ready"                 # yields a str
    yield f"processed {received}"            # yields another str
    return 3.14                              # returns a float
```

This would generate an awaitable function in CSnakes, but the result would have been null, which isn't correct as it should be a stop iteration.

This changes the behaviour, but the use of the Coroutine class for Python's old-style coroutine objects is confusing and should be deprecated.