### PR TITLE
Fix visibility of Python type implementations

### DIFF
--- a/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -51,3 +51,22 @@ static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 
 *REMOVED*static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, CSnakes.Runtime.Locators.RedistributablePythonVersion version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
 *REMOVED*CSnakes.Runtime.PythonEnvironmentOptions.Deconstruct(out string! Home, out string![]! ExtraPaths, out bool InstallSignalHandlers) -> void
 *REMOVED*CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(string! Home, string![]! ExtraPaths, bool InstallSignalHandlers = true) -> void
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.AsTask(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TYield>!
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Current.get -> TYield
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Return.get -> TReturn
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn>
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Current.get -> TYield
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Dispose() -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.GeneratorIterator(CSnakes.Runtime.Python.PyObject! generator) -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.GetEnumerator() -> System.Collections.Generic.IEnumerator<TYield>!
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.MoveNext() -> bool
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Reset() -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Return.get -> TReturn
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Send(TSend value) -> bool
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn>
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn>.GeneratorIterator(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+*REMOVED*virtual CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Dispose(bool disposing) -> void

--- a/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -51,3 +51,23 @@ static readonly CSnakes.Runtime.Locators.RedistributablePythonVersion.Python3_9 
 *REMOVED*static CSnakes.Runtime.ServiceCollectionExtensions.FromRedistributable(this CSnakes.Runtime.IPythonEnvironmentBuilder! builder, CSnakes.Runtime.Locators.RedistributablePythonVersion version, bool debug = false, bool freeThreaded = false, int timeout = 360) -> CSnakes.Runtime.IPythonEnvironmentBuilder!
 *REMOVED*CSnakes.Runtime.PythonEnvironmentOptions.Deconstruct(out string! Home, out string![]! ExtraPaths, out bool InstallSignalHandlers) -> void
 *REMOVED*CSnakes.Runtime.PythonEnvironmentOptions.PythonEnvironmentOptions(string! Home, string![]! ExtraPaths, bool InstallSignalHandlers = true) -> void
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.AsTask(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TYield>!
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Current.get -> TYield
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Return.get -> TReturn
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn>
+*REMOVED*CSnakes.Runtime.Python.Coroutine<TYield, TSend, TReturn>.Coroutine(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Current.get -> TYield
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Dispose() -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.GeneratorIterator(CSnakes.Runtime.Python.PyObject! generator) -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.GetEnumerator() -> System.Collections.Generic.IEnumerator<TYield>!
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.MoveNext() -> bool
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Reset() -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Return.get -> TReturn
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Send(TSend value) -> bool
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn>
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn>.GeneratorIterator(CSnakes.Runtime.Python.PyObject! coroutine) -> void
+*REMOVED*CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Dispose(bool disposing) -> void
+*REMOVED*virtual CSnakes.Runtime.Python.GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>.Dispose(bool disposing) -> void

--- a/src/CSnakes.Runtime/Python/Coroutine.cs
+++ b/src/CSnakes.Runtime/Python/Coroutine.cs
@@ -4,12 +4,12 @@ using System.Diagnostics.CodeAnalysis;
 namespace CSnakes.Runtime.Python;
 
 [RequiresDynamicCode(DynamicCodeMessages.CallsMakeGenericType)]
-public sealed class Coroutine<TYield, TSend, TReturn>(PyObject coroutine) :
+internal sealed class Coroutine<TYield, TSend, TReturn>(PyObject coroutine) :
     Coroutine<TYield, TSend, TReturn,
               PyObjectImporters.Runtime<TYield>,
               PyObjectImporters.Runtime<TReturn>>(coroutine);
 
-public class Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(PyObject coroutine) :
+internal class Coroutine<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(PyObject coroutine) :
     ICoroutine<TYield, TSend, TReturn>
     where TYieldImporter : IPyObjectImporter<TYield>
     where TReturnImporter : IPyObjectImporter<TReturn>

--- a/src/CSnakes.Runtime/Python/GeneratorIterator.cs
+++ b/src/CSnakes.Runtime/Python/GeneratorIterator.cs
@@ -4,12 +4,12 @@ using System.Diagnostics.CodeAnalysis;
 namespace CSnakes.Runtime.Python;
 
 [RequiresDynamicCode(DynamicCodeMessages.CallsMakeGenericType)]
-public sealed class GeneratorIterator<TYield, TSend, TReturn>(PyObject coroutine) :
+internal sealed class GeneratorIterator<TYield, TSend, TReturn>(PyObject coroutine) :
     GeneratorIterator<TYield, TSend, TReturn,
                       PyObjectImporters.Runtime<TYield>,
                       PyObjectImporters.Runtime<TReturn>>(coroutine);
 
-public class GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(PyObject generator) :
+internal class GeneratorIterator<TYield, TSend, TReturn, TYieldImporter, TReturnImporter>(PyObject generator) :
     IGeneratorIterator<TYield, TSend, TReturn>
     where TYieldImporter : IPyObjectImporter<TYield>
     where TReturnImporter : IPyObjectImporter<TReturn>


### PR DESCRIPTION
This PR fixes the visibility of `Coroutine` and `GeneratorIterator` family to types to be internal and removes them from the public API because they are implementation details. Only the interfaces they implement remain public and this is consistent with other types like `PyList`, `PyDictionary`, etc.

While this is a [breaking change](https://github.com/tonybaloney/CSnakes/issues/631), it was never expected for user code to instantiate and reference these.
