### PR TITLE
Add support for functions returning variadic tuples (`tuple[T, ...]`)

### DIFF
--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -17,7 +17,7 @@ Note that any constructs which are not available will be typed as `PyObject`. Th
 | [Generic](https://docs.python.org/3/library/typing.html#typing.Generic) | No | Relies on class reflection | Base class for generic types. |
 | [TypeVar](https://docs.python.org/3/library/typing.html#typing.TypeVar) |  |  | Defines a generic type variable. |
 | [Callable](https://docs.python.org/3/library/typing.html#typing.Callable) | No | Callables would have to by Python objects, not C# functions | Represents a callable object (e.g., function). |
-| [Tuple](https://docs.python.org/3/library/typing.html#typing.Tuple) | Yes |  | Fixed-length, ordered collection of types. |
+| [Tuple](https://docs.python.org/3/library/typing.html#typing.Tuple) | Yes |  | Fixed- or variable-length, ordered collection of types. |
 | [List](https://docs.python.org/3/library/typing.html#typing.List) | Yes |  | Variable-length, ordered collection of types. |
 | [Dict](https://docs.python.org/3/library/typing.html#typing.Dict) | Yes |  | Dictionary mapping keys to values. |
 | [Set](https://docs.python.org/3/library/typing.html#typing.Set) |  | Usage of sets is quite niche, if you would like this feature please request it. | Unordered collection of unique elements. |

--- a/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -29,6 +29,7 @@ CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargv) -> CSnakes.Runtime.Python.PyObject!
 [PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.None
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.VarTuple<T, TImporter>
 override CSnakes.Runtime.Python.KeywordArg.GetHashCode() -> int
 static CSnakes.Runtime.Python.KeywordArg.operator !=(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
 static CSnakes.Runtime.Python.KeywordArg.operator ==(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool

--- a/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/CSnakes.Runtime/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -30,6 +30,7 @@ CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs) -> CSnakes.Runtime.Python.PyObject!
 CSnakes.Runtime.Python.PyObject.Call(System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> args, System.ReadOnlySpan<CSnakes.Runtime.Python.PyObject!> argv, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargs, System.ReadOnlySpan<CSnakes.Runtime.Python.KeywordArg> kwargv) -> CSnakes.Runtime.Python.PyObject!
 [PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.None
+[PRTEXP001]CSnakes.Runtime.Python.PyObjectImporters.VarTuple<T, TImporter>
 override CSnakes.Runtime.Python.KeywordArg.GetHashCode() -> int
 static CSnakes.Runtime.Python.KeywordArg.operator !=(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool
 static CSnakes.Runtime.Python.KeywordArg.operator ==(CSnakes.Runtime.Python.KeywordArg left, CSnakes.Runtime.Python.KeywordArg right) -> bool

--- a/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
+++ b/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
@@ -207,6 +207,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
 
             using System;
             using System.Collections.Generic;
+            using System.Collections.Immutable;
             using System.Diagnostics;
             using System.Reflection.Metadata;
             using System.Text;

--- a/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
@@ -16,21 +16,23 @@ public static class TypeReflection
     public static IEnumerable<TypeSyntax> AsPredefinedType(PythonTypeSpec pythonType, ConversionDirection direction, RefSafetyContext refSafetyContext = RefSafetyContext.Safe) =>
         (pythonType, direction, refSafetyContext) switch
         {
-            (ISequenceType { Of: var t }, _, _) => CreateListType(t, direction),
-            (TupleType     { Parameters: var ts }, _, _) => CreateTupleType(ts, direction),
-            (IMappingType  { Key: var kt, Value: var vt }, _, _) => CreateDictionaryType(kt, vt, direction),
-            (OptionalType  { Of: var t }, _, _) => AsPredefinedType(t, direction).Select(SyntaxFactory.NullableType),
-            (GeneratorType { Yield: var yt, Send: var st, Return: var rt }, _, _) => CreateGeneratorType(yt, st, rt, direction),
-            (CoroutineType { Yield: var yt, Send: var st, Return: var rt }, _, _) => CreateCoroutineType(yt, st, rt, direction),
-            (UnionType     { Choices: var ts }, ConversionDirection.ToPython, _) => [.. ts.SelectMany(t => AsPredefinedType(t, direction))],
+            (ISequenceType     { Of: var t }, _, _) => CreateListType(t, direction),
+            (TupleType         { Parameters: var ts }, _, _) => CreateTupleType(ts, direction),
+            (IMappingType      { Key: var kt, Value: var vt }, _, _) => CreateDictionaryType(kt, vt, direction),
+            (OptionalType      { Of: var t }, _, _) => AsPredefinedType(t, direction).Select(SyntaxFactory.NullableType),
+            (GeneratorType     { Yield: var yt, Send: var st, Return: var rt }, _, _) => CreateGeneratorType(yt, st, rt, direction),
+            (CoroutineType     { Yield: var yt, Send: var st, Return: var rt }, _, _) => CreateCoroutineType(yt, st, rt, direction),
+            (UnionType         { Choices: var ts }, ConversionDirection.ToPython, _) => [.. ts.SelectMany(t => AsPredefinedType(t, direction))],
+            (VariadicTupleType { Of: var t }, ConversionDirection.FromPython, _) => from listType in AsPredefinedType(t, direction)
+                                                                                    select CreateGenericType("ImmutableArray", [listType]),
             // Todo more types... see https://docs.python.org/3/library/stdtypes.html#standard-generic-classes
-            (IntType       , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.LongKeyword))],
-            (StrType       , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword))],
-            (FloatType     , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.DoubleKeyword))],
-            (BoolType      , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.BoolKeyword))],
-            (BytesType     , ConversionDirection.ToPython, RefSafetyContext.RefSafe) => [SyntaxFactory.ParseTypeName("ReadOnlySpan<byte>")],
-            (BytesType     , _, _) => [SyntaxFactory.ParseTypeName("byte[]")],
-            (BufferType    , ConversionDirection.FromPython, _) => [SyntaxFactory.ParseTypeName("IPyBuffer")],
+            (IntType           , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.LongKeyword))],
+            (StrType           , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword))],
+            (FloatType         , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.DoubleKeyword))],
+            (BoolType          , _, _) => [SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.BoolKeyword))],
+            (BytesType         , ConversionDirection.ToPython, RefSafetyContext.RefSafe) => [SyntaxFactory.ParseTypeName("ReadOnlySpan<byte>")],
+            (BytesType         , _, _) => [SyntaxFactory.ParseTypeName("byte[]")],
+            (BufferType        , ConversionDirection.FromPython, _) => [SyntaxFactory.ParseTypeName("IPyBuffer")],
             _ => [SyntaxFactory.ParseTypeName("PyObject")],
         };
 

--- a/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
+++ b/src/CSnakes.SourceGeneration/ResultConversionCodeGenerator.cs
@@ -77,6 +77,12 @@ internal static class ResultConversionCodeGenerator
                 return new ConversionGenerator(TupleType(SeparatedList(from item in generators select TupleElement(item.TypeSyntax))),
                                                TypeReflection.CreateGenericType("Tuple", [.. from item in generators select item.TypeSyntax, .. from item in generators select item.ImporterTypeSyntax]));
             }
+            case VariadicTupleType { Of: var t }:
+            {
+                var generator = Create(t);
+                return new ConversionGenerator(TypeReflection.CreateGenericType(nameof(ImmutableArray<object>), [generator.TypeSyntax]),
+                                               TypeReflection.CreateGenericType("VarTuple", [generator.TypeSyntax, generator.ImporterTypeSyntax]));
+            }
             case DictType { Key: var kt, Value: var vt }:
             {
                 return DictionaryConversionGenerator(kt, vt, "Dictionary");

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;
@@ -24,7 +25,7 @@ public static class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "1968c40e8ee2d29fbf50d2a52f7ea66f"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "cdff078c9923ffcfa1332534221f796b"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {
@@ -58,6 +59,8 @@ public static class TestClassExtensions
         private PyObject __func_test_bytes_async;
         private PyObject __func_test_sequence;
         private PyObject __func_test_none_result;
+        private PyObject __func_test_var_tuple_result;
+        private PyObject __func_test_any_var_tuple_result;
 
         internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
@@ -78,6 +81,8 @@ public static class TestClassExtensions
                 this.__func_test_bytes_async = module.GetAttr("test_bytes_async");
                 this.__func_test_sequence = module.GetAttr("test_sequence");
                 this.__func_test_none_result = module.GetAttr("test_none_result");
+                this.__func_test_var_tuple_result = module.GetAttr("test_var_tuple_result");
+                this.__func_test_any_var_tuple_result = module.GetAttr("test_any_var_tuple_result");
             }
         }
 
@@ -100,6 +105,8 @@ public static class TestClassExtensions
                 this.__func_test_bytes_async.Dispose();
                 this.__func_test_sequence.Dispose();
                 this.__func_test_none_result.Dispose();
+                this.__func_test_var_tuple_result.Dispose();
+                this.__func_test_any_var_tuple_result.Dispose();
                 // Bind to new functions
                 this.__func_test_int_float = module.GetAttr("test_int_float");
                 this.__func_test_int_int = module.GetAttr("test_int_int");
@@ -113,6 +120,8 @@ public static class TestClassExtensions
                 this.__func_test_bytes_async = module.GetAttr("test_bytes_async");
                 this.__func_test_sequence = module.GetAttr("test_sequence");
                 this.__func_test_none_result = module.GetAttr("test_none_result");
+                this.__func_test_var_tuple_result = module.GetAttr("test_var_tuple_result");
+                this.__func_test_any_var_tuple_result = module.GetAttr("test_any_var_tuple_result");
             }
         }
 
@@ -131,6 +140,8 @@ public static class TestClassExtensions
             this.__func_test_bytes_async.Dispose();
             this.__func_test_sequence.Dispose();
             this.__func_test_none_result.Dispose();
+            this.__func_test_var_tuple_result.Dispose();
+            this.__func_test_any_var_tuple_result.Dispose();
             module.Dispose();
         }
 
@@ -296,6 +307,33 @@ public static class TestClassExtensions
                 return;
             }
         }
+
+        public ImmutableArray<(long, string)> TestVarTupleResult(IReadOnlyList<long> ints, IReadOnlyList<string> strs)
+        {
+            using (GIL.Acquire())
+            {
+                this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_var_tuple_result");
+                PyObject __underlyingPythonFunc = this.__func_test_var_tuple_result;
+                using PyObject ints_pyObject = PyObject.From(ints)!;
+                using PyObject strs_pyObject = PyObject.From(strs)!;
+                using PyObject __result_pyObject = __underlyingPythonFunc.Call(ints_pyObject, strs_pyObject);
+                var __return = __result_pyObject.BareImportAs<ImmutableArray<(long, string)>, global::CSnakes.Runtime.Python.PyObjectImporters.VarTuple<(long, string), global::CSnakes.Runtime.Python.PyObjectImporters.Tuple<long, string, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.String>>>();
+                return __return;
+            }
+        }
+
+        public ImmutableArray<PyObject> TestAnyVarTupleResult(IReadOnlyList<PyObject> a)
+        {
+            using (GIL.Acquire())
+            {
+                this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_any_var_tuple_result");
+                PyObject __underlyingPythonFunc = this.__func_test_any_var_tuple_result;
+                using PyObject a_pyObject = PyObject.From(a)!;
+                using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
+                var __return = __result_pyObject.BareImportAs<ImmutableArray<PyObject>, global::CSnakes.Runtime.Python.PyObjectImporters.VarTuple<PyObject, global::CSnakes.Runtime.Python.PyObjectImporters.Clone>>();
+                return __return;
+            }
+        }
     }
 }
 
@@ -399,6 +437,22 @@ public interface ITestClass : IReloadableModuleImport
     /// ]]></code>
     /// </summary>
     void TestNoneResult();
+
+    /// <summary>
+    /// Invokes the Python function <c>test_var_tuple_result</c>:
+    /// <code><![CDATA[
+    /// def test_var_tuple_result(ints: list[int], strs: list[str]) -> tuple[tuple[int, str], ...]: ...
+    /// ]]></code>
+    /// </summary>
+    ImmutableArray<(long, string)> TestVarTupleResult(IReadOnlyList<long> ints, IReadOnlyList<string> strs);
+
+    /// <summary>
+    /// Invokes the Python function <c>test_any_var_tuple_result</c>:
+    /// <code><![CDATA[
+    /// def test_any_var_tuple_result(a: list[Any]) -> tuple: ...
+    /// ]]></code>
+    /// </summary>
+    ImmutableArray<PyObject> TestAnyVarTupleResult(IReadOnlyList<PyObject> a);
 }
 
 file static class ThisModule

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_logging.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_logging.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_overload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_overload.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_source.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_source.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_unions.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_unions.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_windows_arm64.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_windows_arm64.approved.txt
@@ -8,6 +8,7 @@ using CSnakes.Runtime.Python;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Text;

--- a/src/Integration.Tests/BasicTests.cs
+++ b/src/Integration.Tests/BasicTests.cs
@@ -1,4 +1,8 @@
+using CSnakes.Runtime.Python;
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Integration.Tests;
@@ -74,5 +78,30 @@ public class BasicTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(
     {
         var testModule = Env.TestBasic();
         Assert.Equal([2, 3, 4], testModule.TestSequence([1, 2, 3], 2, 5));
+    }
+
+    [Fact]
+    public void TestBasic_ResultAsVariadicTuple()
+    {
+        var testModule = Env.TestBasic();
+        var actual = testModule.TestVarTupleResult([1, 2, 3, 4], ["foo", "bar", "baz", "qux"]);
+        Assert.Equal([(1, "foo"), (2, "bar"), (3, "baz"), (4, "qux")], actual);
+    }
+
+    [Fact]
+    public void TestBasic_ResultAsVariadicTupleOfAny()
+    {
+        var testModule = Env.TestBasic();
+        using var a = PyObject.From((1, "foo"));
+        using var b = PyObject.From((2, "bar"));
+        using var c = PyObject.From((3, "baz"));
+        using var d = PyObject.From((4, "qux"));
+
+        var actual = testModule.TestAnyVarTupleResult([a, b, c, d]);
+
+        Assert.Equal([a, b, c, d], actual);
+
+        foreach (var item in actual)
+            item.Dispose();
     }
 }

--- a/src/Integration.Tests/python/test_basic.py
+++ b/src/Integration.Tests/python/test_basic.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Any, Sequence
 
 def _test_private() -> None:
     pass
@@ -39,3 +39,9 @@ def test_sequence(a: Sequence[int], start: int, end: int) -> Sequence[int]:
 
 def test_none_result() -> None:
     pass
+
+def test_var_tuple_result(ints: list[int], strs: list[str]) -> tuple[tuple[int, str], ...]:
+    return tuple(zip(ints, strs))
+
+def test_any_var_tuple_result(a: list[Any]) -> tuple:
+    return tuple(a)


### PR DESCRIPTION
In PR #669, the parser recognised variadic tuples (`tuple[T, ...]`, variable-length tuples with homogeneous element types, but that was about it. This PR adds full support for Python functions that return tuples of unknown length but known element type, such as `tuple[int, ...]` or `tuple[tuple[int, str], ...]`.

## Design

The implementation introduces a new Python type construct `VariadicTupleType` that represents tuples with an ellipsis syntax (`tuple[T, ...]`). Unlike fixed-length tuples (`TupleType`) which have a known number of elements with potentially different types, variadic tuples have a variable number of elements where all elements are of the same type.

Note that variadic tuples are only supported in _return position_. This PR does not support variadic tuples in argument position, which is something that can be added in the future. Meanwhile, returning variadic tuples seems a lot more common & useful in Python.

### Key Design Decisions:

1. **Immutable Collections**: Variadic tuples are mapped to .NET's `ImmutableArray<T>` rather than `IReadOnlyList<T>` to provide better performance and immutability guarantees that match Python's tuple semantics. Another option would be to return a regular array since the immutability does not need to be strictly maintained on the C# side.

2. **Type Safety**: The implementation preserves full type safety by generating strongly-typed importer classes that handle the conversion from Python tuples to .NET immutable arrays.

3. **Consistent API**: The feature integrates seamlessly with the existing type system and follows the same patterns as other collection types (sequences, dictionaries, etc.). Behaviourally, however, the tuple elements are marshaled and converted eagerly (which can be seen as a feature).

## Technical Implementation

### Core Components

#### 1. Type System Extensions

- **`VariadicTupleType`**: A new record type in `PythonTypeSpec.cs` representing `tuple[T, ...]` syntax
- **Type Reflection**: Extended `TypeReflection.AsPredefinedType()` to map `VariadicTupleType` to `ImmutableArray<T>` for `FromPython` conversions
- **Parser Support**: See PR #669.

#### 2. Runtime Support

- **`VarTuple<T, TImporter>`**: A new importer class in `PyObjectImporters.cs` that handles the conversion from Python tuple objects to `ImmutableArray<T>`
- **Efficient Conversion**: Uses `ImmutableArray.CreateBuilder<T>()` for optimal performance when converting variable-length Python tuples, including dimensioning the array to the correct capacity.

#### 3. Code Generation

- **Result Conversion**: Extended `ResultConversionCodeGenerator` to generate appropriate conversion code for variadic tuple return types
- **Method Signatures**: Generated C# methods return `ImmutableArray<T>` for variadic tuple results

## Example Usage

### Python Code
```python
def get_coordinate_pairs(points: list[tuple[int, int]]) -> tuple[tuple[int, int], ...]:
    return tuple(points)

def get_names() -> tuple[str, ...]:
    return ("Alice", "Bob", "Charlie")
```

### Generated C# Interface
```csharp
public interface IMyModule
{
    ImmutableArray<(long, long)> GetCoordinatePairs(IReadOnlyList<(long, long)> points);
    ImmutableArray<string> GetNames();
}
```

## Breaking Changes

None. This is a pure additive feature that doesn't affect existing APIs or functionality.
