### PR TITLE
Fix binary integer formatting

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonConstant.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonConstant.cs
@@ -20,7 +20,7 @@ public abstract class PythonConstant
 
     public sealed class BinaryInteger(long value) : Integer(value)
     {
-        public override string ToString() => $"0b{Value:X}";
+        public override string ToString() => $"0b{Value:B}";
     }
 
     public sealed class Float(double value) : PythonConstant

--- a/src/CSnakes.Tests/PythonConstantTests.cs
+++ b/src/CSnakes.Tests/PythonConstantTests.cs
@@ -4,6 +4,21 @@ using System.Globalization;
 namespace CSnakes.Tests;
 public class PythonConstantTests
 {
+    public sealed class BinaryIntegerTests
+    {
+        [Theory]
+        [InlineData(0, "0b0")]
+        [InlineData(1, "0b1")]
+        [InlineData(2, "0b10")]
+        [InlineData(3, "0b11")]
+        [InlineData(42, "0b101010")]
+        public void ToString_Returns_BinaryFormatting(long input, string expected)
+        {
+            var n = new PythonConstant.BinaryInteger(input);
+            Assert.Equal(expected, n.ToString());
+        }
+    }
+
     public sealed class FloatTests
     {
         [Fact]


### PR DESCRIPTION
This PR fixes `PythonConstant.BinaryInteger` formatting, which was using hexadecimal instead of binary notation.