### PR TITLE
Format binary integer literal via string interpolation

### DIFF
--- a/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
@@ -49,7 +49,7 @@ public class ArgumentReflection
                         (PythonConstant.BinaryInteger { Value: var v },
                          PredefinedTypeSyntax { Keyword.Value: "long" }) =>
                             SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                                                            SyntaxFactory.Literal($"0b{Convert.ToString(v, 2)}", v)),
+                                                            SyntaxFactory.Literal($"0b{v:B}", v)),
                         (PythonConstant.Integer { Value: var v and >= int.MinValue and <= int.MaxValue },
                          PredefinedTypeSyntax { Keyword.Value: "long" or "double" }) =>
                             // Downcast long to int if the value is small as the code is more readable without the L suffix


### PR DESCRIPTION
This PR makes a minor update to the way binary integer literals are formatted, using string interpolation as is done for hex integer literals.