### PR TITLE
Allow `...` for `Callable` parameters

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
@@ -59,12 +59,14 @@ public static partial class PythonParser
             //
             from callable in
                 TypeDefinitionParser.ManyDelimitedBy(Comma)
+                                    .Select(ps => (PythonTypeSpec[]?)ps)
                                     .Subscript()
+                                    .Or(Token.EqualTo(PythonToken.Ellipsis).Value((PythonTypeSpec[]?)null))
                                     .ThenIgnore(Comma)
                                     .Then(ps => from r in TypeDefinitionParser
                                                 select (Parameters: ps, Return: r))
                                     .Subscript()
-            select (PythonTypeSpec)new CallableType([..callable.Parameters], callable.Return);
+            select (PythonTypeSpec)new CallableType(callable.Parameters is { } ps ? [..ps] : null, callable.Return);
 
         public static readonly PythonTypeSpecParser Literal =
             // Literal can contain any PythonConstant, or a list of them.

--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
@@ -137,9 +137,14 @@ public sealed record OptionalType(PythonTypeSpec Of) : ClosedGenericType("Option
     public override string ToString() => $"{Name}[{Of}]";
 }
 
-public sealed record CallableType(ValueArray<PythonTypeSpec> Parameters, PythonTypeSpec Return) : ClosedGenericType("Callback")
+public sealed record CallableType(ValueArray<PythonTypeSpec>? Parameters, PythonTypeSpec Return) : ClosedGenericType("Callback")
 {
-    public override string ToString() => $"{Name}[[{string.Join(", ", Parameters)}], {Return}]";
+    public override string ToString() => Parameters switch
+    {
+        null => $"{Name}[..., {Return}]",
+        [] => $"{Name}[[], {Return}]",
+        { } ps => $"{Name}[[{string.Join(", ", ps)}], {Return}]",
+    };
 }
 
 public sealed record TupleType(ValueArray<PythonTypeSpec> Parameters) : ClosedGenericType("tuple")

--- a/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
+++ b/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
@@ -128,8 +128,8 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Callable", "Syntax error: unexpected end of input, expected `[`.")]
     [InlineData("typing.Callable", "Syntax error: unexpected end of input, expected `[`.")]
     [InlineData("collections.abc.Callable", "Syntax error: unexpected end of input, expected `[`.")]
-    [InlineData("Callable[]", "Syntax error (line 1, column 10): unexpected `]`, expected `[`.")]
-    [InlineData("Callable[int]", "Syntax error (line 1, column 10): unexpected identifier `int`, expected `[`.")]
+    [InlineData("Callable[]", "Syntax error (line 1, column 10): unexpected `]`, expected `[` or `...`.")]
+    [InlineData("Callable[int]", "Syntax error (line 1, column 10): unexpected identifier `int`, expected `[` or `...`.")]
     [InlineData("Callable[[int]]", "Syntax error (line 1, column 15): unexpected `]`, expected `,`.")]
     public void CallableArgTest(string input, string expectedErrorMessage) =>
         TestParseError(input, expectedErrorMessage);
@@ -221,9 +221,9 @@ public class PythonTypeDefinitionParserTests
     public void CallableTest(string input)
     {
         var type = TestParse<CallableType>(input);
-        Assert.Equal(2, type.Parameters.Length);
-        _ = Assert.IsType<IntType>(type.Parameters[0]);
-        _ = Assert.IsType<StrType>(type.Parameters[1]);
+        var parameters = Assert.NotNull(type.Parameters);
+        _ = Assert.IsType<IntType>(parameters[0]);
+        _ = Assert.IsType<StrType>(parameters[1]);
         _ = Assert.IsType<BoolType>(type.Return);
     }
 
@@ -233,8 +233,18 @@ public class PythonTypeDefinitionParserTests
     public void CallableNoParametersTest(string input)
     {
         var type = TestParse<CallableType>(input);
-        Assert.Empty(type.Parameters);
+        var parameters = Assert.NotNull(type.Parameters);
+        Assert.Empty(parameters);
         _ = Assert.IsType<NoneType>(type.Return);
+    }
+
+    [Theory]
+    [InlineData("Callable[..., Any]")]
+    public void CallableEllipsisParametersTest(string input)
+    {
+        var type = TestParse<CallableType>(input);
+        Assert.Null(type.Parameters);
+        _ = Assert.IsType<AnyType>(type.Return);
     }
 
     [Theory]

--- a/src/CSnakes.Tests/PythonTypeSpecTests.cs
+++ b/src/CSnakes.Tests/PythonTypeSpecTests.cs
@@ -812,6 +812,14 @@ public class PythonTypeSpecTests
         }
 
         [Fact]
+        public void ToString_WhenNullParameters_FormatsEllipsis()
+        {
+            var type = new CallableType(null, PythonTypeSpec.Bool);
+
+            Assert.Equal("Callback[..., bool]", type.ToString());
+        }
+
+        [Fact]
         public void ToString_NoParameters_ReturnsFullyFormattedName()
         {
             var type = new CallableType([], PythonTypeSpec.Bool);


### PR DESCRIPTION
This PR recognises `Callable[..., R]` as valid syntax where `...` is permitted as a specification for parameters to mean any number of parameters of any type. This reduces the false negatives. Consequently, warnings emitted for `StdLib.Test` drop from 166 to 116.