### PR TITLE
Convert `PythonConstant` family to records for value semantics

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.Constants.cs
@@ -95,23 +95,23 @@ public static partial class PythonParser
 
     public static TokenListParser<PythonToken, PythonConstant.Integer> IntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.Integer)
-        .Select(d => new PythonConstant.Integer(long.Parse(d.ToStringValue().Replace("_", ""), NumberStyles.Integer)))
+        .Select(d => PythonConstant.Integer.Decimal(long.Parse(d.ToStringValue().Replace("_", ""), NumberStyles.Integer)))
         .Named("Integer Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant.HexadecimalInteger> HexadecimalIntegerConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.Integer> HexadecimalIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.HexadecimalInteger)
-        .Select(d => new PythonConstant.HexadecimalInteger(long.Parse(d.ToStringValue().Substring(2).Replace("_", ""), NumberStyles.HexNumber)))
+        .Select(d => PythonConstant.Integer.Hexadecimal(long.Parse(d.ToStringValue().Substring(2).Replace("_", ""), NumberStyles.HexNumber)))
         .Named("Hexadecimal Integer Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant.HexadecimalInteger> OctalIntegerConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.Integer> OctalIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.OctalInteger)
-        .Select(d => new PythonConstant.HexadecimalInteger(PythonParserConstants.ParseOctal(d.ToStringValue().Substring(2))))
+        .Select(d => PythonConstant.Integer.Hexadecimal(PythonParserConstants.ParseOctal(d.ToStringValue().Substring(2))))
         .Named("Octal Integer Constant");
 
-    public static TokenListParser<PythonToken, PythonConstant.BinaryInteger> BinaryIntegerConstantTokenizer { get; } =
+    public static TokenListParser<PythonToken, PythonConstant.Integer> BinaryIntegerConstantTokenizer { get; } =
         Token.EqualTo(PythonToken.BinaryInteger)
         // TODO: Consider Binary Format specifier introduced in .NET 8 https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#binary-format-specifier-b
-        .Select(d => new PythonConstant.BinaryInteger((long)Convert.ToUInt64(d.ToStringValue().Substring(2).Replace("_", ""), 2)))
+        .Select(d => PythonConstant.Integer.Binary((long)Convert.ToUInt64(d.ToStringValue().Substring(2).Replace("_", ""), 2)))
         .Named("Binary Integer Constant");
 
     public static TokenListParser<PythonToken, PythonConstant.Bool> BoolConstantTokenizer { get; } =

--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonConstant.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonConstant.cs
@@ -1,55 +1,94 @@
 using System.Globalization;
-using static CSnakes.Parser.Types.PythonConstant.String;
 
 namespace CSnakes.Parser.Types;
 
-public abstract class PythonConstant
+public abstract record PythonConstant
 {
-    public abstract override string ToString();
+    public static implicit operator PythonConstant(long value) => (Integer)value;
+    public static implicit operator PythonConstant(double value) => (Float)value;
+    public static implicit operator PythonConstant(string value) => (String)value;
+    public static implicit operator PythonConstant(bool value) => (Bool)value;
 
-    public class Integer(long value) : PythonConstant
+    public sealed record Integer : PythonConstant
     {
-        public long Value { get; } = value;
-        public override string ToString() => Value.ToString();
+        public enum Notation
+        {
+            Decimal,        // e.g. 42
+            Hexadecimal,    // e.g. 0x2A
+            Binary,         // e.g. 0b101010
+        }
+
+        public static Integer Decimal(long value) => new(value, Notation.Decimal);
+        public static Integer Hexadecimal(long value) => new(value, Notation.Hexadecimal);
+        public static Integer Binary(long value) => new(value, Notation.Binary);
+
+        private Integer(long value, Notation notationHint)
+        {
+            Value = value;
+            NotationHint = notationHint;
+        }
+
+        public long Value { get; init; }
+        public Notation NotationHint { get; init; }
+
+        // Equality is based on value only, not desired notation
+
+        public bool Equals(Integer? other) => other is { Value: var v } && Value == v;
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override string ToString() => NotationHint switch
+        {
+            Notation.Decimal => Value.ToString(),
+            Notation.Hexadecimal => $"0x{Value:X}",
+            Notation.Binary => $"0b{Convert.ToString(Value, 2)}",
+            _ => throw new NotImplementedException()
+        };
+
+        public static implicit operator Integer(long value) => Decimal(value);
     }
 
-    public sealed class HexadecimalInteger(long value) : Integer(value)
+    public sealed record Float : PythonConstant
     {
-        public override string ToString() => $"0x{Value:X}";
-    }
-
-    public sealed class BinaryInteger(long value) : Integer(value)
-    {
-        public override string ToString() => $"0b{Value:B}";
-    }
-
-    public sealed class Float(double value) : PythonConstant
-    {
-        public double Value { get; } = value;
+        public Float(double value) => Value = value;
+        public double Value { get; init; }
         public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
+
+        public static implicit operator Float(double value) => new(value);
     }
 
-    public sealed class String(string value) : PythonConstant
+    public sealed record String : PythonConstant
     {
-        public string Value { get; } = value;
+        public String(string value) => Value = value;
+        public string Value { get; init; }
         public override string ToString() => Value;
+
+        public static implicit operator String(string value) => new(value);
     }
 
-    public sealed class ByteString : PythonConstant
+    public sealed record ByteString : PythonConstant
     {
         private readonly string value;
-        public ByteString(string value)
+
+        public ByteString(string value) => this.value = Checked(value);
+
+        public string Value
+        {
+            get => this.value;
+            init => this.value = Checked(value);
+        }
+
+        private static string Checked(string value)
         {
             // Check value doesn't contain any non-ASCII characters
-            if (value.Any(c => c > 127))
-                throw new ArgumentException("Byte strings must contain only ASCII characters.", nameof(value));
-            this.value = value;
+            return value.All(c => c < 128)
+                 ? value
+                 : throw new ArgumentException("Byte strings must contain only ASCII characters.", nameof(value));
         }
-        public string Value => value;
+
         public override string ToString() => Value;
     }
 
-    public sealed class Bool : PythonConstant
+    public sealed record Bool : PythonConstant
     {
         public static readonly Bool True = new(true);
         public static readonly Bool False = new(false);
@@ -59,9 +98,11 @@ public abstract class PythonConstant
         public bool Value { get; }
 
         public override string ToString() => Value.ToString();
+
+        public static implicit operator Bool(bool value) => value ? True : False;
     }
 
-    public sealed class None : PythonConstant
+    public sealed record None : PythonConstant
     {
         public static readonly None Value = new();
 
@@ -70,7 +111,7 @@ public abstract class PythonConstant
         public override string ToString() => "None";
     }
 
-    public sealed class Ellipsis : PythonConstant
+    public sealed record Ellipsis : PythonConstant
     {
         public static readonly Ellipsis Value = new();
         private Ellipsis() { }

--- a/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/ArgumentReflection.cs
@@ -42,11 +42,11 @@ public class ArgumentReflection
                     from t in TypeReflection.AsPredefinedType(type, conversionDirection)
                     select (Type: t, LiteralExpression: (dv, t) switch
                     {
-                        (PythonConstant.HexadecimalInteger { Value: var v },
+                        (PythonConstant.Integer { Value: var v, NotationHint: PythonConstant.Integer.Notation.Hexadecimal },
                          PredefinedTypeSyntax { Keyword.Value: "long" }) =>
                             SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression,
                                                             SyntaxFactory.Literal($"0x{v:X}", v)),
-                        (PythonConstant.BinaryInteger { Value: var v },
+                        (PythonConstant.Integer { Value: var v, NotationHint: PythonConstant.Integer.Notation.Binary },
                          PredefinedTypeSyntax { Keyword.Value: "long" }) =>
                             SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression,
                                                             SyntaxFactory.Literal($"0b{v:B}", v)),

--- a/src/CSnakes.Tests/PythonConstantTests.cs
+++ b/src/CSnakes.Tests/PythonConstantTests.cs
@@ -4,23 +4,123 @@ using System.Globalization;
 namespace CSnakes.Tests;
 public class PythonConstantTests
 {
-    public sealed class BinaryIntegerTests
+    public class IntegerTests
     {
+        [Fact]
+        public void Long_To_PythonConstant_Creates_Integer()
+        {
+            PythonConstant constant = 42L;
+            var integer = Assert.IsType<PythonConstant.Integer>(constant);
+            Assert.Equal(42L, integer.Value);
+        }
+
+        [Fact]
+        public void Instances_With_Same_Value_Are_Equal()
+        {
+            PythonConstant.Integer int1 = 42;
+            PythonConstant.Integer int2 = 42;
+
+            Assert.Equal(int1, int2);
+            Assert.True(int1 == int2);
+            Assert.False(int1 != int2);
+            Assert.Equal(int1.GetHashCode(), int2.GetHashCode());
+        }
+
+        [Fact]
+        public void Instances_With_Different_Values_Are_Not_Equal()
+        {
+            PythonConstant.Integer int1 = 42;
+            PythonConstant.Integer int2 = 24;
+
+            Assert.NotEqual(int1, int2);
+            Assert.False(int1 == int2);
+            Assert.True(int1 != int2);
+        }
+
+        [Fact]
+        public void Supports_Value_Init()
+        {
+            var integer = PythonConstant.Integer.Decimal(10) with { Value = 42 };
+            Assert.Equal(42, integer.Value);
+        }
+
+        [Fact]
+        public void ToString_Returns_Value_As_String()
+        {
+            PythonConstant.Integer integer = 42;
+            Assert.Equal("42", integer.ToString());
+        }
+
+        [Fact]
+        public void HexadecimalInteger_With_Same_Value_Are_Equal()
+        {
+            var hex1 = PythonConstant.Integer.Hexadecimal(255);
+            var hex2 = PythonConstant.Integer.Hexadecimal(255);
+
+            Assert.Equal(hex1, hex2);
+            Assert.True(hex1 == hex2);
+            Assert.Equal(hex1.GetHashCode(), hex2.GetHashCode());
+        }
+
+        [Fact]
+        public void HexadecimalInteger_ToString_Returns_Hex_Format()
+        {
+            var hex = PythonConstant.Integer.Hexadecimal(255);
+            Assert.Equal("0xFF", hex.ToString());
+        }
+
+        [Fact]
+        public void BinaryInteger_With_Same_Value_Are_Equal()
+        {
+            var bin1 = PythonConstant.Integer.Binary(15);
+            var bin2 = PythonConstant.Integer.Binary(15);
+
+            Assert.Equal(bin1, bin2);
+            Assert.True(bin1 == bin2);
+            Assert.Equal(bin1.GetHashCode(), bin2.GetHashCode());
+        }
+
         [Theory]
         [InlineData(0, "0b0")]
         [InlineData(1, "0b1")]
         [InlineData(2, "0b10")]
         [InlineData(3, "0b11")]
         [InlineData(42, "0b101010")]
-        public void ToString_Returns_BinaryFormatting(long input, string expected)
+        public void BinaryInteger_ToString_Returns_Binary_Format(int value, string expected)
         {
-            var n = new PythonConstant.BinaryInteger(input);
-            Assert.Equal(expected, n.ToString());
+            var bin = PythonConstant.Integer.Binary(value);
+            Assert.Equal(expected, bin.ToString());
         }
     }
 
-    public sealed class FloatTests
+    public class FloatTests
     {
+        [Fact]
+        public void Double_To_PythonConstant_Creates_Float()
+        {
+            PythonConstant constant = 3.14;
+            var floatConstant = Assert.IsType<PythonConstant.Float>(constant);
+            Assert.Equal(3.14, floatConstant.Value);
+        }
+
+        [Fact]
+        public void Instances_With_Same_Value_Are_Equal()
+        {
+            var float1 = new PythonConstant.Float(3.14);
+            var float2 = new PythonConstant.Float(3.14);
+
+            Assert.Equal(float1, float2);
+            Assert.True(float1 == float2);
+            Assert.Equal(float1.GetHashCode(), float2.GetHashCode());
+        }
+
+        [Fact]
+        public void Supports_Value_Init()
+        {
+            var floatConstant = new PythonConstant.Float(1.0) { Value = 3.14 };
+            Assert.Equal(3.14, floatConstant.Value);
+        }
+
         [Fact]
         public void ToString_Is_Not_Culture_Specific()
         {
@@ -40,6 +140,198 @@ public class PythonConstantTests
             {
                 CultureInfo.CurrentCulture = oldCulture;
             }
+        }
+
+        [Theory]
+        [InlineData(0.0, "0")]
+        [InlineData(1.5, "1.5")]
+        [InlineData(-42.125, "-42.125")]
+        public void ToString_Formats_Correctly(double value, string expected)
+        {
+            var floatConstant = new PythonConstant.Float(value);
+            Assert.Equal(expected, floatConstant.ToString());
+        }
+    }
+
+    public class StringTests
+    {
+        [Fact]
+        public void String_To_PythonConstant_Creates_String()
+        {
+            PythonConstant constant = "hello";
+            var stringConstant = Assert.IsType<PythonConstant.String>(constant);
+            Assert.Equal("hello", stringConstant.Value);
+        }
+
+        [Fact]
+        public void Instances_With_Same_Value_Are_Equal()
+        {
+            var str1 = new PythonConstant.String("hello");
+            var str2 = new PythonConstant.String("hello");
+
+            Assert.Equal(str1, str2);
+            Assert.True(str1 == str2);
+            Assert.Equal(str1.GetHashCode(), str2.GetHashCode());
+        }
+
+        [Fact]
+        public void Instances_With_Different_Values_Are_Not_Equal()
+        {
+            var str1 = new PythonConstant.String("hello");
+            var str2 = new PythonConstant.String("world");
+
+            Assert.NotEqual(str1, str2);
+            Assert.False(str1 == str2);
+            Assert.True(str1 != str2);
+        }
+
+        [Fact]
+        public void Supports_Value_Init()
+        {
+            var stringConstant = new PythonConstant.String("old") { Value = "new" };
+            Assert.Equal("new", stringConstant.Value);
+        }
+    }
+
+    public class BoolTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Bool_To_PythonConstant_Creates_Bool(bool value)
+        {
+            PythonConstant constant = value;
+            var boolConstant = Assert.IsType<PythonConstant.Bool>(constant);
+            Assert.Equal(value, boolConstant.Value);
+
+            // Verify singleton pattern is maintained
+            Assert.Same(value ? PythonConstant.Bool.True : PythonConstant.Bool.False, boolConstant);
+        }
+
+        [Fact]
+        public void True_Is_Singleton()
+        {
+            var bool1 = PythonConstant.Bool.True;
+            var bool2 = PythonConstant.Bool.True;
+            Assert.Same(bool1, bool2);
+        }
+
+        [Fact]
+        public void False_Is_Singleton()
+        {
+            var bool1 = PythonConstant.Bool.False;
+            var bool2 = PythonConstant.Bool.False;
+            Assert.Same(bool1, bool2);
+        }
+
+        [Fact]
+        public void True_ToString_Returns_True()
+        {
+            Assert.Equal("True", PythonConstant.Bool.True.ToString());
+        }
+
+        [Fact]
+        public void False_ToString_Returns_False()
+        {
+            Assert.Equal("False", PythonConstant.Bool.False.ToString());
+        }
+    }
+
+    public class ByteStringTests
+    {
+        [Fact]
+        public void Instances_With_Same_Value_Are_Equal()
+        {
+            var bytes1 = new PythonConstant.ByteString("test");
+            var bytes2 = new PythonConstant.ByteString("test");
+
+            Assert.Equal(bytes1, bytes2);
+            Assert.True(bytes1 == bytes2);
+            Assert.Equal(bytes1.GetHashCode(), bytes2.GetHashCode());
+        }
+
+        [Fact]
+        public void Supports_Value_Init()
+        {
+            var byteString = new PythonConstant.ByteString("old") { Value = "new" };
+            Assert.Equal("new", byteString.Value);
+        }
+
+        [Fact]
+        public void Constructor_Accepts_ASCII_Characters()
+        {
+            var chars = Enumerable.Range(0, 128).Select(i => (char)i).ToArray();
+            var str = new string(chars);
+            var byteString = new PythonConstant.ByteString(str);
+            Assert.Equal(str, byteString.Value);
+        }
+
+        public static TheoryData<string> InvalidValues = new()
+        {
+            "Héllo", // é is not ASCII
+            "Hello£", // £ is not ASCII
+            "こんにちは", // Japanese characters
+            "🚀", // Emoji
+            "\x80", // Character 128
+        };
+
+        [Theory]
+        [MemberData(nameof(InvalidValues))]
+        public void Constructor_Throws_For_NonASCII_Characters(string invalidValue)
+        {
+            void Act() => _ = new PythonConstant.ByteString(invalidValue);
+            var exception = Assert.Throws<ArgumentException>(Act);
+            Assert.Equal("Byte strings must contain only ASCII characters. (Parameter 'value')", exception.Message);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidValues))]
+        public void Value_Init_Validates_ASCII(string invalidValue)
+        {
+            void Act() => _ = new PythonConstant.ByteString("valid") { Value = invalidValue };
+            var exception = Assert.Throws<ArgumentException>(Act);
+            Assert.Equal("Byte strings must contain only ASCII characters. (Parameter 'value')", exception.Message);
+        }
+
+        [Fact]
+        public void ToString_Returns_Value()
+        {
+            var byteString = new PythonConstant.ByteString("test");
+            Assert.Equal("test", byteString.ToString());
+        }
+    }
+
+    public class NoneTests
+    {
+        [Fact]
+        public void Is_Singleton()
+        {
+            var none1 = PythonConstant.None.Value;
+            var none2 = PythonConstant.None.Value;
+            Assert.Same(none1, none2);
+        }
+
+        [Fact]
+        public void ToString_Returns_None()
+        {
+            Assert.Equal("None", PythonConstant.None.Value.ToString());
+        }
+    }
+
+    public class EllipsisTests
+    {
+        [Fact]
+        public void Is_Singleton()
+        {
+            var ellipsis1 = PythonConstant.Ellipsis.Value;
+            var ellipsis2 = PythonConstant.Ellipsis.Value;
+            Assert.Same(ellipsis1, ellipsis2);
+        }
+
+        [Fact]
+        public void ToString_Returns_Ellipsis()
+        {
+            Assert.Equal("...", PythonConstant.Ellipsis.Value.ToString());
         }
     }
 }

--- a/src/CSnakes.Tests/PythonTypeSpecTests.cs
+++ b/src/CSnakes.Tests/PythonTypeSpecTests.cs
@@ -677,8 +677,8 @@ public class PythonTypeSpecTests
     {
         private static class Constants
         {
-            public static readonly PythonConstant Integer1 = new PythonConstant.Integer(42);
-            public static readonly PythonConstant Integer2 = new PythonConstant.Integer(43);
+            public static readonly PythonConstant Integer1 = PythonConstant.Integer.Decimal(42);
+            public static readonly PythonConstant Integer2 = PythonConstant.Integer.Decimal(43);
             public static readonly PythonConstant String = new PythonConstant.String("hello");
             public static readonly PythonConstant Float = new PythonConstant.Float(3.14);
         }


### PR DESCRIPTION
# Refactor PythonConstant Integer Types with Notation Hints

This PR is forked from PR #728 as in independent change. It refactors the `PythonConstant` type hierarchy in two ways:

- All `PythonConstant` subclasses are converted to C# records for value & equality semantics, such that a `LiteralType` composed of constants can be compared by value.
- Improve the representation of integer constants with different notations (decimal, hexadecimal, and binary). The design consolidates the previously separate `Integer`, `HexadecimalInteger`, and `BinaryInteger` classes into a single `Integer` record with a notation hint, while also modernizing the

Tests have been added to verify all constant values behave as expected.

## Design Changes

### Unified Integer Representation

The previous design used separate classes for different integer notations:

- `PythonConstant.Integer` for decimal integers
- `PythonConstant.HexadecimalInteger` extending `Integer`
- `PythonConstant.BinaryInteger` extending `Integer`

This approach had several issues:

1. **Type-based distinction**: The notation was encoded in the type itself, making comparisons awkward (42 decimal vs 0x2A hex should be equal)
2. **Inheritance hierarchy**: Using inheritance for what is essentially presentation formatting violated proper object-oriented design
3. **Equality semantics**: Two integers with the same value but different notations were not equal

The new design introduces a single `PythonConstant.Integer` record with:

- A `Value` property containing the actual numeric value
- A `NotationHint` enum property indicating the desired string representation
- Factory methods: `Decimal()`, `Hexadecimal()`, and `Binary()`
- **Value-based equality**: Two integers are equal if their values match, regardless of notation

### Record-based Type System

All `PythonConstant` types have been converted from classes to records:
- `Integer`, `Float`, `String`, `ByteString`, `Bool`, `None`, `Ellipsis`

This provides equality by default, which would be intuitive.
