### PR TITLE
Fix empty tuple string representation

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
+++ b/src/CSnakes.SourceGeneration/Parser/Types/PythonTypeSpec.cs
@@ -149,7 +149,11 @@ public sealed record CallableType(ValueArray<PythonTypeSpec>? Parameters, Python
 
 public sealed record TupleType(ValueArray<PythonTypeSpec> Parameters) : ClosedGenericType("tuple")
 {
-    public override string ToString() => $"{Name}[{string.Join(", ", Parameters)}]";
+    public override string ToString() => Parameters switch
+    {
+        [] => $"{Name}[()]",
+        var @params => $"{Name}[{string.Join(", ", @params)}]"
+    };
 }
 
 public sealed record VariadicTupleType(PythonTypeSpec Of) : PythonTypeSpec("tuple")

--- a/src/CSnakes.Tests/PythonTypeSpecTests.cs
+++ b/src/CSnakes.Tests/PythonTypeSpecTests.cs
@@ -890,7 +890,7 @@ public class PythonTypeSpecTests
             ValueArray<PythonTypeSpec> parameters = [];
             var type = new TupleType(parameters);
 
-            Assert.Equal("tuple[]", type.ToString());
+            Assert.Equal("tuple[()]", type.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes the string representation for an empty tuple. According to the [Python documentation](https://docs.python.org/3/library/typing.html#annotating-tuples):

> To denote an empty tuple, use `tuple[()]`. Using plain tuple as an annotation is equivalent to using `tuple[Any, ...]`:
