### PR TITLE
Fix `PythonConstant.Float` string representation to match Python's `repr`

### DIFF
--- a/src/CSnakes.Tests/PythonConstantTests.cs
+++ b/src/CSnakes.Tests/PythonConstantTests.cs
@@ -169,7 +169,7 @@ public class PythonConstantTests
         // values >= 1e16 get an exponent...
         [InlineData(1000000000000000.0, "1000000000000000.0")]
         [InlineData(9999999999999990.0, "9999999999999990.0")]
-        // FIXME [InlineData(1e+16, "1e+16")]
+        [InlineData(1e+16, "1e+16")]
         [InlineData(1e+17, "1e+17")]
         // ... and so do values < 1e-4
         [InlineData(0.001, "0.001")]


### PR DESCRIPTION
This PR updates the formatting logic for floating-point constants to better match Python's string representation of floats, and expands the associated test coverage to ensure compliance with Python's formatting rules.

It should also address the following [test failure from CI run](https://github.com/tonybaloney/CSnakes/actions/runs/20207486074/job/58008215732?pr=728#step:7:12) for PR #728:

    [xUnit.net 00:00:01.98]     CSnakes.Tests.TokenizerTests.ParseFunctionParameter(code: "value: Literal[1, 'two', 3.0]", expectedName: "value", expectedType: "Literal[1, 'two', 3.0]") [FAIL]
      Failed CSnakes.Tests.TokenizerTests.ParseFunctionParameter(code: "value: Literal[1, 'two', 3.0]", expectedName: "value", expectedType: "Literal[1, 'two', 3.0]") [4 ms]
      Error Message:
       Assert.Equal() Failure: Strings differ
                                  ↓ (pos 19)
    Expected: "Literal[1, 'two', 3.0]"
    Actual:   "Literal[1, 'two', 3]"
                                  ↑ (pos 19)
      Stack Trace:
         at CSnakes.Tests.TokenizerTests.ParseFunctionParameter(String code, String expectedName, String expectedType) in /_/src/CSnakes.Tests/TokenizerTests.cs:line 121
       at InvokeStub_TokenizerTests.ParseFunctionParameter(Object, Span`1)
       at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
