### PR TITLE
Update Basic.Reference.Assemblies family of packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
     Runtime dependencies
    -->
   <ItemGroup>
-    <PackageVersion Include="Basic.Reference.Assemblies" Version="1.8.3" />
+    <PackageVersion Include="Basic.Reference.Assemblies" Version="1.8.4" />
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
@@ -24,11 +24,11 @@
     <PackageVersion Include="ZstdSharp.Port" Version="0.8.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.3" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.3" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.9" />
   </ItemGroup>


### PR DESCRIPTION
This PR groups the updates to **Basic.Reference.Assemblies** family of packages, superseding PRs #751, #752 and #753.