### PR TITLE
Test that generator-based coroutines are not supported

### DIFF
--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -25,7 +25,7 @@ static partial class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "08afa2080196c6ea4204b0a0576ebec8"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "e982e1262cfab1c660ea0808d8fb68fd"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {
@@ -50,6 +50,7 @@ static partial class TestClassExtensions
         private PyObject __func_test_coroutine;
         private PyObject __func_test_coroutine_raises_exception;
         private PyObject __func_test_coroutine_returns_nothing;
+        private PyObject __func_test_generator_based_coroutine;
 
         internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
@@ -61,6 +62,7 @@ static partial class TestClassExtensions
                 this.__func_test_coroutine = module.GetAttr("test_coroutine");
                 this.__func_test_coroutine_raises_exception = module.GetAttr("test_coroutine_raises_exception");
                 this.__func_test_coroutine_returns_nothing = module.GetAttr("test_coroutine_returns_nothing");
+                this.__func_test_generator_based_coroutine = module.GetAttr("test_generator_based_coroutine");
             }
         }
 
@@ -74,10 +76,12 @@ static partial class TestClassExtensions
                 this.__func_test_coroutine.Dispose();
                 this.__func_test_coroutine_raises_exception.Dispose();
                 this.__func_test_coroutine_returns_nothing.Dispose();
+                this.__func_test_generator_based_coroutine.Dispose();
                 // Bind to new functions
                 this.__func_test_coroutine = module.GetAttr("test_coroutine");
                 this.__func_test_coroutine_raises_exception = module.GetAttr("test_coroutine_raises_exception");
                 this.__func_test_coroutine_returns_nothing = module.GetAttr("test_coroutine_returns_nothing");
+                this.__func_test_generator_based_coroutine = module.GetAttr("test_generator_based_coroutine");
             }
         }
 
@@ -87,6 +91,7 @@ static partial class TestClassExtensions
             this.__func_test_coroutine.Dispose();
             this.__func_test_coroutine_raises_exception.Dispose();
             this.__func_test_coroutine_returns_nothing.Dispose();
+            this.__func_test_generator_based_coroutine.Dispose();
             module.Dispose();
         }
 
@@ -127,6 +132,18 @@ static partial class TestClassExtensions
                 return __return;
             }
         }
+
+        public PyObject TestGeneratorBasedCoroutine(double seconds = 0.1)
+        {
+            using (GIL.Acquire())
+            {
+                this.logger?.LogDebug("Invoking Python function: {FunctionName}", "test_generator_based_coroutine");
+                PyObject __underlyingPythonFunc = this.__func_test_generator_based_coroutine;
+                using PyObject seconds_pyObject = PyObject.From(seconds)!;
+                PyObject __result_pyObject = __underlyingPythonFunc.Call(seconds_pyObject);
+                return __result_pyObject;
+            }
+        }
     }
 }
 
@@ -158,6 +175,14 @@ public interface ITestClass : IReloadableModuleImport
     /// ]]></code>
     /// </summary>
     Task TestCoroutineReturnsNothing(double seconds = 0.1, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invokes the Python function <c>test_generator_based_coroutine</c>:
+    /// <code><![CDATA[
+    /// def test_generator_based_coroutine(seconds: float = 0.1): ...
+    /// ]]></code>
+    /// </summary>
+    PyObject TestGeneratorBasedCoroutine(double seconds = 0.1);
 }
 
 file static class ThisModule

--- a/src/Integration.Tests/CoroutineTests.cs
+++ b/src/Integration.Tests/CoroutineTests.cs
@@ -1,3 +1,4 @@
+using CSnakes.Runtime.Python;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,5 +75,14 @@ public class CoroutineTests(PythonEnvironmentFixture fixture) : IntegrationTestB
     {
         var mod = Env.TestCoroutines();
         await mod.TestCoroutineReturnsNothing(cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public void GeneratorBasedCoroutineIsNotSupported()
+    {
+        var mod = Env.TestCoroutines();
+        using var coro = mod.TestGeneratorBasedCoroutine();
+        void Act() => _ = coro.As<ICoroutine<PyObject, PyObject, PyObject>>();
+        Assert.Throws<InvalidCastException>(Act);
     }
 }

--- a/src/Integration.Tests/python/test_coroutines.py
+++ b/src/Integration.Tests/python/test_coroutines.py
@@ -1,3 +1,4 @@
+import types
 import asyncio
 
 
@@ -12,3 +13,8 @@ async def test_coroutine_raises_exception() -> int:
 
 async def test_coroutine_returns_nothing(seconds: float = 0.1) -> None:
     await asyncio.sleep(seconds)
+
+
+@types.coroutine
+def test_generator_based_coroutine(seconds: float = 0.1):
+    return (yield from test_coroutine(seconds))


### PR DESCRIPTION
This PR adds a test to demonstrate/assert that conversion from generator-based coroutines is not supported.

See also: https://github.com/tonybaloney/CSnakes/pull/700#pullrequestreview-3597594503
