### PR TITLE
Run download validation tests on CI only

### DIFF
--- a/src/CSnakes.Runtime.Tests/Locators/RedistributableLocatorTests.cs
+++ b/src/CSnakes.Runtime.Tests/Locators/RedistributableLocatorTests.cs
@@ -33,7 +33,10 @@ public class RedistributableLocatorTests
         }
     }
 
-    [Theory]
+    public static bool IsContinuousIntegrationEnvironment =>
+        Environment.GetEnvironmentVariable("CI")?.ToLowerInvariant() is { } and not "0" and not "false";
+
+    [Theory(Skip = "Environment is not CI", SkipUnless = nameof(IsContinuousIntegrationEnvironment))]
     [MemberData(nameof(AllTestCases))]
     public void ValidateDownloadUrl(DownloadUrlCase c)
         => VerifyDownloadUrl(c.Platform, c.Architecture, c.FreeThreaded, c.Debug, c.Version);


### PR DESCRIPTION
This PR closes #670 by [skipping](https://xunit.net/docs/getting-started/v3/whats-new.html?q=skipunless#dynamically-skippable-tests) the download validation tests unless running in a CI environment.

When run locally via:

```sh
dotnet test -f net9.0 src/CSnakes.Runtime.Tests
```

the summary shows that 69 tests were skipped:

    Test summary: total: 320, failed: 0, succeeded: 251, skipped: 69, duration: 6.2s

On CI, [none are skipped](https://github.com/tonybaloney/CSnakes/actions/runs/20411668733/job/58649403589#step:8:22):

    Passed!  - Failed:     0, Passed:   320, Skipped:     0, Total:   320, Duration: 21 s - CSnakes.Runtime.Tests.dll (net9.0)

The skipped tests can be forced to run locally too by defining the `CI` environment variable with the value `true`:

```sh
CI=true dotnet test -f net9.0 src/CSnakes.Runtime.Tests
```
