### PR TITLE
Fix typo in `async.md` documentation

### DIFF
--- a/docs/user-guide/async.md
+++ b/docs/user-guide/async.md
@@ -27,7 +27,7 @@ The [C# Async model](https://learn.microsoft.com/en-us/dotnet/standard/parallel-
 - Python event loops belong to the thread that created them. C# tasks can be scheduled on any thread.
 - Python async functions are coroutines that are scheduled on the event loop. C# async functions are tasks that are scheduled on the task pool.
 
-To converge these two models, CSnakes creates a Python event-loop that is services by a .NET thread and which is in turn used to schedule the Python async functions.
+To converge these two models, CSnakes creates a Python event-loop that is serviced by a .NET thread and which is in turn used to schedule the Python async functions.
 
 ## Parallelism considerations
 


### PR DESCRIPTION
Follow-up of #770 

Correct the spelling of "services" to "serviced" in the documentation.