### PR TITLE
Optimise calls by pooling interop arrays for args

### DIFF
--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -457,10 +457,8 @@ public partial class PyObject : SafeHandle, ICloneable
             }
         }
 
-        var marshallers = new SafeHandleMarshaller<PyObject>.ManagedToUnmanagedIn[args.Length];
-        var argHandles = args.Length < 16
-            ? stackalloc IntPtr[args.Length]
-            : new IntPtr[args.Length];
+        var marshallers = CallArrayPool<SafeHandleMarshaller<PyObject>.ManagedToUnmanagedIn>.Get(args.Length);
+        var argHandles = CallArrayPool<nint>.Get(args.Length);
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -551,6 +549,30 @@ public partial class PyObject : SafeHandle, ICloneable
         }
     }
 
+    private static class CallArrayPool<T>
+    {
+        private const int SlotsPerArg = 3;       // Expected slots per argument
+        private const int MinArgsThreshold = 16; // Minimum number of arguments to pool for
+        private const int MaxArgsThreshold = 32; // Maximum number of arguments to pool for
+
+        private const int MinLength          = MinArgsThreshold * SlotsPerArg; // Minimum pooled array length
+        private const int MaxLengthThreshold = MaxArgsThreshold * SlotsPerArg; // New array returned above this
+
+        [ThreadStatic]
+        private static T[]? array;
+
+        public static Span<T> Get(int length)
+        {
+            if (length > MaxLengthThreshold)
+                return new T[length];
+
+            if (array is not { Length: var pooledLength } || pooledLength < length)
+                array = new T[Math.Max(MinLength, length)];
+
+            return array.AsSpan(0, length);
+        }
+    }
+
     /// <summary>
     /// Calls the object with the given arguments and returns the result.
     /// </summary>
@@ -566,18 +588,34 @@ public partial class PyObject : SafeHandle, ICloneable
 
         RaiseOnPythonNotInitialized();
 
-        var argMarshallers = new SafeHandleMarshaller<PyObject>.ManagedToUnmanagedIn[args.Length];
-        var keywordMarshallers = new SafeHandleMarshaller<PyObject>.ManagedToUnmanagedIn[kwargs.Length];
-        var kwargMarshallers = new SafeHandleMarshaller<PyObject>.ManagedToUnmanagedIn[kwargs.Length];
-        var argHandles = args.Length < 16
-            ? stackalloc IntPtr[args.Length]
-            : new IntPtr[args.Length];
-        var kwargNames = kwargs.Length <= 16
-            ? stackalloc IntPtr[kwargs.Length]
-            : new IntPtr[kwargs.Length];
-        var kwargHandles = kwargs.Length < 16
-            ? stackalloc IntPtr[kwargs.Length]
-            : new IntPtr[kwargs.Length];
+        // Use one array for marshallers and another for handles, then segment them such that
+        // arguments are laid out as shown below...
+
+        //
+        // Given: args.Length = 3, kwargs.Length = 2
+        // Total length = args.Length + kwargs.Length * 2 = 3 + 2 * 2 = 7
+        //
+        // index:       0          1          2          3          4          5          6
+        //              +----------+----------+----------+----------+----------+----------+----------+
+        // marshallers/ |   arg1   |   arg2   |   arg3   |   key1   |   key2   |   val1   |   val2   |
+        //     handles: +----------+----------+----------+----------+----------+----------+----------+
+        //              |<---------- argRange ---------->|<-- keywordRange --->|<--- kwargRange ---->|
+        //                          (..3)                     (^4..^2)               (^2..)
+
+        var length = args.Length + kwargs.Length * 2;
+        var argRange = ..args.Length;
+        var keywordRange = ^(kwargs.Length * 2)..^kwargs.Length;
+        var kwargRange = ^kwargs.Length..;
+
+        var marshallers = CallArrayPool<SafeHandleMarshaller<PyObject>.ManagedToUnmanagedIn>.Get(length);
+        var argMarshallers = marshallers[argRange];
+        var keywordMarshallers = marshallers[keywordRange];
+        var kwargMarshallers = marshallers[kwargRange];
+
+        var handles = CallArrayPool<nint>.Get(length);
+        var argHandles = handles[argRange];
+        var keywordHandles = handles[keywordRange];
+        var kwargHandles = handles[kwargRange];
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -589,7 +627,7 @@ public partial class PyObject : SafeHandle, ICloneable
         {
             ref var k = ref keywordMarshallers[i];
             k.FromManaged(kwargs[i].Name);
-            kwargNames[i] = k.ToUnmanaged();
+            keywordHandles[i] = k.ToUnmanaged();
 
             ref var m = ref kwargMarshallers[i];
             m.FromManaged(kwargs[i].Value);
@@ -600,7 +638,7 @@ public partial class PyObject : SafeHandle, ICloneable
         {
             using (GIL.Acquire())
             {
-                return Create(CPythonAPI.Call(this, argHandles, kwargNames, kwargHandles));
+                return Create(CPythonAPI.Call(this, argHandles, keywordHandles, kwargHandles));
             }
         }
         finally


### PR DESCRIPTION
This PR significantly reduces memory allocations during Python function calls by implementing a thread-local array pooling strategy. The optimization replaces heap-allocated arrays and stack-allocated spans with pooled, reusable arrays for argument marshalling, resulting in **41-61% reduction in allocations** with minimal performance impact (0-7% increase in execution time across benchmarks).

Previously, every Python function call allocated new arrays for argument marshallers and handles. For functions with fewer than 16 arguments, stack allocation (`stackalloc`) was used, but this approach still incurred overhead for managing multiple separate allocations per call. This PR introduces a generic `CallArrayPool<T>` class that maintains thread-local pooled arrays for reuse across function calls.

Key design decisions:

1. **Thread-local storage**: Uses `[ThreadStatic]` to avoid synchronization overhead while preventing cross-thread contamination
2. **Lazy initialization**: Arrays are allocated on first use and sized appropriately (minimum 48 elements for 16 args × 3 slots)
3. **Adaptive sizing**: Pools arrays for 16-32 arguments; falls back to regular allocation for larger calls though those should be rare
4. **Single array segmentation**: For kwargs-enabled calls, uses range operators to segment a single pooled array into multiple logical sections (args, keyword names, keyword values), reducing allocation count from 6 arrays to 2!

## Benchmarks

| Diff    | Method                              |                 Mean |        Error |        Allocated |
| ------- | ----------------------------------- | -------------------: | -----------: | ---------------: |
| Old     | `PositionalOnlyArgs`                |             369.6 ns |      5.68 ns |            168 B |
| **New** |                                     |   **367.6 ns (-1%)** |  **7.01 ns** |  **96 B (-43%)** |
| Old     | `CollectStarArgs`                   |             449.5 ns |      6.06 ns |            168 B |
| **New** |                                     |   **455.9 ns (+1%)** |  **5.67 ns** |  **96 B (-43%)** |
| Old     | `CollectStarStarKwargs`             |             601.1 ns |      8.72 ns |            232 B |
| **New** |                                     |   **617.2 ns (+3%)** | **10.11 ns** |  **96 B (-59%)** |
| Old     | `PositionalAndKwargs`               |             741.0 ns |      9.50 ns |            296 B |
| **New** |                                     |   **789.5 ns (+7%)** | **14.80 ns** | **128 B (-57%)** |
| Old     | `KeywordOnly`                       |             500.9 ns |      6.63 ns |            248 B |
| **New** |                                     |   **515.0 ns (+3%)** |  **5.97 ns** |  **96 B (-61%)** |
| Old     | `CollectStarArgsAndKeywordOnlyArgs` |             687.3 ns |      8.30 ns |            368 B |
| **New** |                                     |   **717.5 ns (+4%)** | **13.97 ns** | **216 B (-41%)** |
| Old     | `ManyKeywordOnly`                   |           1,747.3 ns |     26.71 ns |            728 B |
| **New** |                                     | **1,841.5 ns (+5%)** | **30.40 ns** | **304 B (-58%)** |

Benchmarks show substantial memory savings with acceptable performance tradeoff:

- **Allocations reduced by 41-61%** across all scenarios
- **Execution time increased by 0-7%**, with most cases showing 1-5% overhead
- Best improvement: `KeywordOnly` calls save 61% allocations with only 3% time increase
- Worst case: `PositionalAndKwargs` shows 7% time increase but 57% allocation reduction

The slight performance penalty is due to array bounds checks and span slicing overhead, but the dramatic reduction in GC pressure makes this a net win for applications with frequent Python interop calls (including those that CSnakes makes internally).

The slight increase in execution speed is relative to optimisations in PR #772, but when the optimisations across this PR and #772 are taken into account, **the improvements can be seen in execution speed and allocations, in every scenario**:

| Diff    | Method                              |                  Mean |        Error |        Allocated |
| ------- | ----------------------------------- | --------------------: | -----------: | ---------------: |
| Old     | `PositionalOnlyArgs`                |              378.3 ns |      6.36 ns |            168 B |
| **New** |                                     |    **367.6 ns (-3%)** |  **7.01 ns** |  **96 B (-43%)** |
| Old     | `CollectStarArgs`                   |              472.8 ns |      5.54 ns |            168 B |
| **New** |                                     |    **455.9 ns (-4%)** |  **5.67 ns** |  **96 B (-43%)** |
| Old     | `CollectStarStarKwargs`             |              651.8 ns |      6.18 ns |            192 B |
| **New** |                                     |    **617.2 ns (-5%)** | **10.11 ns** |  **96 B (-50%)** |
| Old     | `PositionalAndKwargs`               |              815.9 ns |     11.30 ns |            240 B |
| **New** |                                     |    **789.5 ns (-3%)** | **14.80 ns** | **128 B (-47%)** |
| Old     | `KeywordOnly`                       |              570.1 ns |     11.19 ns |            192 B |
| **New** |                                     |   **515.0 ns (-10%)** |  **5.97 ns** |  **96 B (-50%)** |
| Old     | `CollectStarArgsAndKeywordOnlyArgs` |              730.6 ns |      8.45 ns |            328 B |
| **New** |                                     |    **717.5 ns (-2%)** | **13.97 ns** | **216 B (-34%)** |
| Old     | `ManyKeywordOnly`                   |            2,198.9 ns |     40.24 ns |            528 B |
| **New** |                                     | **1,841.5 ns (-16%)** | **30.40 ns** | **304 B (-42%)** |
