### PR TITLE
Fix race condition in concurrent Python installs

### DIFF
--- a/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
+++ b/src/CSnakes.Runtime/Locators/RedistributableLocator.cs
@@ -107,7 +107,11 @@ internal class RedistributableLocator(ILogger<RedistributableLocator>? logger, R
             {
                 installCompletionSource.SetException(ex);
             }
-        });
+        })
+        {
+            IsBackground = true,
+            Name = $"CSnakes Python {dottedVersion} Installer"
+        };
 
         installerThread.Start();
         return installCompletionSource.Task.GetAwaiter().GetResult();


### PR DESCRIPTION
This PR fixes #805 by means of the following key changes:

1. **Dedicated installer thread**: The mutex is now created, acquired, and released entirely within a single thread's scope. This ensures that if the thread terminates without an explicit `ReleaseMutex()`, the OS correctly identifies the mutex as abandoned by that specific thread&mdash;rather than relying on the host or caller's thread.

2. **Guaranteed mutex release on all paths**: The `mutex.ReleaseMutex()` call is now in the `try` block that wraps the `Install()` local function, ensuring it is called on both the cache-hit (early return) and fresh-install paths. Only on exception is the mutex intentionally left unreleased, so that the next waiter's `AbandonedMutexException` correctly triggers cleanup of a failed installation.

3. **Local function for installation logic**: The installation logic (mutex wait &rarr; check cache &rarr; download/extract) is extracted into the local function `Install()`, keeping the flow clear while the outer method manages the thread lifecycle and result propagation via `TaskCompletionSource`.

## Validation

[Merged](https://github.com/tonybaloney/CSnakes/pull/709/commits/e932416934e5a36015c86cee33c3dfcc72578fe0) into and tested with PR #709. [See run 23410859526](https://github.com/tonybaloney/CSnakes/actions/runs/23410859526) for pass.