### PR TITLE
Use `PythonVersion` property in F# samle for consistency

### DIFF
--- a/samples/simple/FSharpSample/FSharpSample.fsproj
+++ b/samples/simple/FSharpSample/FSharpSample.fsproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="CSnakes.Runtime" Version="2.*-*" />
-        <PackageReference Include="python" Version="3.12.4" />
+        <PackageReference Include="python" Version="$(PythonVersion)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR aligns the F# sample project, `FSharpSample.fsproj`, with the other samples that use the [centrally managed `$(PythonVersion)`](https://github.com/tonybaloney/CSnakes/blob/4dd2d13a26d8cb01abe3149b6cea0c3d358b7f14/samples/simple/Directory.Build.props#L4) variable instead of a hard-coded version number.