### PR TITLE
Fix zero address debug print when `PyObject` is finalized

### DIFF
--- a/src/CSnakes.Runtime/Python/PyObject.cs
+++ b/src/CSnakes.Runtime/Python/PyObject.cs
@@ -38,12 +38,10 @@ public partial class PyObject : SafeHandle, ICloneable
         {
             // The Python environment has been disposed, and therefore Python has freed it's memory pools.
             // Don't run decref since the Python process isn't running and this pointer will point somewhere else.
-            handle = IntPtr.Zero;
             // TODO: Consider moving this to a logger.
             Debug.WriteLine($"Python object at 0x{handle:X} was released, but Python is no longer running.");
-            return true;
         }
-        if (GIL.IsAcquired)
+        else if (GIL.IsAcquired)
         {
             using (GIL.Acquire())
             {


### PR DESCRIPTION
This PR fixes #823.

## Validation

The following file-based program is used to exercise the bug and the fix:

```c#
#:package Microsoft.Extensions.Hosting@10.0.3
#:project src/CSnakes.Runtime/CSnakes.Runtime.csproj

using CSnakes.Runtime;
using CSnakes.Runtime.Python;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Hosting;

Test();
GC.Collect();
GC.WaitForPendingFinalizers();

static void Test()
{
    var builder = Host.CreateApplicationBuilder();
    _ = builder.Services
               .WithPython()
               .FromRedistributable();

    using var app = builder.Build();

    using var env = app.Services.GetRequiredService<IPythonEnvironment>();

    _ = PyObject.From("foo");
    _ = PyObject.From("bar");
    _ = PyObject.From("baz");
}
```

It creates 3 strings that are never explicitly disposed. The Python runtime is explicitly finalized by the time `Test` method returns. A full GC collection is then forced with a wait for finalizer thread to invoke finalization of 3 Python strings.

Next, run the following in Bash on Linux or a compatible WSL distro:

```sh
docker run --rm -it --name csnakes mcr.microsoft.com/dotnet/sdk:10.0 bash -exc '
git clone --single-branch -b main https://github.com/atifaziz/CSnakes.git
cd CSnakes

# Commit of main when bug was reported
git checkout f8a86f3a77c9b1b3d2cfd5dfd294cd40f937da83

cat > test.cs <<EOF
#:package Microsoft.Extensions.Hosting@10.0.3
#:project src/CSnakes.Runtime/CSnakes.Runtime.csproj

using CSnakes.Runtime;
using CSnakes.Runtime.Python;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Hosting;

Test();
GC.Collect();
GC.WaitForPendingFinalizers();

static void Test()
{
    var builder = Host.CreateApplicationBuilder();
    _ = builder.Services
               .WithPython()
               .FromRedistributable();

    using var app = builder.Build();

    using var env = app.Services.GetRequiredService<IPythonEnvironment>();

    _ = PyObject.From("foo");
    _ = PyObject.From("bar");
    _ = PyObject.From("baz");
}
EOF

export DOTNET_DebugWriteToStdErr=1

dotnet test.cs

git fetch --depth 1 https://github.com/atifaziz/CSnakes.git fix/823
git switch -c fix/823 FETCH_HEAD

dotnet test.cs
'
```

The first `dotnet run` should end with the following lines:

    Initializing Python on thread -1
    Calling Py_Finalize() on thread -1
    Python object at 0x0 was released, but Python is no longer running.
    Python object at 0x0 was released, but Python is no longer running.
    Python object at 0x0 was released, but Python is no longer running.

The second run after checking out the fix should end with the following lines where the addresses should be non-zero:

    Initializing Python on thread -1
    Calling Py_Finalize() on thread -1
    Python object at 0x7B668012D4D0 was released, but Python is no longer running.
    Python object at 0x7B668012D530 was released, but Python is no longer running.
    Python object at 0x7B668012D500 was released, but Python is no longer running.
