### PR TITLE
Reuse Python environment fixture across all tests

### DIFF
--- a/src/CSnakes.Runtime.Tests/Converter/BigIntegerConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/BigIntegerConverterTest.cs
@@ -2,8 +2,8 @@ using System.Numerics;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class BigIntegerConverterTest :
-    ConverterTestBase<BigInteger, BigIntegerConverterTest>,
+public class BigIntegerConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<BigInteger, BigIntegerConverterTest>(fixture),
     IConverterTestCasesContainer<BigInteger>
 {
     public static TheoryData<BigInteger> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/BoolConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/BoolConverterTest.cs
@@ -1,7 +1,7 @@
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class BoolConverterTest :
-    ConverterTestBase<bool, BoolConverterTest>,
+public class BoolConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<bool, BoolConverterTest>(fixture),
     IConverterTestCasesContainer<bool>
 {
     public static TheoryData<bool> TestCases => new() { true, false };

--- a/src/CSnakes.Runtime.Tests/Converter/BytesConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/BytesConverterTest.cs
@@ -2,8 +2,8 @@ using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class BytesConverterTest :
-    ConverterTestBase<byte[], PyObjectImporters.ByteArray, BytesConverterTest>,
+public class BytesConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<byte[], PyObjectImporters.ByteArray, BytesConverterTest>(fixture),
     IConverterTestCasesContainer<byte[]>
 {
     public static TheoryData<byte[]> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/ConverterTestBase.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/ConverterTestBase.cs
@@ -6,7 +6,8 @@ public interface IConverterTestCasesContainer<T>
     static abstract TheoryData<T> TestCases { get; }
 }
 
-public abstract class ConverterTestBase<T, TTestCases> : RuntimeTestBase
+public abstract class ConverterTestBase<T, TTestCases>(PythonEnvironmentFixture fixture) :
+    RuntimeTestBase(fixture)
     where TTestCases : IConverterTestCasesContainer<T>
 {
     public static TheoryData<T> SubTestCases => TTestCases.TestCases;
@@ -27,8 +28,8 @@ public abstract class ConverterTestBase<T, TTestCases> : RuntimeTestBase
         TestRoundtrip(input, static obj => obj.As<T>());
 }
 
-public abstract class ConverterTestBase<T, TImporter, TTestCases> :
-    ConverterTestBase<T, TTestCases>
+public abstract class ConverterTestBase<T, TImporter, TTestCases>(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<T, TTestCases>(fixture)
     where TImporter : IPyObjectImporter<T>
     where TTestCases : IConverterTestCasesContainer<T>
 {

--- a/src/CSnakes.Runtime.Tests/Converter/DictionaryConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/DictionaryConverterTest.cs
@@ -2,10 +2,10 @@ using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class DictionaryConverterTest :
+public class DictionaryConverterTest(PythonEnvironmentFixture fixture) :
     ConverterTestBase<IReadOnlyDictionary<string, string>,
                       PyObjectImporters.Dictionary<string, string, PyObjectImporters.String, PyObjectImporters.String>,
-                      DictionaryConverterTest>,
+                      DictionaryConverterTest>(fixture),
     IConverterTestCasesContainer<IReadOnlyDictionary<string, string>>
 {
     public static TheoryData<IReadOnlyDictionary<string, string>> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/DoubleConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/DoubleConverterTest.cs
@@ -2,8 +2,8 @@ using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class DoubleConverterTest :
-    ConverterTestBase<double, PyObjectImporters.Double, DoubleConverterTest>,
+public class DoubleConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<double, PyObjectImporters.Double, DoubleConverterTest>(fixture),
     IConverterTestCasesContainer<double>
 {
     public static TheoryData<double> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/FloatConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/FloatConverterTest.cs
@@ -1,7 +1,7 @@
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class FloatConverterTest :
-    ConverterTestBase<float, FloatConverterTest>,
+public class FloatConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<float, FloatConverterTest>(fixture),
     IConverterTestCasesContainer<float>
 {
     public static TheoryData<float> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/IntConverterTest.cs
@@ -2,8 +2,8 @@ using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class IntConverterTest :
-    ConverterTestBase<int, IntConverterTest>,
+public class IntConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<int, IntConverterTest>(fixture),
     IConverterTestCasesContainer<int>
 {
     public static TheoryData<int> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/ListConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/ListConverterTest.cs
@@ -2,10 +2,10 @@ using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class ListConverterTest :
+public class ListConverterTest(PythonEnvironmentFixture fixture) :
     ConverterTestBase<IReadOnlyList<long>,
                       PyObjectImporters.List<long, PyObjectImporters.Int64>,
-                      ListConverterTest>,
+                      ListConverterTest>(fixture),
     IConverterTestCasesContainer<IReadOnlyList<long>>
 {
     public static TheoryData<IReadOnlyList<long>> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/LongConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/LongConverterTest.cs
@@ -1,8 +1,8 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
-public class LongConverterTest :
-    ConverterTestBase<long, PyObjectImporters.Int64, LongConverterTest>,
+public class LongConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<long, PyObjectImporters.Int64, LongConverterTest>(fixture),
     IConverterTestCasesContainer<long>
 {
     public static TheoryData<long> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Converter/TupleConverterTests.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/TupleConverterTests.cs
@@ -2,49 +2,49 @@ using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class Tuple1ConverterTests :
+public class Tuple1ConverterTests(PythonEnvironmentFixture fixture) :
     ConverterTestBase<ValueTuple<long>,
                       PyObjectImporters.Tuple<long, PyObjectImporters.Int64>,
-                      Tuple1ConverterTests>,
+                      Tuple1ConverterTests>(fixture),
     IConverterTestCasesContainer<ValueTuple<long>>
 {
     public static TheoryData<ValueTuple<long>> TestCases => new() { ValueTuple.Create(1) };
 }
 
-public class Tuple2ConverterTests :
+public class Tuple2ConverterTests(PythonEnvironmentFixture fixture) :
     ConverterTestBase<(long, long),
         PyObjectImporters.Tuple<long, long, PyObjectImporters.Int64, PyObjectImporters.Int64>,
-        Tuple2ConverterTests>,
+        Tuple2ConverterTests>(fixture),
     IConverterTestCasesContainer<(long, long)>
 {
     public static TheoryData<(long, long)> TestCases => new() { (1, 2) };
 }
 
-public class Tuple3ConverterTests :
+public class Tuple3ConverterTests(PythonEnvironmentFixture fixture) :
     ConverterTestBase<(long, long, long),
         PyObjectImporters.Tuple<long, long, long, PyObjectImporters.Int64, PyObjectImporters.Int64, PyObjectImporters.Int64>,
-        Tuple3ConverterTests>,
+        Tuple3ConverterTests>(fixture),
     IConverterTestCasesContainer<(long, long, long)>
 {
     public static TheoryData<(long, long, long)> TestCases => new() { (1, 2, 3) };
 }
 
-public class Tuple8ConverterTests :
+public class Tuple8ConverterTests(PythonEnvironmentFixture fixture) :
     ConverterTestBase<(long, long, long, long, long, long, long, long),
         PyObjectImporters.Tuple<long, long, long, long, long, long, long, long,
             PyObjectImporters.Int64, PyObjectImporters.Int64, PyObjectImporters.Int64,
             PyObjectImporters.Int64, PyObjectImporters.Int64, PyObjectImporters.Int64,
             PyObjectImporters.Int64, PyObjectImporters.Int64>,
-        Tuple8ConverterTests>,
+        Tuple8ConverterTests>(fixture),
     IConverterTestCasesContainer<(long, long, long, long, long, long, long, long)>
 {
     public static TheoryData<(long, long, long, long, long, long, long, long)> TestCases =>
         new() { (1, 2, 3, 4, 5, 6, 7, 8) };
 }
 
-public class Tuple17ConverterTests :
+public class Tuple17ConverterTests(PythonEnvironmentFixture fixture) :
     ConverterTestBase<(long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long),
-        Tuple17ConverterTests>,
+        Tuple17ConverterTests>(fixture),
     IConverterTestCasesContainer<(long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long)>
 {
     public static TheoryData<(long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long, long)>

--- a/src/CSnakes.Runtime.Tests/Converter/UnicodeConverterTest.cs
+++ b/src/CSnakes.Runtime.Tests/Converter/UnicodeConverterTest.cs
@@ -2,8 +2,8 @@ using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Converter;
 
-public class UnicodeConverterTest :
-    ConverterTestBase<string, PyObjectImporters.String, UnicodeConverterTest>,
+public class UnicodeConverterTest(PythonEnvironmentFixture fixture) :
+    ConverterTestBase<string, PyObjectImporters.String, UnicodeConverterTest>(fixture),
     IConverterTestCasesContainer<string>
 {
     public static TheoryData<string> TestCases => new()

--- a/src/CSnakes.Runtime.Tests/Python/AwaitableTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/AwaitableTests.cs
@@ -1,14 +1,14 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class AwaitableTests : RuntimeTestBase
+public class AwaitableTests(PythonEnvironmentFixture fixture) : RuntimeTestBase(fixture)
 {
     private PyObject AsyncIoSleep()
     {
         var locals = new Dictionary<string, PyObject>();
         var globals = new Dictionary<string, PyObject>();
 
-        using var result = env.Execute(locals: locals, globals: globals, code: """
+        using var result = Env.Execute(locals: locals, globals: globals, code: """
             import asyncio
             a = asyncio.sleep(0)
 
@@ -17,12 +17,12 @@ public class AwaitableTests : RuntimeTestBase
         return locals["a"];
     }
 
-    public class PyObjectWaitAsync : AwaitableTests
+    public class PyObjectWaitAsync(PythonEnvironmentFixture fixture) : AwaitableTests(fixture)
     {
         [Fact]
         public void WhenNotAwaitable_Throws()
         {
-            using var result = env.ExecuteExpression("42");
+            using var result = Env.ExecuteExpression("42");
 
             void Act() => Awaitable.WaitAsync(result, TestContext.Current.CancellationToken);
             var ex = Assert.Throws<ArgumentException>(Act);
@@ -54,7 +54,7 @@ public class AwaitableTests : RuntimeTestBase
         static abstract Task<PyObject> Invoke(T awaitable, CancellationToken cancellationToken);
     }
 
-    public abstract class WaitAsync<T, TWaitAsync> : AwaitableTests
+    public abstract class WaitAsync<T, TWaitAsync>(PythonEnvironmentFixture fixture) : AwaitableTests(fixture)
         where T : IAwaitable
         where TWaitAsync : IWaitAsync<TWaitAsync, T>
     {
@@ -95,7 +95,7 @@ public class AwaitableTests : RuntimeTestBase
 
             var locals = new Dictionary<string, PyObject>();
             var globals = new Dictionary<string, PyObject>();
-            using var result = env.Execute(code, locals, globals);
+            using var result = Env.Execute(code, locals, globals);
 
             (string BeforeAwait, string AfterAwait, string Deletion) expectedLog;
             using var log = PyObject.From(Array.Empty<string>());
@@ -125,14 +125,18 @@ public class AwaitableTests : RuntimeTestBase
         }
     }
 
-    public class NonGenericWaitAsync : WaitAsync<IAwaitable, NonGenericWaitAsync>, IWaitAsync<NonGenericWaitAsync, IAwaitable>
+    public class NonGenericWaitAsync(PythonEnvironmentFixture fixture) :
+        WaitAsync<IAwaitable, NonGenericWaitAsync>(fixture),
+        IWaitAsync<NonGenericWaitAsync, IAwaitable>
     {
         static Task<PyObject> IWaitAsync<NonGenericWaitAsync, IAwaitable>.Invoke(IAwaitable awaitable,
                                                                                  CancellationToken cancellationToken) =>
             awaitable.WaitAsync(cancellationToken);
     }
 
-    public class GenericWaitAsync : WaitAsync<IAwaitable<PyObject>, GenericWaitAsync>, IWaitAsync<GenericWaitAsync, IAwaitable<PyObject>>
+    public class GenericWaitAsync(PythonEnvironmentFixture fixture):
+        WaitAsync<IAwaitable<PyObject>, GenericWaitAsync>(fixture),
+        IWaitAsync<GenericWaitAsync, IAwaitable<PyObject>>
     {
         static Task<PyObject> IWaitAsync<GenericWaitAsync, IAwaitable<PyObject>>.Invoke(IAwaitable<PyObject> awaitable,
                                                                                         CancellationToken cancellationToken) =>

--- a/src/CSnakes.Runtime.Tests/Python/GILTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/GILTests.cs
@@ -1,7 +1,7 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class GILTests : RuntimeTestBase
+public class GILTests(PythonEnvironmentFixture fixture) : RuntimeTestBase(fixture)
 {
     [Fact]
     public void IsAcquired_WhenGilIsNotAcquired_ReturnsFalse()

--- a/src/CSnakes.Runtime.Tests/Python/ImmortalTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/ImmortalTests.cs
@@ -8,7 +8,8 @@ public interface IImmortalFromTestCasesContainer<T>
     static abstract TheoryData<T> TestCases { get; }
 }
 
-public abstract class ImmortalTestsBase<T, TTestCases>(string repr) : RuntimeTestBase
+public abstract class ImmortalTestsBase<T, TTestCases>(PythonEnvironmentFixture fixture, string repr) :
+    RuntimeTestBase(fixture)
     where TTestCases : IImmortalFromTestCasesContainer<T>
 {
     protected abstract PyObject Subject { get; }
@@ -48,8 +49,8 @@ public abstract class ImmortalTestsBase<T, TTestCases>(string repr) : RuntimeTes
     }
 }
 
-public class ImmortalZeroTests() :
-    ImmortalTestsBase<object, ImmortalZeroTests>("0"),
+public class ImmortalZeroTests(PythonEnvironmentFixture fixture) :
+    ImmortalTestsBase<object, ImmortalZeroTests>(fixture, "0"),
     IImmortalFromTestCasesContainer<object>
 {
     protected override PyObject Subject => PyObject.Zero;
@@ -57,8 +58,8 @@ public class ImmortalZeroTests() :
     static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 0, 0L, new BigInteger(0) };
 }
 
-public class ImmortalOneTests() :
-    ImmortalTestsBase<object, ImmortalOneTests>("1"),
+public class ImmortalOneTests(PythonEnvironmentFixture fixture) :
+    ImmortalTestsBase<object, ImmortalOneTests>(fixture, "1"),
     IImmortalFromTestCasesContainer<object>
 {
     protected override PyObject Subject => PyObject.One;
@@ -66,8 +67,8 @@ public class ImmortalOneTests() :
     static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { 1, 1L, new BigInteger(1) };
 }
 
-public class ImmortalNegativeOneTests() :
-    ImmortalTestsBase<object, ImmortalNegativeOneTests>("-1"),
+public class ImmortalNegativeOneTests(PythonEnvironmentFixture fixture) :
+    ImmortalTestsBase<object, ImmortalNegativeOneTests>(fixture, "-1"),
     IImmortalFromTestCasesContainer<object>
 {
     protected override PyObject Subject => PyObject.NegativeOne;
@@ -75,8 +76,8 @@ public class ImmortalNegativeOneTests() :
     static TheoryData<object> IImmortalFromTestCasesContainer<object>.TestCases => new() { -1, -1L, new BigInteger(-1) };
 }
 
-public class ImmortalTrueTests() :
-    ImmortalTestsBase<bool, ImmortalTrueTests>("True"),
+public class ImmortalTrueTests(PythonEnvironmentFixture fixture) :
+    ImmortalTestsBase<bool, ImmortalTrueTests>(fixture, "True"),
     IImmortalFromTestCasesContainer<bool>
 {
     protected override PyObject Subject => PyObject.True;
@@ -84,8 +85,8 @@ public class ImmortalTrueTests() :
     static TheoryData<bool> IImmortalFromTestCasesContainer<bool>.TestCases => new() { true };
 }
 
-public class ImmortalFalseTests() :
-    ImmortalTestsBase<bool, ImmortalFalseTests>("False"),
+public class ImmortalFalseTests(PythonEnvironmentFixture fixture) :
+    ImmortalTestsBase<bool, ImmortalFalseTests>(fixture, "False"),
     IImmortalFromTestCasesContainer<bool>
 {
     protected override PyObject Subject => PyObject.False;

--- a/src/CSnakes.Runtime.Tests/Python/ImportTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/ImportTests.cs
@@ -1,7 +1,7 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class ImportTests : RuntimeTestBase
+public class ImportTests(PythonEnvironmentFixture fixture) : RuntimeTestBase(fixture)
 {
     [Fact]
     public void TestImportModule()

--- a/src/CSnakes.Runtime.Tests/Python/PyDictionaryTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyDictionaryTests.cs
@@ -1,7 +1,7 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class PyDictionaryTests : RuntimeTestBase
+public class PyDictionaryTests(PythonEnvironmentFixture fixture) : RuntimeTestBase(fixture)
 {
     [Fact]
     public void TestIndex()

--- a/src/CSnakes.Runtime.Tests/Python/PyListTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyListTests.cs
@@ -1,7 +1,7 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class PyListTests : RuntimeTestBase
+public class PyListTests(PythonEnvironmentFixture fixture) : RuntimeTestBase(fixture)
 {
     [Fact]
     public void TestGetEnumeratorFunctionsDespiteEarlyListDisposal()

--- a/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/PyObjectTests.cs
@@ -1,7 +1,7 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class PyObjectTests : RuntimeTestBase
+public class PyObjectTests(PythonEnvironmentFixture fixture) : RuntimeTestBase(fixture)
 {
     [Fact]
     public void TestToString()

--- a/src/CSnakes.Runtime.Tests/Python/RunTests.cs
+++ b/src/CSnakes.Runtime.Tests/Python/RunTests.cs
@@ -1,19 +1,19 @@
 using CSnakes.Runtime.Python;
 
 namespace CSnakes.Runtime.Tests.Python;
-public class RunTests : RuntimeTestBase
+public class RunTests(PythonEnvironmentFixture fixture) : RuntimeTestBase(fixture)
 {
     [Fact]
     public void TestSimpleString()
     {
-        using var result = env.ExecuteExpression("1+1");
+        using var result = Env.ExecuteExpression("1+1");
         Assert.Equal("2", result.ToString());
     }
 
     [Fact]
     public void TestBadString()
     {
-        Assert.Throws<PythonInvocationException>(() => env.ExecuteExpression("1+"));
+        Assert.Throws<PythonInvocationException>(() => Env.ExecuteExpression("1+"));
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class RunTests : RuntimeTestBase
         {
             ["a"] = PyObject.From(101)
         };
-        using var result = env.ExecuteExpression("a+1", locals);
+        using var result = Env.ExecuteExpression("a+1", locals);
         Assert.Equal("102", result.ToString());
     }
 
@@ -38,7 +38,7 @@ public class RunTests : RuntimeTestBase
         {
             ["b"] = PyObject.From(100)
         };
-        using var result = env.ExecuteExpression("a+b+1", locals, globals);
+        using var result = Env.ExecuteExpression("a+b+1", locals, globals);
         Assert.Equal("202", result.ToString());
     }
 
@@ -57,7 +57,7 @@ b = c + a
         {
             ["d"] = PyObject.From(100)
         };
-        using var result = env.Execute(c, locals, globals);
+        using var result = Env.Execute(c, locals, globals);
         Assert.Equal("None", result.ToString());
     }
 
@@ -73,7 +73,7 @@ b = c + a
         {
             ["b"] = PyObject.From(100)
         };
-        using var result = env.Execute(code, locals, globals);
+        using var result = Env.Execute(code, locals, globals);
         Assert.Equal("None", result.ToString());
         Assert.Equal(202, locals["c"].As<long>());
         Assert.Equal(101, locals["b"].As<long>());

--- a/src/CSnakes.Runtime.Tests/PythonEnvironmentFixtures.cs
+++ b/src/CSnakes.Runtime.Tests/PythonEnvironmentFixtures.cs
@@ -1,0 +1,97 @@
+using System;
+using CSnakes.Runtime.Locators;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CSnakes.Runtime.Tests;
+
+public sealed class PythonEnvironmentFixtureBuildContext(IPythonEnvironmentBuilder environment,
+                                                         ILoggingBuilder logging)
+{
+    public IPythonEnvironmentBuilder Environment { get; } = environment;
+    public ILoggingBuilder Logging { get; } = logging;
+}
+
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+public abstract class PythonEnvironmentFixtureBase : IDisposable
+{
+    private readonly IHost app;
+
+    protected PythonEnvironmentFixtureBase(string? home = null,
+                                           Action<PythonEnvironmentFixtureBuildContext>? configure = null)
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var environmentBuilder =
+            builder.Services
+                   .AddLogging(loggingBuilder => XUnitLoggerExtensions.AddXUnit(loggingBuilder))
+                   .WithPython()
+                   .WithHome(home ?? Environment.CurrentDirectory);
+
+        configure?.Invoke(new(environmentBuilder, builder.Logging));
+
+        this.app = builder.Build();
+        Env = app.Services.GetRequiredService<IPythonEnvironment>();
+    }
+
+    public virtual void Dispose()
+    {
+        Env.Dispose();
+        app.Dispose();
+        GC.Collect();
+    }
+
+    public IPythonEnvironment Env { get; }
+
+    protected IServiceProvider Services => app.Services;
+}
+
+public sealed record RedistributablePythonSku
+{
+    public RedistributablePythonSku(int versionMajor, int versionMinor)
+    {
+        if (versionMajor is not 3)
+            throw new ArgumentException($"Python version {versionMajor}.x is not supported.", nameof(versionMajor));
+
+        Version = versionMinor switch
+        {
+             9 => RedistributablePythonVersion.Python3_9,
+            10 => RedistributablePythonVersion.Python3_10,
+            11 => RedistributablePythonVersion.Python3_11,
+            12 => RedistributablePythonVersion.Python3_12,
+            13 => RedistributablePythonVersion.Python3_13,
+            14 => RedistributablePythonVersion.Python3_14,
+            var minor => throw new ArgumentException($"Python version 3.{minor} is not supported.", nameof(versionMinor)),
+        };
+
+        VersionMajor = versionMajor;
+        VersionMinor = versionMinor;
+    }
+
+    public RedistributablePythonVersion Version { get; }
+
+    public int VersionMajor { get; }
+    public int VersionMinor { get; }
+
+    public bool Debug { get; init; }
+    public bool FreeThreaded { get; init; }
+}
+
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+public abstract class RedistributablePythonEnvironmentFixture(
+                          string? home = null,
+                          Action<PythonEnvironmentFixtureBuildContext, RedistributablePythonSku>? configure = null) :
+    PythonEnvironmentFixtureBase(home, context =>
+    {
+        var version = ServiceCollectionExtensions.ParsePythonVersion(Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.9");
+        var sku = new RedistributablePythonSku(version.Major, version.Minor)
+        {
+            Debug = Environment.GetEnvironmentVariable("PYTHON_DEBUG") == "1",
+            FreeThreaded = Environment.GetEnvironmentVariable("PYTHON_FREETHREADED") == "1",
+        };
+
+        context.Environment.FromRedistributable(sku.Version, debug: sku.Debug, freeThreaded: sku.FreeThreaded);
+
+        configure?.Invoke(context, sku);
+    });

--- a/src/CSnakes.Runtime.Tests/RuntimeTestBase.cs
+++ b/src/CSnakes.Runtime.Tests/RuntimeTestBase.cs
@@ -1,47 +1,16 @@
-using CSnakes.Runtime.Locators;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-
 namespace CSnakes.Runtime.Tests;
 
-public class RuntimeTestBase : IDisposable
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+[CollectionDefinition(Name)]
+public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvironmentFixture>
 {
-    protected readonly IPythonEnvironment env;
-    protected readonly IHost app;
+    public const string Name = "PythonEnvironment";
+}
 
-    public RuntimeTestBase()
-    {
-        Version pythonVersionToTest = ServiceCollectionExtensions.ParsePythonVersion(Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.9");
-        bool freeThreaded = Environment.GetEnvironmentVariable("PYTHON_FREETHREADED") == "1";
-        bool debugPython = Environment.GetEnvironmentVariable("PYTHON_DEBUG") == "1";
+public sealed class PythonEnvironmentFixture : RedistributablePythonEnvironmentFixture;
 
-        RedistributablePythonVersion redistributableVersion = pythonVersionToTest.Minor switch
-        {
-            9 => RedistributablePythonVersion.Python3_9,
-            10 => RedistributablePythonVersion.Python3_10,
-            11 => RedistributablePythonVersion.Python3_11,
-            12 => RedistributablePythonVersion.Python3_12,
-            13 => RedistributablePythonVersion.Python3_13,
-            14 => RedistributablePythonVersion.Python3_14,
-            _ => throw new NotSupportedException($"Python version {pythonVersionToTest} is not supported.")
-        };
-
-        var builder = Host.CreateApplicationBuilder();
-        var pb = builder.Services.WithPython();
-        pb.WithHome(Environment.CurrentDirectory)
-          .FromRedistributable(version: redistributableVersion, debug: debugPython, freeThreaded: freeThreaded);
-
-        builder.Services.AddLogging(loggingBuilder => loggingBuilder.AddXUnit());
-
-        app = builder.Build();
-
-        env = app.Services.GetRequiredService<IPythonEnvironment>();
-    }
-
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-        GC.Collect();
-    }
+[Collection(PythonEnvironmentCollection.Name)]
+public abstract class RuntimeTestBase(PythonEnvironmentFixture fixture)
+{
+    public IPythonEnvironment Env { get; } = fixture.Env;
 }

--- a/src/Conda.Tests/BasicTests.cs
+++ b/src/Conda.Tests/BasicTests.cs
@@ -1,6 +1,6 @@
 namespace Conda.Tests;
 
-public class BasicTests : CondaTestBase
+public class BasicTests(PythonEnvironmentFixture fixture) : CondaTestBase(fixture)
 {
     [Fact]
     public void TestSimpleImport()

--- a/src/Conda.Tests/Conda.Tests.csproj
+++ b/src/Conda.Tests/Conda.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 
   <PropertyGroup>
@@ -23,6 +23,10 @@
   <ItemGroup>
     <ProjectReference Include="..\CSnakes.Runtime\CSnakes.Runtime.csproj" />
     <ProjectReference Include="..\CSnakes.SourceGeneration\CSnakes.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\CSnakes.Runtime.Tests\PythonEnvironmentFixtures.cs" Link="PythonEnvironmentFixtures.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conda.Tests/CondaTestBase.cs
+++ b/src/Conda.Tests/CondaTestBase.cs
@@ -1,60 +1,51 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using CSnakes.Runtime.Tests;
 
 namespace Conda.Tests;
-public class CondaTestBase : IDisposable
+
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+[CollectionDefinition(Name)]
+public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvironmentFixture>
 {
-    private readonly IPythonEnvironment env;
-    private readonly IHost app;
+    public const string Name = "PythonEnvironment";
+}
 
-    public CondaTestBase()
+public class PythonEnvironmentFixture : PythonEnvironmentFixtureBase
+{
+    public PythonEnvironmentFixture() :
+        base(home: Path.Join(Environment.CurrentDirectory, "python"),
+             static context =>
+             {
+                 var condaEnv = Environment.GetEnvironmentVariable("CONDA") ?? string.Empty;
+                 var pythonVersion = Environment.GetEnvironmentVariable("PYTHON_VERSION");
+                 var isWindows = OperatingSystem.IsWindows();
+
+                 if (string.IsNullOrEmpty(condaEnv))
+                 {
+                     var basePath = isWindows
+                                  ? Environment.GetEnvironmentVariable("LOCALAPPDATA")
+                                  : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+                     if (basePath is { } someBasePath)
+                     {
+                         IEnumerable<string> condaNames = ["anaconda3", "miniconda3"];
+                         condaEnv = condaNames.Select(condaName => Path.Join(someBasePath, condaName))
+                                              .FirstOrDefault(Directory.Exists) ?? condaEnv;
+                     }
+                 }
+
+                 var condaBinPath = isWindows ? Path.Join(condaEnv, "Scripts", "conda.exe") : Path.Join(condaEnv, "bin", "conda");
+                 var environmentSpecPath = Path.Join(Environment.CurrentDirectory, "python", "environment.yml");
+
+                 _ = context.Environment
+                            .FromConda(condaBinPath)
+                            .WithCondaEnvironment("csnakes_test", environmentSpecPath, true, pythonVersion);
+             })
     {
-        string condaEnv = Environment.GetEnvironmentVariable("CONDA") ?? string.Empty;
-        string? pythonVersion = Environment.GetEnvironmentVariable("PYTHON_VERSION");
-
-        if (string.IsNullOrEmpty(condaEnv))
-        {
-            string? basePath = null;
-            if (OperatingSystem.IsWindows())
-            {
-                basePath = Environment.GetEnvironmentVariable("LOCALAPPDATA");
-            }
-            else
-            {
-                basePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            }
-
-            if (basePath is not null)
-            {
-                condaEnv = new[] { "anaconda3", "miniconda3" }
-                    .Select(condaName => Path.Join(basePath, condaName))
-                    .FirstOrDefault(Directory.Exists) ?? condaEnv;
-            }
-
-        }
-
-        var condaBinPath = OperatingSystem.IsWindows() ? Path.Join(condaEnv, "Scripts", "conda.exe") : Path.Join(condaEnv, "bin", "conda");
-        var environmentSpecPath = Path.Join(Environment.CurrentDirectory, "python", "environment.yml");
-        var builder = Host.CreateApplicationBuilder();
-        var pb = builder.Services.WithPython();
-        pb.WithHome(Path.Join(Environment.CurrentDirectory, "python"));
-
-        pb.FromConda(condaBinPath)
-          .WithCondaEnvironment("csnakes_test", environmentSpecPath, true, pythonVersion);
-
-        builder.Services.AddLogging(loggingBuilder => loggingBuilder.AddXUnit());
-
-        app = builder.Build();
-
-        env = app.Services.GetRequiredService<IPythonEnvironment>();
     }
+}
 
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-        GC.Collect();
-    }
-
-    public IPythonEnvironment Env => env;
+[Collection(PythonEnvironmentCollection.Name)]
+public abstract class CondaTestBase(PythonEnvironmentFixture fixture)
+{
+    public IPythonEnvironment Env { get; } = fixture.Env;
 }

--- a/src/Integration.Tests/Integration.Tests.csproj
+++ b/src/Integration.Tests/Integration.Tests.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\CSnakes.Runtime.Tests\PythonEnvironmentFixtures.cs" Link="PythonEnvironmentFixtures.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="python\requirements.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/Integration.Tests/IntegrationTestBase.cs
+++ b/src/Integration.Tests/IntegrationTestBase.cs
@@ -1,8 +1,6 @@
-using CSnakes.Runtime.Locators;
 using CSnakes.Runtime.PackageManagement;
+using CSnakes.Runtime.Tests;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 
@@ -16,56 +14,22 @@ public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvir
 }
 
 /// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
-public sealed class PythonEnvironmentFixture : IDisposable
+public sealed class PythonEnvironmentFixture : RedistributablePythonEnvironmentFixture
 {
-    private readonly IPythonEnvironment env;
-    private readonly IPythonPackageInstaller installer;
-    private readonly IHost app;
-
-    public PythonEnvironmentFixture()
+    public PythonEnvironmentFixture() :
+        base(home: Path.Join(Environment.CurrentDirectory, "python"),
+             (context, sku) =>
+             {
+                 var venv = FormattableString.Invariant($".venv-{sku.VersionMajor}.{sku.VersionMinor}{(sku.FreeThreaded ? "t" : "")}{(sku.Debug ? "d" : "")}");
+                 context.Environment
+                        .WithVirtualEnvironment(Path.Join(Environment.CurrentDirectory, "python", venv))
+                        .WithPipInstaller();
+             })
     {
-        Version pythonVersionToTest = ServiceCollectionExtensions.ParsePythonVersion(Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.9");
-        bool freeThreaded = Environment.GetEnvironmentVariable("PYTHON_FREETHREADED") == "1";
-        bool debugPython = Environment.GetEnvironmentVariable("PYTHON_DEBUG") == "1";
-        string venvPath = Path.Join(Environment.CurrentDirectory, "python", $".venv-{pythonVersionToTest}{(freeThreaded ? "t": "")}{(debugPython ? "d": "")}");
-
-        RedistributablePythonVersion redistributableVersion = pythonVersionToTest.Minor switch
-        {
-            9 => RedistributablePythonVersion.Python3_9,
-            10 => RedistributablePythonVersion.Python3_10,
-            11 => RedistributablePythonVersion.Python3_11,
-            12 => RedistributablePythonVersion.Python3_12,
-            13 => RedistributablePythonVersion.Python3_13,
-            14 => RedistributablePythonVersion.Python3_14,
-            _ => throw new NotSupportedException($"Python version {pythonVersionToTest} is not supported.")
-        };
-
-        var builder = Host.CreateApplicationBuilder();
-        var pb = builder.Services.WithPython();
-        pb.WithHome(Path.Join(Environment.CurrentDirectory, "python"));
-
-        pb.FromRedistributable(version: redistributableVersion, debug: debugPython, freeThreaded: freeThreaded)
-          .WithVirtualEnvironment(venvPath)
-          .WithPipInstaller();
-
-        builder.Services.AddLogging(loggingBuilder => loggingBuilder.AddXUnit());
-
-        app = builder.Build();
-
-        env = app.Services.GetRequiredService<IPythonEnvironment>();
-        installer = app.Services.GetRequiredService<IPythonPackageInstaller>();
+        Installer = Services.GetRequiredService<IPythonPackageInstaller>();
     }
 
-    public void Dispose()
-    {
-        env.Dispose();
-        app.Dispose();
-        GC.SuppressFinalize(this);
-        GC.Collect();
-    }
-
-    public IPythonEnvironment Env => env;
-    public IPythonPackageInstaller Installer => installer;
+    public IPythonPackageInstaller Installer { get; }
 }
 
 [Collection(PythonEnvironmentCollection.Name)]

--- a/src/RedistributablePython.Tests/BasicTests.cs
+++ b/src/RedistributablePython.Tests/BasicTests.cs
@@ -1,6 +1,6 @@
 namespace RedistributablePython.Tests;
 
-public class BasicTests: RedistributablePythonTestBase
+public class BasicTests(PythonEnvironmentFixture fixture) : RedistributablePythonTestBase(fixture)
 {
     [Fact]
     public void TestSimpleRedistributableImport()

--- a/src/RedistributablePython.Tests/RedistributablePython.Tests.csproj
+++ b/src/RedistributablePython.Tests/RedistributablePython.Tests.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\CSnakes.Runtime.Tests\PythonEnvironmentFixtures.cs" Link="PythonEnvironmentFixtures.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="python\requirements.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/RedistributablePython.Tests/RedistributablePythonTestBase.cs
+++ b/src/RedistributablePython.Tests/RedistributablePythonTestBase.cs
@@ -1,55 +1,42 @@
-using CSnakes.Runtime.Locators;
+using CSnakes.Runtime.PackageManagement;
+using CSnakes.Runtime.Tests;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace RedistributablePython.Tests;
-public class RedistributablePythonTestBase : IDisposable
+
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+[CollectionDefinition(Name)]
+public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvironmentFixture>
 {
-    private readonly IPythonEnvironment env;
-    private readonly IHost app;
+    public const string Name = "PythonEnvironment";
+}
 
-    public RedistributablePythonTestBase()
+/// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
+public sealed class PythonEnvironmentFixture : RedistributablePythonEnvironmentFixture
+{
+    public PythonEnvironmentFixture() :
+        base(home: Path.Join(Environment.CurrentDirectory, "python"),
+             static (context, sku) =>
+             {
+                 var venv = FormattableString.Invariant($".venv-{sku.VersionMajor}.{sku.VersionMinor}{(sku.FreeThreaded ? "t" : "")}{(sku.Debug ? "d" : "")}");
+                 _ = context.Environment.DisableSignalHandlers()
+                            .WithUvInstaller()
+                            .WithVirtualEnvironment(Path.Join(Environment.CurrentDirectory, "python", venv))
+                            .CapturePythonLogs();
+
+                 context.Logging.SetMinimumLevel(LogLevel.Debug)
+                                .AddFilter(_ => true);
+             })
     {
-        Version pythonVersionToTest = ServiceCollectionExtensions.ParsePythonVersion(Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.9");
-        bool freeThreaded = Environment.GetEnvironmentVariable("PYTHON_FREETHREADED") == "1";
-        bool debugPython = Environment.GetEnvironmentVariable("PYTHON_DEBUG") == "1";
-        string venvPath = Path.Join(Environment.CurrentDirectory, "python", $".venv-{pythonVersionToTest}{(freeThreaded ? "t" : "")}{(debugPython ? "d" : "")}");
-
-        RedistributablePythonVersion redistributableVersion = pythonVersionToTest.Minor switch
-        {
-            9 => RedistributablePythonVersion.Python3_9,
-            10 => RedistributablePythonVersion.Python3_10,
-            11 => RedistributablePythonVersion.Python3_11,
-            12 => RedistributablePythonVersion.Python3_12,
-            13 => RedistributablePythonVersion.Python3_13,
-            14 => RedistributablePythonVersion.Python3_14,
-            _ => throw new NotSupportedException($"Python version {pythonVersionToTest} is not supported.")
-        };
-        var builder = Host.CreateApplicationBuilder();
-        var pb = builder.Services.WithPython();
-        pb.WithHome(Path.Join(Environment.CurrentDirectory, "python"))
-          .DisableSignalHandlers()
-          .FromRedistributable(version: redistributableVersion, debug: debugPython, freeThreaded: freeThreaded)
-          .WithUvInstaller()
-          .WithVirtualEnvironment(venvPath)
-          .CapturePythonLogs();
-
-        builder.Services.AddLogging(loggingBuilder => loggingBuilder.AddXUnit());
-
-        builder.Logging.SetMinimumLevel(LogLevel.Debug);
-        builder.Logging.AddFilter(_ => true);
-
-        app = builder.Build();
-
-        env = app.Services.GetRequiredService<IPythonEnvironment>();
+        Installer = Services.GetRequiredService<IPythonPackageInstaller>();
     }
 
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-        GC.Collect();
-    }
+    public IPythonPackageInstaller Installer { get; }
+}
 
-    public IPythonEnvironment Env => env;
+[Collection(PythonEnvironmentCollection.Name)]
+public class RedistributablePythonTestBase(PythonEnvironmentFixture fixture)
+{
+    public IPythonEnvironment Env { get; } = fixture.Env;
 }


### PR DESCRIPTION
This PR refactors the test infrastructure across all test projects to share a single Python environment instance per test collection, rather than creating and destroying one per test class. It leverages xUnit's [collection fixture](https://xunit.net/docs/shared-context.html#collection-fixture) pattern to reduce test execution overhead initialising and finalising (which was missing) once. It also reduces the amount code duplication around the environment setup.

### Technical Details

- Introduces `PythonEnvironmentFixtureBase`, an abstract base that encapsulates the host-building, service registration, and `IPythonEnvironment` resolution into a single disposable fixture. xUnit manages its lifetime once per collection.
- Adds `RedistributablePythonEnvironmentFixture`, a derived fixture that reads `PYTHON_VERSION`, `PYTHON_DEBUG`, and `PYTHON_FREETHREADED` environment variables and configures the redistributable Python locator accordingly.
- Introduces `RedistributablePythonSku` as a typed record to cleanly bundle version/debug/free-threaded settings.
- Adds `PythonEnvironmentFixtureBuildContext` to expose both `IPythonEnvironmentBuilder` and `ILoggingBuilder` to fixture configuration callbacks.
- `RuntimeTestBase` is no longer `IDisposable` and no longer owns the environment lifecycle.
- A `PythonEnvironmentCollection` collection definition ties the fixture to a named collection, and `[Collection]` attributes route test classes into it.
- `Integration.Tests` and `RedistributablePython.Tests` define their own `PythonEnvironmentFixture` subclasses that add virtual environments and package installers (pip/uv) via the configuration callback.
- `Conda.Tests` defines its fixture using `PythonEnvironmentFixtureBase` directly to configure the conda locator.
- All three satellite test projects link `PythonEnvironmentFixtures.cs` from `CSnakes.Runtime.Tests` via `<Compile Include="..." Link="..." />` to share the base classes without a separate shared project.

The changes are structural (test infrastructure only) and do not alter runtime behavior except now properly disposing the environment.