### PR TITLE
Make generated interface partial without access modifier

### DIFF
--- a/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
+++ b/src/CSnakes.SourceGeneration/PythonStaticGenerator.cs
@@ -313,7 +313,7 @@ public class PythonStaticGenerator : IIncrementalGenerator
             /// <summary>
             /// Represents functions of the Python module <c>{{moduleAbsoluteName}}</c>.
             /// </summary>
-            public interface I{{pascalFileName}} : IReloadableModuleImport
+            partial interface I{{pascalFileName}} : IReloadableModuleImport
             {
             {{  Lines(IndentationLevel.One,
                       Enumerable.Skip(count: 1, source:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args.approved.txt
@@ -265,7 +265,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>positional_only_args</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_args_underscore.approved.txt
@@ -98,7 +98,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_with_underscore</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_awaitables.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_awaitables.approved.txt
@@ -98,7 +98,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_awaitable</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_basic.approved.txt
@@ -340,7 +340,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_int_float</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -659,7 +659,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_bool_buffer</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_coroutines.approved.txt
@@ -185,7 +185,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_coroutine</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_defaults.approved.txt
@@ -274,7 +274,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_default_str_arg</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dependency.approved.txt
@@ -114,7 +114,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_nothing</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_dicts.approved.txt
@@ -152,7 +152,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_dict_str_int</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_exceptions.approved.txt
@@ -114,7 +114,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_raise_python_exception</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_false_returns.approved.txt
@@ -284,7 +284,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_str_actually_returns_int</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_generators.approved.txt
@@ -132,7 +132,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>example_generator</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_keywords.approved.txt
@@ -121,7 +121,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_keyword_only</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_logging.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_logging.approved.txt
@@ -178,7 +178,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_log_debug</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_none.approved.txt
@@ -114,7 +114,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>returns_none</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_optional.approved.txt
@@ -152,7 +152,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_int</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_overload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_overload.approved.txt
@@ -168,7 +168,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_overload_supported_type</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_pybind11.approved.txt
@@ -97,7 +97,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_pybind11_function</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reload.approved.txt
@@ -113,7 +113,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_number</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_reserved.approved.txt
@@ -97,7 +97,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>switch</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_source.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_source.approved.txt
@@ -97,7 +97,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>get_mad_string</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_sys.approved.txt
@@ -114,7 +114,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_sys_executable</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
@@ -386,7 +386,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>tuple_1</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_unions.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_unions.approved.txt
@@ -211,7 +211,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>test_union_basic</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_windows_arm64.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_windows_arm64.approved.txt
@@ -948,7 +948,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>get_machine_architecture</c>:

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethodsWhenCSharp12.test_args.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethodsWhenCSharp12.test_args.approved.txt
@@ -265,7 +265,7 @@ static partial class TestClassExtensions
 /// <summary>
 /// Represents functions of the Python module <c>test</c>.
 /// </summary>
-public interface ITestClass : IReloadableModuleImport
+partial interface ITestClass : IReloadableModuleImport
 {
     /// <summary>
     /// Invokes the Python function <c>positional_only_args</c>:

--- a/src/Integration.Tests/Public.cs
+++ b/src/Integration.Tests/Public.cs
@@ -1,0 +1,3 @@
+namespace CSnakes.Runtime;
+
+public partial interface ITestBuffer;


### PR DESCRIPTION
In PR #724, the `public` accessibility modifier was removed from the generated classes so they're considered internal by default. The `partial` modifier was added so that the developer can still opt-in for public accessibility by adding the `public` modifier to another definition part; see https://github.com/tonybaloney/CSnakes/pull/724#pullrequestreview-3317443812. This PR does the same for the generated interface.

This is somewhat of a potentially source-breaking change.