### PR TITLE
Make generated module interfaces public in simple sample set

### DIFF
--- a/samples/simple/ExamplePythonDependency/Public.cs
+++ b/samples/simple/ExamplePythonDependency/Public.cs
@@ -1,7 +1,16 @@
 namespace CSnakes.Runtime;
 
 public partial class HelloWorldExtensions;
+public partial interface IHelloWorld;
+
 public partial class KmeansExampleExtensions;
+public partial interface IKmeansExample;
+
 public partial class Phi3DemoExtensions;
+public partial interface IPhi3Demo;
+
 public partial class QuickDemoExtensions;
+public partial interface IQuickDemo;
+
 public partial class TypeDemosExtensions;
+public partial interface ITypeDemos;


### PR DESCRIPTION
Commit 50a827f5b4310a1ce63988a16bff4ff6bd0f24c4 from PR #826 broke the simple sample set that this PR fixes as a follow-up. Unfortunately, this break didn't get picked up by CI because the samples reference the last published package and use it for validation instead of the package resulting from the changes in the PR.