### PR TITLE
Remove accidentally committed Copilot settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,3 @@
 {
-    "dotnet.defaultSolution": "src/CSnakes.slnx",
-    "github.copilot.enable": {
-        "*": false,
-        "plaintext": true,
-        "markdown": true,
-        "scminput": false,
-        "yaml": true,
-        "typescript": true,
-        "jsonc": true,
-        "python": true,
-        "csv": false
-    }
+    "dotnet.defaultSolution": "src/CSnakes.slnx"
 }


### PR DESCRIPTION
This PR removes Copilot settings that seem to have been accidentally committed as part of 5f650a9ae4f0c71d905492244ea87ecfe18f8766. The `github.copilot.enable` setting was disabled for all languages except some. Since `csharp` wasn't part of the exceptions, Copilot is disabled in VS Code for the primary language of the solution. I believe this may have been an accident.