### PR TITLE
Revise `Py_buffer` alignment with CPython definition

### DIFF
--- a/src/CSnakes.Runtime/CPython/Buffer.cs
+++ b/src/CSnakes.Runtime/CPython/Buffer.cs
@@ -17,20 +17,24 @@ internal unsafe partial class CPythonAPI
         AnyContiguous = 0x80 | Strides,
     }
 
+    /// <summary>
+    /// Represents <see href="https://github.com/python/cpython/blob/6280bb547840b609feedb78887c6491af75548e8/Include/pybuffer.h#L20-L33">
+    /// <c>Py_buffer</c> from CPython</see>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     internal struct Py_buffer
     {
-        public nint buf;
-        public nint obj;
-        public nint len;
-        public nint itemsize;
-        public int @readonly;
-        public int ndim;
-        public nint format;
-        public nint* shape;
-        public nint* strides;
-        public nint* suboffsets;
-        public nint* @internal;
+        public void* /* void*       */ buf;
+        public void* /* PyObject*   */ obj;
+        public nint  /* Py_ssize_t  */ len;
+        public nint  /* Py_ssize_t  */ itemsize;
+        public int   /* int         */ @readonly;
+        public int   /* int         */ ndim;
+        public byte* /* char*       */ format;
+        public nint* /* Py_ssize_t* */ shape;
+        public nint* /* Py_ssize_t* */ strides;
+        public nint* /* Py_ssize_t* */ suboffsets;
+        public void* /* void*       */ @internal;
     }
 
     public static bool IsBuffer(PyObject p) => PyObject_CheckBuffer(p) == 1;

--- a/src/CSnakes.Runtime/Python/PyBuffer.cs
+++ b/src/CSnakes.Runtime/Python/PyBuffer.cs
@@ -3,6 +3,7 @@ using CSnakes.Runtime.CPython;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.Marshalling;
 
 #if NET9_0_OR_GREATER
 using System.Numerics.Tensors;
@@ -48,14 +49,14 @@ internal sealed class PyBuffer : IPyBuffer
         SSizeT = 'N', // C ssize_t
     }
 
-    public PyBuffer(PyObject exporter)
+    public unsafe PyBuffer(PyObject exporter)
     {
         using (GIL.Acquire())
         {
             CPythonAPI.GetBuffer(exporter, out _buffer);
         }
         IsScalar = _buffer.ndim is 0 or 1;
-        _format = Marshal.PtrToStringUTF8(_buffer.format) ?? string.Empty;
+        _format = Utf8StringMarshaller.ConvertToManaged(_buffer.format) ?? string.Empty;
         _byteOrder = GetByteOrder();
     }
 
@@ -70,7 +71,7 @@ internal sealed class PyBuffer : IPyBuffer
         GC.SuppressFinalize(this);
     }
 
-    private bool IsDisposed => _buffer.buf == 0;
+    private unsafe bool IsDisposed => _buffer.buf is null;
 
     private void Dispose(bool disposing)
     {
@@ -92,7 +93,7 @@ internal sealed class PyBuffer : IPyBuffer
             // If the GIL is not acquired, we should not release the buffer here
             // as it may lead to
             GIL.QueueForDisposal(ref _buffer);
-            Debug.Assert(_buffer.buf == 0);
+            unsafe { Debug.Assert(_buffer.buf is null); }
             return;
         }
 


### PR DESCRIPTION
This PR revises the definition `Py_buffer` struct to be more accurately and correctly aligned with the [CPython definition](https://docs.python.org/3/library/struct.html#byte-order-size-and-alignment).

I've added original C field type definitions as comments for ease of reference and linked back to the CPython definition. I've also addressed the following suggestions & fixes from PR #505:

- https://github.com/tonybaloney/CSnakes/pull/505#discussion_r3304489424 by @AaronRobinsonMSFT 
- https://github.com/tonybaloney/CSnakes/pull/505#discussion_r3305003149 by @tannergooding
- https://github.com/tonybaloney/CSnakes/pull/505#discussion_r3304614365 by @AaronRobinsonMSFT 
