### PR TITLE
Embed logging helper module via source generator

### DIFF
--- a/src/CSnakes.Runtime/CSnakes.Runtime.csproj
+++ b/src/CSnakes.Runtime/CSnakes.Runtime.csproj
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);SYSLIB5001</NoWarn>
     <!-- Suppress warnings related to use of own experimental API -->
     <NoWarn>$(NoWarn);PRTEXP001;PRTEXP002;PRTEXP003</NoWarn>
+    <EmbedPythonSources>true</EmbedPythonSources>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -31,7 +32,7 @@
 
   <ItemGroup>
     <!-- Reference the source generator purely for packaging purposes -->
-    <ProjectReference Include="..\CSnakes.SourceGeneration\CSnakes.SourceGeneration.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\CSnakes.SourceGeneration\CSnakes.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>
@@ -60,4 +61,6 @@
 
   <Import Project="Packaging.targets" />
   <Import Project="TextTemplates.targets" />
+  <Import Project="..\CSnakes.SourceGeneration\NuGet\buildTransitive\net8.0\CSnakes.SourceGeneration.targets" />
+
 </Project>

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -156,5 +156,5 @@ internal class PythonEnvironment : IPythonEnvironment
         return disposedValue;
     }
 
-    public EventHandler? Disposing;
+    public event EventHandler? Disposing;
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -127,7 +127,7 @@ internal class PythonEnvironment : IPythonEnvironment
             if (disposing)
             {
                 pythonCaptureLogger?.DisposeAsync().GetAwaiter().GetResult();
-                this.disposal?.Fire();
+                this.Disposing?.Invoke(this, EventArgs.Empty);
                 api.Dispose();
                 if (pythonEnvironment is not null)
                 {
@@ -156,62 +156,5 @@ internal class PythonEnvironment : IPythonEnvironment
         return disposedValue;
     }
 
-    Event<IPythonEnvironment>? disposal;
-
-    public IDisposable AddDisposalListener<TArg>(TArg arg, Action<IPythonEnvironment, IDisposable, TArg> handler) =>
-        (disposal ??= new(this)).Subscribe(arg, handler);
-
-    sealed class Event<T>(T sender)
-    {
-        readonly List<Subscription?> subscriptions = new();
-        bool firing;
-
-        public IDisposable Subscribe<TArg>(TArg arg, Action<T, IDisposable, TArg> handler)
-        {
-            var subscription = new Subscription<TArg>(this, arg, handler);
-            subscriptions.Add(subscription);
-            return subscription;
-        }
-
-        void Remove(Subscription subscription)
-        {
-            if (firing)
-            {
-                if (subscriptions.IndexOf(subscription) is var index and >= 0)
-                    subscriptions[index] = null;
-            }
-            else
-            {
-                subscriptions.Remove(subscription);
-            }
-        }
-
-        public void Fire()
-        {
-            firing = true;
-
-            try
-            {
-                for (int i = 0; i < subscriptions.Count; i++)
-                    subscriptions[i]?.Fire(sender);
-            }
-            finally
-            {
-                firing = false;
-                subscriptions.RemoveAll(s => s is null);
-            }
-        }
-
-        abstract class Subscription(Event<T> @event) : IDisposable
-        {
-            public abstract void Fire(T sender);
-            public void Dispose() => @event.Remove(this);
-        }
-
-        sealed class Subscription<TArg>(Event<T> @event, TArg arg, Action<T, IDisposable, TArg> handler) :
-            Subscription(@event)
-        {
-            public override void Fire(T sender) => handler(sender, this, arg);
-        }
-    }
+    public EventHandler? Disposing;
 }

--- a/src/CSnakes.Runtime/PythonEnvironment.cs
+++ b/src/CSnakes.Runtime/PythonEnvironment.cs
@@ -101,7 +101,7 @@ internal class PythonEnvironment : IPythonEnvironment
         {
             if (logger is null)
                 throw new ArgumentNullException(nameof(logger), "Argument cannot be null when capturing Python logs.");
-            pythonCaptureLogger = PythonLogger.EnableGlobalLogging(logger);
+            pythonCaptureLogger = PythonLogger.EnableGlobalLogging(this, logger);
         }
     }
 
@@ -127,6 +127,7 @@ internal class PythonEnvironment : IPythonEnvironment
             if (disposing)
             {
                 pythonCaptureLogger?.DisposeAsync().GetAwaiter().GetResult();
+                this.disposal?.Fire();
                 api.Dispose();
                 if (pythonEnvironment is not null)
                 {
@@ -153,5 +154,64 @@ internal class PythonEnvironment : IPythonEnvironment
     public bool IsDisposed()
     {
         return disposedValue;
+    }
+
+    Event<IPythonEnvironment>? disposal;
+
+    public IDisposable AddDisposalListener<TArg>(TArg arg, Action<IPythonEnvironment, IDisposable, TArg> handler) =>
+        (disposal ??= new(this)).Subscribe(arg, handler);
+
+    sealed class Event<T>(T sender)
+    {
+        readonly List<Subscription?> subscriptions = new();
+        bool firing;
+
+        public IDisposable Subscribe<TArg>(TArg arg, Action<T, IDisposable, TArg> handler)
+        {
+            var subscription = new Subscription<TArg>(this, arg, handler);
+            subscriptions.Add(subscription);
+            return subscription;
+        }
+
+        void Remove(Subscription subscription)
+        {
+            if (firing)
+            {
+                if (subscriptions.IndexOf(subscription) is var index and >= 0)
+                    subscriptions[index] = null;
+            }
+            else
+            {
+                subscriptions.Remove(subscription);
+            }
+        }
+
+        public void Fire()
+        {
+            firing = true;
+
+            try
+            {
+                for (int i = 0; i < subscriptions.Count; i++)
+                    subscriptions[i]?.Fire(sender);
+            }
+            finally
+            {
+                firing = false;
+                subscriptions.RemoveAll(s => s is null);
+            }
+        }
+
+        abstract class Subscription(Event<T> @event) : IDisposable
+        {
+            public abstract void Fire(T sender);
+            public void Dispose() => @event.Remove(this);
+        }
+
+        sealed class Subscription<TArg>(Event<T> @event, TArg arg, Action<T, IDisposable, TArg> handler) :
+            Subscription(@event)
+        {
+            public override void Fire(T sender) => handler(sender, this, arg);
+        }
     }
 }

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -39,8 +39,15 @@ public static class PythonLogger
 
                 void OnDisposing(object? sender, EventArgs args)
                 {
-                    result.Dispose();
                     env.Disposing -= OnDisposing;
+
+                    lock (ModuleLock)
+                    {
+                        Debug.Assert(module == result);
+                        module = null;
+                    }
+
+                    result.Dispose();
                 }
 
                 env.Disposing += OnDisposing;

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -11,125 +11,70 @@ namespace CSnakes.Runtime;
 /// </summary>
 public static class PythonLogger
 {
-    public static IAsyncDisposable WithPythonLogging(this IPythonEnvironment env, ILogger logger, string? loggerName = null) =>
-        Bridge.Create(logger, loggerName);
+    static readonly Lock ModuleLock = new();
+    static ICsnakesLogging? module;
 
-    internal static IAsyncDisposable EnableGlobalLogging(ILogger logger) =>
-        Bridge.Create(logger);
+    public static IAsyncDisposable WithPythonLogging(this IPythonEnvironment env, ILogger logger, string? loggerName = null) =>
+        Bridge.Create(GetModule(env), logger, loggerName);
+
+    internal static IAsyncDisposable EnableGlobalLogging(IPythonEnvironment env, ILogger logger) =>
+        Bridge.Create(GetModule(env), logger);
+
+    private static ICsnakesLogging GetModule(IPythonEnvironment env)
+    {
+        lock (ModuleLock)
+        {
+            ICsnakesLogging result;
+
+            if (module is { } someModule)
+            {
+                result = someModule;
+            }
+            else
+            {
+                result = module = env.CsnakesLogging();
+                ((PythonEnvironment)env).AddDisposalListener(result, static (_, subscription, module) =>
+                {
+                    module.Dispose();
+                    subscription.Dispose();
+                });
+            }
+
+            return result;
+        }
+    }
 }
 
-file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Task listenerTask) : IAsyncDisposable
+file sealed class Bridge(PyObject handler, ICsnakesLogging module, Task listenerTask) : IAsyncDisposable
 {
-    const string ModuleCode = """
-        import logging
-        import queue
-        import threading
-
-
-        class __csnakesMemoryHandler(logging.Handler):
-            def __init__(self):
-                logging.Handler.__init__(self)
-                self.queue = queue.Queue(200)
-                self.stats_lock = threading.Lock()
-                self.drop_count = 0
-
-            def emit(self, record):
-                _ = self._put(record)
-
-            def _put(self, record, attempts = 10):
-                for _ in range(attempts):  # attempts to try enqueue the record
-                    try:
-                        self.queue.put_nowait(record)
-                        return True  # successfully enqueued
-                    except queue.Full:
-                        try:
-                            _ = self.queue.get_nowait()  # drop the oldest record
-                            self.queue.task_done()
-                            with self.stats_lock:
-                                self.drop_count += 1
-                        except queue.Empty:
-                            pass
-                return False  # all attempts to put failed
-
-            def get_records(self):
-                while True:
-                    record = self.queue.get()
-                    self.queue.task_done()
-                    if record is None:
-                        break
-                    with self.stats_lock:
-                        drop_count = self.drop_count
-                        self.drop_count = 0
-                    yield (drop_count, record.levelno, record.getMessage(), record.exc_info)
-
-            def close(self):
-                _ = self._put(None)
-                logging.Handler.close(self)
-
-
-        def installCSnakesHandler(handler, name = None):
-            logging.getLogger(name).addHandler(handler)
-
-
-        def uninstallCSnakesHandler(handler, name = None):
-            logging.getLogger(name).removeHandler(handler)
-            handler.close()
-
-        """;
-
     private bool disposed;
 
-    internal static Bridge Create(ILogger logger, string? loggerName = null)
+    internal static Bridge Create(ICsnakesLogging module, ILogger logger, string? loggerName = null)
     {
         PyObject? handler = null;
-        PyObject? uninstallCSnakesHandler = null;
-
-        using var module = Import.ImportModule("_csnakesLoggingBridge", ModuleCode, "_csnakesLoggingBridge.py");
-        using var handlerClass = module.GetAttr("__csnakesMemoryHandler");
-        using var installCSnakesHandler = module.GetAttr("installCSnakesHandler");
-
         Task listenerTask;
 
         try
         {
             using (GIL.Acquire())
             {
-                handler = handlerClass.Call();
-                uninstallCSnakesHandler = module.GetAttr("uninstallCSnakesHandler");
-
-                using var loggerNameStr = PyObject.From(loggerName);
-                installCSnakesHandler.Call(handler, loggerNameStr).Dispose();
-
-                listenerTask = StartRecordListener(handler, logger);
+                handler = module.NewHandler();
+                module.InstallHandler(handler, loggerName);
+                listenerTask = StartRecordListener(module, handler, logger);
             }
         }
         catch
         {
             handler?.Dispose();
-            uninstallCSnakesHandler?.Dispose();
             throw;
         }
 
-        return new(handler, uninstallCSnakesHandler, listenerTask);
+        return new(handler, module, listenerTask);
     }
 
-    private static Task StartRecordListener(PyObject handler, ILogger logger)
+    private static Task StartRecordListener(ICsnakesLogging module, PyObject handler, ILogger logger)
     {
-        using PyObject getRecords = handler.GetAttr("get_records");
-        using PyObject getRecordsResult = getRecords.Call();
-        IGeneratorIterator<(long, long, string, ExceptionInfo?), PyObject, PyObject> generator =
-            getRecordsResult.ImportAs<IGeneratorIterator<(long, long, string, ExceptionInfo?), PyObject, PyObject>,
-                                                         PyObjectImporters.Generator<(long, long, string, ExceptionInfo?), PyObject, PyObject,
-                                                                                     PyObjectImporters.Tuple<long, long, string, ExceptionInfo?,
-                                                                                                             PyObjectImporters.Int64,
-                                                                                                             PyObjectImporters.Int64,
-                                                                                                             PyObjectImporters.String,
-                                                                                                             PyObjectImporters.OptionalValue<ExceptionInfo,
-                                                                                                                                             PyObjectImporters.Tuple<PyObject, PyObject, PyObject,
-                                                                                                                                                                     PyObjectImporters.Runtime<PyObject>,
-                                                                                                                                                                     PyObjectImporters.Runtime<PyObject>,
-                                                                                                                                                                     PyObjectImporters.Runtime<PyObject>>>>,
-                                                                                     PyObjectImporters.Runtime<PyObject>>>();
+        var generator = module.GetRecords(handler);
 
         return Task.Run(() =>
         {
@@ -202,7 +147,7 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
 
         try
         {
-            uninstallCSnakesHandler.Call(handler).Dispose();
+            module.UninstallHandler(handler);
             uninstalled = true;
         }
         catch (Exception ex)
@@ -238,6 +183,5 @@ file sealed class Bridge(PyObject handler, PyObject uninstallCSnakesHandler, Tas
         }
 
         handler.Dispose();
-        uninstallCSnakesHandler.Dispose();
     }
 }

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -20,7 +20,10 @@ public static class PythonLogger
     internal static IAsyncDisposable EnableGlobalLogging(IPythonEnvironment env, ILogger logger) =>
         Bridge.Create(GetModule(env), logger);
 
-    private static ICsnakesLogging GetModule(IPythonEnvironment env)
+    private static ICsnakesLogging GetModule(IPythonEnvironment env) =>
+        GetModule((PythonEnvironment)env);
+
+    private static ICsnakesLogging GetModule(PythonEnvironment env)
     {
         lock (ModuleLock)
         {
@@ -33,11 +36,14 @@ public static class PythonLogger
             else
             {
                 result = module = env.CsnakesLogging();
-                ((PythonEnvironment)env).AddDisposalListener(result, static (_, subscription, module) =>
+
+                void OnDisposing(object? sender, EventArgs args)
                 {
-                    module.Dispose();
-                    subscription.Dispose();
-                });
+                    result.Dispose();
+                    env.Disposing -= OnDisposing;
+                }
+
+                env.Disposing += OnDisposing;
             }
 
             return result;

--- a/src/CSnakes.Runtime/csnakes_logging.py
+++ b/src/CSnakes.Runtime/csnakes_logging.py
@@ -1,0 +1,65 @@
+import logging
+import queue
+import threading
+
+from collections.abc import Generator, Iterator
+from logging import LogRecord
+from typing import Any, Union
+
+
+class __csnakesMemoryHandler(logging.Handler):
+    def __init__(self) -> None:
+        logging.Handler.__init__(self)
+        self.queue = queue.Queue[Union[LogRecord, None]](200)
+        self.stats_lock = threading.Lock()
+        self.drop_count = 0
+
+    def emit(self, record: LogRecord) -> None:
+        _ = self._put(record)
+
+    def _put(self, record: Union[LogRecord, None], attempts: int = 10) -> bool:
+        for _ in range(attempts):  # attempts to try enqueue the record
+            try:
+                self.queue.put_nowait(record)
+                return True  # successfully enqueued
+            except queue.Full:
+                try:
+                    _ = self.queue.get_nowait()  # drop the oldest record
+                    self.queue.task_done()
+                    with self.stats_lock:
+                        self.drop_count += 1
+                except queue.Empty:
+                    pass
+        return False  # all attempts to put failed
+
+    def get_records(self) -> Iterator[tuple[int, int, str, Union[tuple[Any, Any, Any], None]]]:
+        while True:
+            record = self.queue.get()
+            self.queue.task_done()
+            if record is None:
+                break
+            with self.stats_lock:
+                drop_count = self.drop_count
+                self.drop_count = 0
+            yield (drop_count, record.levelno, record.getMessage(), record.exc_info)
+
+    def close(self) -> None:
+        _ = self._put(None)
+        logging.Handler.close(self)
+
+
+def new_handler():
+    return __csnakesMemoryHandler()
+
+
+def get_records(handler) -> Generator[tuple[int, int, str, Union[tuple[Any, Any, Any], None]], None, None]:
+    return handler.get_records()
+
+
+def install_handler(handler, name: Union[str, None] = None) -> None:
+    logging.getLogger(name).addHandler(handler)
+
+
+def uninstall_handler(handler, name: Union[str, None] = None) -> None:
+    logging.getLogger(name).removeHandler(handler)
+    handler.close()


### PR DESCRIPTION
This PR refactors embeds the helper module into **CSnakes.Runtime** via the source generator. The benefits of this are:

- Logging module moves into a stand-alone `.py` file that can be easily edited, formatted, linted and type-checked.
- Calls to helper module functions are strong-typed via generated signatures
- Gets rid of this monstrosity:
  https://github.com/tonybaloney/CSnakes/blob/ff41f263bc95560504fc029dabae7adbc505f720/src/CSnakes.Runtime/PythonLogger.cs#L120-L132

I had to do an awkward workaround to share the module's and defer its disposal until finalization-time.
