### PR TITLE
Simplify logging module interop with fewer helpers

### DIFF
--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -58,42 +58,43 @@ public static class PythonLogger
     }
 }
 
-file sealed class Bridge(PyObject handler, ICsnakesLogging module, Task listenerTask) : IAsyncDisposable
+file sealed class Bridge(PyObject closeCallable, Task listenerTask) : IAsyncDisposable
 {
     private bool disposed;
 
     internal static Bridge Create(ICsnakesLogging module, ILogger logger, string? loggerName = null)
     {
-        PyObject? handler = null;
+        PyObject? closeCallable = null;
         Task listenerTask;
 
         try
         {
             using (GIL.Acquire())
             {
-                handler = module.NewHandler();
-                module.InstallHandler(handler, loggerName);
-                listenerTask = StartRecordListener(module, handler, logger);
+                (var generator, closeCallable) = module.Monitor(loggerName);
+                listenerTask = StartRecordListener(generator, logger);
             }
         }
         catch
         {
-            handler?.Dispose();
+            if (closeCallable is { } callable)
+            {
+                callable.Call();
+                callable.Dispose();
+            }
             throw;
         }
 
-        return new(handler, module, listenerTask);
+        return new(closeCallable, listenerTask);
     }
 
-    private static Task StartRecordListener(ICsnakesLogging module, PyObject handler, ILogger logger)
+    private static Task StartRecordListener(IEnumerator<(long, long, string, ExceptionInfo?)> record, ILogger logger)
     {
-        var generator = module.GetRecords(handler);
-
         return Task.Run(() =>
         {
-            while (generator.MoveNext()) // TODO Restart log records reading loop on failure
+            while (record.MoveNext()) // TODO Restart log records reading loop on failure
             {
-                var (dropCount, level, message, exceptionInfo) = generator.Current;
+                var (dropCount, level, message, exceptionInfo) = record.Current;
 
                 if (dropCount > 0)
                 {
@@ -156,19 +157,19 @@ file sealed class Bridge(PyObject handler, ICsnakesLogging module, Task listener
 
         disposed = true;
 
-        var uninstalled = false;
+        var closed = false;
 
         try
         {
-            module.UninstallHandler(handler);
-            uninstalled = true;
+            closeCallable.Call();
+            closed = true;
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"Error during uninstallation of handler: {ex}");
         }
 
-        if (uninstalled)
+        if (closed)
         {
             var completed = false;
 
@@ -195,6 +196,6 @@ file sealed class Bridge(PyObject handler, ICsnakesLogging module, Task listener
             }
         }
 
-        handler.Dispose();
+        closeCallable.Dispose();
     }
 }

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -79,7 +79,7 @@ file sealed class Bridge(PyObject closeCallable, Task listenerTask) : IAsyncDisp
         {
             if (closeCallable is { } callable)
             {
-                callable.Call();
+                callable.Call().Dispose();
                 callable.Dispose();
             }
             throw;

--- a/src/CSnakes.Runtime/csnakes_logging.py
+++ b/src/CSnakes.Runtime/csnakes_logging.py
@@ -2,12 +2,12 @@ import logging
 import queue
 import threading
 
-from collections.abc import Generator, Iterator
+from collections.abc import Callable, Generator, Iterator
 from logging import LogRecord
 from typing import Any, Union
 
 
-class __csnakesMemoryHandler(logging.Handler):
+class _Handler(logging.Handler):
     def __init__(self) -> None:
         logging.Handler.__init__(self)
         self.queue = queue.Queue[Union[LogRecord, None]](200)
@@ -32,7 +32,7 @@ class __csnakesMemoryHandler(logging.Handler):
                     pass
         return False  # all attempts to put failed
 
-    def get_records(self) -> Iterator[tuple[int, int, str, Union[tuple[Any, Any, Any], None]]]:
+    def get_records(self) -> Generator[tuple[int, int, str, Union[tuple[Any, Any, Any], None]]]:
         while True:
             record = self.queue.get()
             self.queue.task_done()
@@ -48,18 +48,13 @@ class __csnakesMemoryHandler(logging.Handler):
         logging.Handler.close(self)
 
 
-def new_handler():
-    return __csnakesMemoryHandler()
+def monitor(name: Union[str, None] = None) -> tuple[Generator[tuple[int, int, str, Union[tuple[Any, Any, Any], None]], None, None], Callable[[], None]]:
+    handler = _Handler()
+    logger = logging.getLogger(name)
+    logger.addHandler(handler)
 
+    def close():
+        logger.removeHandler(handler)
+        handler.close()
 
-def get_records(handler) -> Generator[tuple[int, int, str, Union[tuple[Any, Any, Any], None]], None, None]:
-    return handler.get_records()
-
-
-def install_handler(handler, name: Union[str, None] = None) -> None:
-    logging.getLogger(name).addHandler(handler)
-
-
-def uninstall_handler(handler, name: Union[str, None] = None) -> None:
-    logging.getLogger(name).removeHandler(handler)
-    handler.close()
+    return (close, handler.get_records())

--- a/src/CSnakes.Runtime/csnakes_logging.py
+++ b/src/CSnakes.Runtime/csnakes_logging.py
@@ -57,4 +57,4 @@ def monitor(name: Union[str, None] = None) -> tuple[Generator[tuple[int, int, st
         logger.removeHandler(handler)
         handler.close()
 
-    return (close, handler.get_records())
+    return (handler.get_records(), close)


### PR DESCRIPTION
This PR builds on top of PR #831. It simplifies the logging module by folding all helper functions into one, reducing the number of interop roundtrips. It replaces the handler instantiation, installation & uninstallation with monitoring (instantiation, installation) + close (uninstallation).
