### PR TITLE
Expand Pyright type-checking to all CI Python versions

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -26,6 +26,10 @@ permissions:
 jobs:
   validate-python:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
@@ -35,13 +39,13 @@ jobs:
         id: installpython
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "${{ matrix.python }}"
 
       - name: Run pyright on test Python code
         run: |
           python -m pip install pyright attrs
           python -m pip install -r src/Integration.Tests/python/requirements.txt
-          pyright src/*.Tests/**/*.py
+          pyright --pythonversion ${{ matrix.python }} src/*.Tests/**/*.py
   unit-test:
     permissions:
       contents: read

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -25,7 +25,7 @@ static partial class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "a14184ac39abd83d437130afbf039361"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "c99d8998db0f565fe615b2d642671b36"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_buffer.approved.txt
@@ -25,7 +25,7 @@ static partial class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "648fa64ee4e57f1215ea2d6c75e52f78"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "a14184ac39abd83d437130afbf039361"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {

--- a/src/Integration.Tests/python/test_buffer.py
+++ b/src/Integration.Tests/python/test_buffer.py
@@ -1,8 +1,9 @@
+import sys
 from typing import Generator
 
-try:
+if sys.version_info >= (3, 12):
     from collections.abc import Buffer
-except ImportError:
+else:
     from typing_extensions import Buffer
 
 import numpy as np

--- a/src/Integration.Tests/python/test_buffer.py
+++ b/src/Integration.Tests/python/test_buffer.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Generator
+from typing import Generator, TypeVar, cast
 
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer
@@ -8,83 +8,94 @@ else:
 
 import numpy as np
 
+_T = TypeVar("_T")
+
+if sys.version_info >= (3, 12):
+    def _as_buffer(val: _T) -> _T:
+        return val
+else:
+    # On Python < 3.12, numpy's stubs don't declare NDArray as implementing
+    # the Buffer protocol, so we cast to satisfy the type checker.
+    def _as_buffer(val: object) -> Buffer:
+        return cast(Buffer, val)
+
 def test_bool_buffer() -> Buffer:
-    return np.array([True, False, True, False, False], dtype=np.bool_)
+    return _as_buffer(np.array([True, False, True, False, False], dtype=np.bool_))
 
 def test_int8_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.int8)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.int8))
 
 def test_uint8_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.uint8)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.uint8))
 
 def test_int16_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.int16)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.int16))
 
 def test_uint16_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.uint16)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.uint16))
 
 def test_int32_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.int32)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.int32))
 
 def test_int64_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.int64)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.int64))
 
 def test_uint32_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.uint32)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.uint32))
 
 def test_uint64_buffer() -> Buffer:
-    return np.array([1, 2, 3, 4, 5], dtype=np.uint64)
+    return _as_buffer(np.array([1, 2, 3, 4, 5], dtype=np.uint64))
 
 def test_float16_buffer() -> Buffer:
-    return np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float16)
+    return _as_buffer(np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float16))
 
 def test_float32_buffer() -> Buffer:
-    return np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float32)
+    return _as_buffer(np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float32))
 
 def test_float64_buffer() -> Buffer:
-    return np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64)
+    return _as_buffer(np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64))
 
 def test_vector_buffer() -> Buffer:
     # create an array with 1532 floats between 0 and 1, similar to an embedding vector
-    return np.random.rand(1532).astype(np.float32)
+    return _as_buffer(np.random.rand(1532).astype(np.float32))
 
 def test_int8_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int8)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int8))
 
 def test_uint8_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8))
 
 def test_int16_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int16)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int16))
 
 def test_uint16_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint16)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint16))
 
 def test_int32_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32))
 
 def test_uint32_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint32)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint32))
 
 def test_int64_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64))
 
 def test_uint64_2d_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint64)
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint64))
 
 def test_float16_2d_buffer() -> Buffer:
-    return np.array([[1.1 , 2.2, 3.3], [4.4, 5.5, 6.6]], dtype=np.float16)
+    return _as_buffer(np.array([[1.1 , 2.2, 3.3], [4.4, 5.5, 6.6]], dtype=np.float16))
 
 def test_float32_2d_buffer() -> Buffer:
-    return np.array([[1.1 , 2.2, 3.3], [4.4, 5.5, 6.6]], dtype=np.float32)
+    return _as_buffer(np.array([[1.1 , 2.2, 3.3], [4.4, 5.5, 6.6]], dtype=np.float32))
 
 def test_float64_2d_buffer() -> Buffer:
-    return np.array([[1.1 , 2.2, 3.3], [4.4, 5.5, 6.6]], dtype=np.float64)
+    return _as_buffer(np.array([[1.1 , 2.2, 3.3], [4.4, 5.5, 6.6]], dtype=np.float64))
 
 arr = np.zeros((2, 3), dtype=np.int32)
 
 def test_global_buffer() -> Buffer:
-    return arr
+    return _as_buffer(arr)
 
 def test_bytes_as_buffer() -> Buffer:
     return b"hello"
@@ -96,31 +107,31 @@ def test_non_buffer() -> Buffer:
     return "hello"  # type: ignore[return-value]
 
 def test_non_contiguous_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)[::2]
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)[::2])
 
 def test_transposed_buffer() -> Buffer:
-    return np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32).T
+    return _as_buffer(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32).T)
 
 def test_ndim_3d_buffer() -> Buffer:
     arr =  np.zeros((2, 3, 4), dtype=np.int32)
     arr[0, 0, 0] = 1
     arr[0, 0, 1] = 2
     arr[1, 2, 3] = 3
-    return arr
+    return _as_buffer(arr)
 
 def test_ndim_3d_float32_buffer() -> Buffer:
     arr = np.ones((3, 4, 5), dtype=np.float32)
-    return arr
+    return _as_buffer(arr)
 
 def test_ndim_4d_buffer() -> Buffer:
     arr = np.zeros((2, 3, 4, 5), dtype=np.int32)
     arr[0, 0, 0, 0] = 1
     arr[0, 0, 0, 1] = 2
     arr[1, 2, 3, 4] = 3
-    return arr
+    return _as_buffer(arr)
 
 
 def sum_of_2d_array(n: int) -> Generator[Buffer, None, int]:
     arr = np.zeros((n, n), dtype=np.int32)
-    yield arr
+    yield _as_buffer(arr)
     return np.sum(arr).item()


### PR DESCRIPTION
This PR improves Python type-checking validation CI job by using the same matrix of Python versions as the integration test job.

Checking against a single version, like 3.13 so far, can give some false positives. For more, see:

- https://github.com/tonybaloney/CSnakes/pull/834#issuecomment-4620996190
- https://github.com/tonybaloney/CSnakes/pull/834#issuecomment-4621171932

Tested locally with 3.9:

    uv run --python 3.9 --isolated --with pyright --with attrs --with-requirements src/Integration.Tests/python/requirements.txt -- pyright --pythonversion 3.9 src/Integration.Tests/python/test_buffer.py

and 3.12:

    uv run --python 3.12 --isolated --with pyright --with attrs --with-requirements src/Integration.Tests/python/requirements.txt -- pyright --pythonversion 3.12 src/Integration.Tests/python/test_buffer.py

Both returned 0 errors & warnings.