### PR TITLE
Install Python environment & packages in CI before running integration tests

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -161,7 +161,7 @@ jobs:
         working-directory: src
 
       - name: Pre-install Python packages
-        run: ./src/Integration.Tests/Install-PythonPackages.ps1 -PythonVersion ${{ matrix.python }} -NoBuild -Verbose
+        run: ./src/Integration.Tests/python/install.ps1 -PythonVersion ${{ matrix.python }} -NoBuild -Verbose
         shell: pwsh
 
       - name: Integration Tests

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -161,7 +161,7 @@ jobs:
         working-directory: src
 
       - name: Pre-install Python packages
-        run: ./src/Integration.Tests/Install-PythonPackages.ps1 -PythonVersion ${{ matrix.python }}
+        run: ./src/Integration.Tests/Install-PythonPackages.ps1 -PythonVersion ${{ matrix.python }} -NoBuild
         shell: pwsh
 
       - name: Integration Tests

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -161,7 +161,7 @@ jobs:
         working-directory: src
 
       - name: Pre-install Python packages
-        run: ./src/Integration.Tests/Install-PythonPackages.ps1 -PythonVersion ${{ matrix.python }} -NoBuild
+        run: ./src/Integration.Tests/Install-PythonPackages.ps1 -PythonVersion ${{ matrix.python }} -NoBuild -Verbose
         shell: pwsh
 
       - name: Integration Tests

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -160,7 +160,7 @@ jobs:
         run: dotnet build --no-restore -bl:${{ github.workspace }}/build-${{ matrix.os }}-${{ matrix.python }}.binlog
         working-directory: src
 
-      - name: Pre-install Python packages
+      - name: Prime Python environment
         run: ./src/Integration.Tests/python/install.ps1 -PythonVersion ${{ matrix.python }} -NoBuild -Verbose
         shell: pwsh
 
@@ -170,6 +170,11 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python }}
           UV_NO_CACHE: 1
+
+      - name: Prime Python environment (Free Threaded)
+        run: ./src/Integration.Tests/python/install.ps1 -PythonVersion ${{ matrix.python }} -FreeThreaded -NoBuild -Verbose
+        if: startsWith(matrix.python, '3.13') || startsWith(matrix.python, '3.14')
+        shell: pwsh
 
       - name: Integration Tests (Free Threaded)
         run: dotnet test --no-build --blame --verbosity m --logger "console;verbosity=detailed" --collect "XPlat Code Coverage" --results-directory test-results /p:TrxLogFileNameSuffix=${{ matrix.os }}-${{ matrix.python }} -bl:${{ github.workspace }}/tests-${{ matrix.os }}-${{ matrix.python }}.binlog Integration.Tests ${{ matrix.os != 'windows-11-arm' && '--filter "FullyQualifiedName!~WindowsArm64Tests"' || '' }}

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -160,6 +160,10 @@ jobs:
         run: dotnet build --no-restore -bl:${{ github.workspace }}/build-${{ matrix.os }}-${{ matrix.python }}.binlog
         working-directory: src
 
+      - name: Pre-install Python packages
+        run: ./src/Integration.Tests/Install-PythonPackages.ps1 -PythonVersion ${{ matrix.python }}
+        shell: pwsh
+
       - name: Integration Tests
         run: dotnet test --no-build --blame --verbosity m --logger "console;verbosity=detailed" --collect "XPlat Code Coverage" --results-directory test-results /p:TrxLogFileNameSuffix=${{ matrix.os }}-${{ matrix.python }} -bl:${{ github.workspace }}/tests-${{ matrix.os }}-${{ matrix.python }}.binlog Integration.Tests ${{ matrix.os != 'windows-11-arm' && '--filter "FullyQualifiedName!~WindowsArm64Tests"' || '' }}
         working-directory: src

--- a/src/CSnakes.Stage/Program.cs
+++ b/src/CSnakes.Stage/Program.cs
@@ -37,6 +37,7 @@ static async Task<int> Main(ProgramArguments args)
                        .WithPython()
                        .WithHome(home)
                        .FromRedistributable(version: pythonVersion,
+                                            freeThreaded: args.OptFreeThreaded,
                                             timeout: args.OptTimeout is { } timeout
                                                      ? int.Parse(timeout, NumberStyles.None, CultureInfo.InvariantCulture)
                                                      : BuildConstants.DefaultTimeoutInSeconds);
@@ -118,6 +119,7 @@ partial class ProgramArguments
         Usage:
           {BinName}
               [--verbose]
+              [--free-threaded]
               [--timeout=SECONDS]
               [--venv=PATH]
               [--pip-requirements=FILE | --uv-requirements=FILE]
@@ -129,6 +131,7 @@ partial class ProgramArguments
           -?, -h, --help           Show help and usage information
           --version                Show version information
           --verbose                Enable verbose output
+          --free-threaded          Use free-threaded Python build
           --python=VERSION         Python version to use (e.g., 3.12)
           --timeout=SECONDS        Timeout in seconds for downloading Python
                                      (default is {BuildConstants.DefaultTimeoutInSecondsString} seconds)

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -25,11 +25,25 @@ $PSNativeCommandUseErrorActionPreference = $true
 $testProject = Join-Path $PSScriptRoot 'Integration.Tests.csproj'
 $stageProject = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
 
-# Build the test project to ensure output directories and requirements.txt exist
+# Determine the staging tool's target framework and build it (once)
+$stageTfm = ((dotnet msbuild $stageProject -getProperty:TargetFrameworks -nologo) -split ';')[0]
+if (-not $stageTfm) {
+    throw "No target frameworks found in $stageProject."
+}
+
 if (-not $NoBuild) {
     Write-Verbose "Building $testProject..."
     dotnet build $testProject
+    Write-Verbose "Building $stageProject ($stageTfm)..."
+    dotnet build $stageProject --framework $stageTfm
 }
+
+# Resolve the staging tool executable path
+$stageOutputPath = dotnet msbuild $stageProject -property:TargetFramework=$stageTfm -getProperty:OutputPath -nologo
+if (-not $stageOutputPath) {
+    throw "Failed to resolve OutputPath for staging tool ($stageTfm)."
+}
+$stageExe = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' $stageOutputPath 'CSnakes.Stage'
 
 # Query target frameworks from the test project
 $tfms = (dotnet msbuild $testProject -getProperty:TargetFrameworks -nologo) -split ';' | Where-Object { $_ -ne '' }
@@ -55,7 +69,7 @@ foreach ($tfm in $tfms) {
 
     Push-Location $pythonHome
     try {
-        dotnet run --project $stageProject --framework net8.0 -- `
+        & $stageExe `
             --python=$PythonVersion `
             --venv=$venvPath `
             --pip-requirements=requirements.txt

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -14,7 +14,9 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [string]$PythonVersion
+    [string]$PythonVersion,
+
+    [switch]$NoBuild
 )
 
 $ErrorActionPreference = 'Stop'
@@ -24,8 +26,10 @@ $testProject = Join-Path $PSScriptRoot 'Integration.Tests.csproj'
 $stageProject = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
 
 # Build the test project to ensure output directories and requirements.txt exist
-Write-Host "Building $testProject..."
-dotnet build $testProject
+if (-not $NoBuild) {
+    Write-Host "Building $testProject..."
+    dotnet build $testProject
+}
 
 # Query target frameworks from the test project
 $tfms = (dotnet msbuild $testProject -getProperty:TargetFrameworks -nologo) -split ';'

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+    Pre-installs Python packages for integration tests.
+
+.DESCRIPTION
+    Discovers target frameworks and output paths from the Integration.Tests project,
+    then runs CSnakes.Stage to create virtual environments and install pip packages
+    for each target framework.
+
+.PARAMETER PythonVersion
+    The Python version to install (e.g., "3.12", "3.9").
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$PythonVersion
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+$testProject = Join-Path $PSScriptRoot 'Integration.Tests.csproj'
+$stageProject = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
+
+# Build the test project to ensure output directories and requirements.txt exist
+Write-Host "Building $testProject..."
+dotnet build $testProject
+
+# Query target frameworks from the test project
+$tfms = (dotnet msbuild $testProject -getProperty:TargetFrameworks -nologo) -split ';'
+
+Write-Host "Target frameworks: $($tfms -join ', ')"
+
+foreach ($tfm in $tfms) {
+    # Query the output path for this TFM
+    $outputPath = dotnet msbuild $testProject -property:TargetFramework=$tfm -getProperty:OutputPath -nologo
+    $pythonHome = Join-Path $PSScriptRoot $outputPath 'python'
+    $venvName = ".venv-$PythonVersion"
+    $venvPath = Join-Path $pythonHome $venvName
+
+    Write-Host ''
+    Write-Host "[$tfm] Python home: $pythonHome"
+    Write-Host "[$tfm] Venv path: $venvPath"
+
+    Push-Location $pythonHome
+    try {
+        dotnet run --project $stageProject --framework net8.0 -- `
+            --python=$PythonVersion `
+            --venv=$venvPath `
+            --pip-requirements=requirements.txt
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Write-Host ''
+Write-Host 'Python package pre-installation complete.'

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -32,13 +32,20 @@ if (-not $NoBuild) {
 }
 
 # Query target frameworks from the test project
-$tfms = (dotnet msbuild $testProject -getProperty:TargetFrameworks -nologo) -split ';'
+$tfms = (dotnet msbuild $testProject -getProperty:TargetFrameworks -nologo) -split ';' | Where-Object { $_ -ne '' }
+
+if (-not $tfms) {
+    throw "No target frameworks found in $testProject."
+}
 
 Write-Host "Target frameworks: $($tfms -join ', ')"
 
 foreach ($tfm in $tfms) {
     # Query the output path for this TFM
     $outputPath = dotnet msbuild $testProject -property:TargetFramework=$tfm -getProperty:OutputPath -nologo
+    if (-not $outputPath) {
+        throw "Failed to resolve OutputPath for target framework '$tfm'."
+    }
     $pythonHome = Join-Path $PSScriptRoot $outputPath 'python'
     $venvName = ".venv-$PythonVersion"
     $venvPath = Join-Path $pythonHome $venvName

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -38,12 +38,11 @@ if (-not $NoBuild) {
     dotnet build $stageProject --framework $stageTfm
 }
 
-# Resolve the staging tool executable path
-$stageOutputPath = dotnet msbuild $stageProject -property:TargetFramework=$stageTfm -getProperty:OutputPath -nologo
-if (-not $stageOutputPath) {
-    throw "Failed to resolve OutputPath for staging tool ($stageTfm)."
+# Resolve the staging tool assembly path
+$stageAssembly = dotnet msbuild $stageProject -property:TargetFramework=$stageTfm -getProperty:TargetPath -nologo
+if (-not $stageAssembly) {
+    throw "Failed to resolve TargetPath for staging tool ($stageTfm)."
 }
-$stageExe = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' $stageOutputPath 'CSnakes.Stage'
 
 # Query target frameworks from the test project
 $tfms = (dotnet msbuild $testProject -getProperty:TargetFrameworks -nologo) -split ';' | Where-Object { $_ -ne '' }
@@ -69,7 +68,7 @@ foreach ($tfm in $tfms) {
 
     Push-Location $pythonHome
     try {
-        & $stageExe `
+        dotnet $stageAssembly `
             --python=$PythonVersion `
             --venv=$venvPath `
             --pip-requirements=requirements.txt

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -21,11 +21,16 @@ param(
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 
+$savedMSBuildTerminalLogger = $env:MSBUILDTERMINALLOGGER
+$env:MSBUILDTERMINALLOGGER = 'off'
+
+try {
+
 $testProject = Join-Path $PSScriptRoot 'Integration.Tests.csproj'
 $stageProject = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
 
 # Determine the staging tool's target framework and build it (once)
-$stageTfm = ((dotnet build $stageProject -getProperty:TargetFrameworks -tl:false) -split ';')[0]
+$stageTfm = ((dotnet build $stageProject -getProperty:TargetFrameworks) -split ';')[0]
 if (-not $stageTfm) {
     throw "No target frameworks found in $stageProject."
 }
@@ -38,13 +43,13 @@ if (-not $NoBuild) {
 }
 
 # Resolve the staging tool assembly path
-$stageAssembly = dotnet build $stageProject -property:TargetFramework=$stageTfm -getProperty:TargetPath -tl:false
+$stageAssembly = dotnet build $stageProject -property:TargetFramework=$stageTfm -getProperty:TargetPath
 if (-not $stageAssembly) {
     throw "Failed to resolve TargetPath for staging tool ($stageTfm)."
 }
 
 # Query target frameworks from the test project
-$tfms = (dotnet build $testProject -getProperty:TargetFrameworks -tl:false) -split ';' | Where-Object { $_ -ne '' }
+$tfms = (dotnet build $testProject -getProperty:TargetFrameworks) -split ';' | Where-Object { $_ -ne '' }
 
 if (-not $tfms) {
     throw "No target frameworks found in $testProject."
@@ -54,7 +59,7 @@ Write-Verbose "Target frameworks: $($tfms -join ', ')"
 
 foreach ($tfm in $tfms) {
     # Query the output path for this TFM
-    $outputPath = dotnet build $testProject -property:TargetFramework=$tfm -getProperty:OutputPath -tl:false
+    $outputPath = dotnet build $testProject -property:TargetFramework=$tfm -getProperty:OutputPath
     if (-not $outputPath) {
         throw "Failed to resolve OutputPath for target framework '$tfm'."
     }
@@ -75,5 +80,15 @@ foreach ($tfm in $tfms) {
     }
     finally {
         Pop-Location
+    }
+}
+
+}
+finally {
+    if ($null -eq $savedMSBuildTerminalLogger) {
+        Remove-Item env:MSBUILDTERMINALLOGGER -ErrorAction Ignore
+    }
+    else {
+        $env:MSBUILDTERMINALLOGGER = $savedMSBuildTerminalLogger
     }
 }

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -69,6 +69,7 @@ foreach ($tfm in $tfms) {
     Push-Location $pythonHome
     try {
         dotnet $stageAssembly `
+            $(if ($VerbosePreference -ne 'SilentlyContinue') { '--verbose' }) `
             --python=$PythonVersion `
             --venv=$venvPath `
             --pip-requirements=requirements.txt

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -15,7 +15,6 @@
 param(
     [Parameter(Mandatory)]
     [string]$PythonVersion,
-
     [switch]$NoBuild
 )
 
@@ -26,7 +25,7 @@ $testProject = Join-Path $PSScriptRoot 'Integration.Tests.csproj'
 $stageProject = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
 
 # Determine the staging tool's target framework and build it (once)
-$stageTfm = ((dotnet msbuild $stageProject -getProperty:TargetFrameworks -nologo) -split ';')[0]
+$stageTfm = ((dotnet build $stageProject -getProperty:TargetFrameworks -tl:false) -split ';')[0]
 if (-not $stageTfm) {
     throw "No target frameworks found in $stageProject."
 }
@@ -39,13 +38,13 @@ if (-not $NoBuild) {
 }
 
 # Resolve the staging tool assembly path
-$stageAssembly = dotnet msbuild $stageProject -property:TargetFramework=$stageTfm -getProperty:TargetPath -nologo
+$stageAssembly = dotnet build $stageProject -property:TargetFramework=$stageTfm -getProperty:TargetPath -tl:false
 if (-not $stageAssembly) {
     throw "Failed to resolve TargetPath for staging tool ($stageTfm)."
 }
 
 # Query target frameworks from the test project
-$tfms = (dotnet msbuild $testProject -getProperty:TargetFrameworks -nologo) -split ';' | Where-Object { $_ -ne '' }
+$tfms = (dotnet build $testProject -getProperty:TargetFrameworks -tl:false) -split ';' | Where-Object { $_ -ne '' }
 
 if (-not $tfms) {
     throw "No target frameworks found in $testProject."
@@ -55,7 +54,7 @@ Write-Verbose "Target frameworks: $($tfms -join ', ')"
 
 foreach ($tfm in $tfms) {
     # Query the output path for this TFM
-    $outputPath = dotnet msbuild $testProject -property:TargetFramework=$tfm -getProperty:OutputPath -nologo
+    $outputPath = dotnet build $testProject -property:TargetFramework=$tfm -getProperty:OutputPath -tl:false
     if (-not $outputPath) {
         throw "Failed to resolve OutputPath for target framework '$tfm'."
     }

--- a/src/Integration.Tests/Install-PythonPackages.ps1
+++ b/src/Integration.Tests/Install-PythonPackages.ps1
@@ -27,7 +27,7 @@ $stageProject = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' 'CSnakes.Stage.cspr
 
 # Build the test project to ensure output directories and requirements.txt exist
 if (-not $NoBuild) {
-    Write-Host "Building $testProject..."
+    Write-Verbose "Building $testProject..."
     dotnet build $testProject
 }
 
@@ -38,7 +38,7 @@ if (-not $tfms) {
     throw "No target frameworks found in $testProject."
 }
 
-Write-Host "Target frameworks: $($tfms -join ', ')"
+Write-Verbose "Target frameworks: $($tfms -join ', ')"
 
 foreach ($tfm in $tfms) {
     # Query the output path for this TFM
@@ -50,9 +50,8 @@ foreach ($tfm in $tfms) {
     $venvName = ".venv-$PythonVersion"
     $venvPath = Join-Path $pythonHome $venvName
 
-    Write-Host ''
-    Write-Host "[$tfm] Python home: $pythonHome"
-    Write-Host "[$tfm] Venv path: $venvPath"
+    Write-Verbose "[$tfm] Python home: $pythonHome"
+    Write-Verbose "[$tfm] Venv path: $venvPath"
 
     Push-Location $pythonHome
     try {
@@ -65,6 +64,3 @@ foreach ($tfm in $tfms) {
         Pop-Location
     }
 }
-
-Write-Host ''
-Write-Host 'Python package pre-installation complete.'

--- a/src/Integration.Tests/python/install.ps1
+++ b/src/Integration.Tests/python/install.ps1
@@ -14,7 +14,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [string]$PythonVersion,
+    [version]$PythonVersion,
     [switch]$FreeThreaded,
     [switch]$NoBuild
 )
@@ -64,7 +64,7 @@ try {
             throw "Failed to resolve OutputPath for target framework '$tfm'."
         }
         $pythonHome = Join-Path $PSScriptRoot '..' $outputPath 'python'
-        $venvName = ".venv-$PythonVersion"
+        $venvName = ".venv-$($PythonVersion.Major).$($PythonVersion.Minor)$(if ($FreeThreaded) { 't' })"
         $venvPath = Join-Path $pythonHome $venvName
 
         Write-Verbose "[$tfm] Python home: $pythonHome"

--- a/src/Integration.Tests/python/install.ps1
+++ b/src/Integration.Tests/python/install.ps1
@@ -26,8 +26,8 @@ $env:MSBUILDTERMINALLOGGER = 'off'
 
 try {
 
-$testProject = Join-Path $PSScriptRoot 'Integration.Tests.csproj'
-$stageProject = Join-Path $PSScriptRoot '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
+$testProject = Join-Path $PSScriptRoot '..' 'Integration.Tests.csproj'
+$stageProject = Join-Path $PSScriptRoot '..' '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
 
 # Determine the staging tool's target framework and build it (once)
 $stageTfm = ((dotnet build $stageProject -getProperty:TargetFrameworks) -split ';')[0]
@@ -63,7 +63,7 @@ foreach ($tfm in $tfms) {
     if (-not $outputPath) {
         throw "Failed to resolve OutputPath for target framework '$tfm'."
     }
-    $pythonHome = Join-Path $PSScriptRoot $outputPath 'python'
+    $pythonHome = Join-Path $PSScriptRoot '..' $outputPath 'python'
     $venvName = ".venv-$PythonVersion"
     $venvPath = Join-Path $pythonHome $venvName
 

--- a/src/Integration.Tests/python/install.ps1
+++ b/src/Integration.Tests/python/install.ps1
@@ -15,6 +15,7 @@
 param(
     [Parameter(Mandatory)]
     [string]$PythonVersion,
+    [switch]$FreeThreaded,
     [switch]$NoBuild
 )
 
@@ -73,6 +74,7 @@ try {
         try {
             dotnet $stageAssembly `
                 $(if ($VerbosePreference -ne 'SilentlyContinue') { '--verbose' }) `
+                $(if ($FreeThreaded) { '--free-threaded' }) `
                 --python=$PythonVersion `
                 --venv=$venvPath `
                 --pip-requirements=requirements.txt

--- a/src/Integration.Tests/python/install.ps1
+++ b/src/Integration.Tests/python/install.ps1
@@ -25,64 +25,62 @@ $savedMSBuildTerminalLogger = $env:MSBUILDTERMINALLOGGER
 $env:MSBUILDTERMINALLOGGER = 'off'
 
 try {
+    $testProject = Join-Path $PSScriptRoot '..' 'Integration.Tests.csproj'
+    $stageProject = Join-Path $PSScriptRoot '..' '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
 
-$testProject = Join-Path $PSScriptRoot '..' 'Integration.Tests.csproj'
-$stageProject = Join-Path $PSScriptRoot '..' '..' 'CSnakes.Stage' 'CSnakes.Stage.csproj'
-
-# Determine the staging tool's target framework and build it (once)
-$stageTfm = ((dotnet build $stageProject -getProperty:TargetFrameworks) -split ';')[0]
-if (-not $stageTfm) {
-    throw "No target frameworks found in $stageProject."
-}
-
-if (-not $NoBuild) {
-    Write-Verbose "Building $testProject..."
-    dotnet build $testProject
-    Write-Verbose "Building $stageProject ($stageTfm)..."
-    dotnet build $stageProject --framework $stageTfm
-}
-
-# Resolve the staging tool assembly path
-$stageAssembly = dotnet build $stageProject -property:TargetFramework=$stageTfm -getProperty:TargetPath
-if (-not $stageAssembly) {
-    throw "Failed to resolve TargetPath for staging tool ($stageTfm)."
-}
-
-# Query target frameworks from the test project
-$tfms = (dotnet build $testProject -getProperty:TargetFrameworks) -split ';' | Where-Object { $_ -ne '' }
-
-if (-not $tfms) {
-    throw "No target frameworks found in $testProject."
-}
-
-Write-Verbose "Target frameworks: $($tfms -join ', ')"
-
-foreach ($tfm in $tfms) {
-    # Query the output path for this TFM
-    $outputPath = dotnet build $testProject -property:TargetFramework=$tfm -getProperty:OutputPath
-    if (-not $outputPath) {
-        throw "Failed to resolve OutputPath for target framework '$tfm'."
+    # Determine the staging tool's target framework and build it (once)
+    $stageTfm = ((dotnet build $stageProject -getProperty:TargetFrameworks) -split ';')[0]
+    if (-not $stageTfm) {
+        throw "No target frameworks found in $stageProject."
     }
-    $pythonHome = Join-Path $PSScriptRoot '..' $outputPath 'python'
-    $venvName = ".venv-$PythonVersion"
-    $venvPath = Join-Path $pythonHome $venvName
 
-    Write-Verbose "[$tfm] Python home: $pythonHome"
-    Write-Verbose "[$tfm] Venv path: $venvPath"
-
-    Push-Location $pythonHome
-    try {
-        dotnet $stageAssembly `
-            $(if ($VerbosePreference -ne 'SilentlyContinue') { '--verbose' }) `
-            --python=$PythonVersion `
-            --venv=$venvPath `
-            --pip-requirements=requirements.txt
+    if (-not $NoBuild) {
+        Write-Verbose "Building $testProject..."
+        dotnet build $testProject
+        Write-Verbose "Building $stageProject ($stageTfm)..."
+        dotnet build $stageProject --framework $stageTfm
     }
-    finally {
-        Pop-Location
-    }
-}
 
+    # Resolve the staging tool assembly path
+    $stageAssembly = dotnet build $stageProject -property:TargetFramework=$stageTfm -getProperty:TargetPath
+    if (-not $stageAssembly) {
+        throw "Failed to resolve TargetPath for staging tool ($stageTfm)."
+    }
+
+    # Query target frameworks from the test project
+    $tfms = (dotnet build $testProject -getProperty:TargetFrameworks) -split ';' | Where-Object { $_ -ne '' }
+
+    if (-not $tfms) {
+        throw "No target frameworks found in $testProject."
+    }
+
+    Write-Verbose "Target frameworks: $($tfms -join ', ')"
+
+    foreach ($tfm in $tfms) {
+        # Query the output path for this TFM
+        $outputPath = dotnet build $testProject -property:TargetFramework=$tfm -getProperty:OutputPath
+        if (-not $outputPath) {
+            throw "Failed to resolve OutputPath for target framework '$tfm'."
+        }
+        $pythonHome = Join-Path $PSScriptRoot '..' $outputPath 'python'
+        $venvName = ".venv-$PythonVersion"
+        $venvPath = Join-Path $pythonHome $venvName
+
+        Write-Verbose "[$tfm] Python home: $pythonHome"
+        Write-Verbose "[$tfm] Venv path: $venvPath"
+
+        Push-Location $pythonHome
+        try {
+            dotnet $stageAssembly `
+                $(if ($VerbosePreference -ne 'SilentlyContinue') { '--verbose' }) `
+                --python=$PythonVersion `
+                --venv=$venvPath `
+                --pip-requirements=requirements.txt
+        }
+        finally {
+            Pop-Location
+        }
+    }
 }
 finally {
     if ($null -eq $savedMSBuildTerminalLogger) {


### PR DESCRIPTION
In recent weeks, integration tests have gotten very flaky, failing due to transient network errors during pip package installation. They appear as test failures since installation happens implicitly during the test run. And because it happens very early, during the fixture setup, all integrate tests appear to fail as a result. See [job #79507552357in run #26948325597](https://github.com/tonybaloney/CSnakes/actions/runs/26948325597/job/79507552357) for an example.

The exception thrown is `System.InvalidOperationException`, with the message “Failed to install packages”. For example:

      Failed Integration.Tests.BufferTests+TensorBufferUseAfterDisposalTests.TestAsSpan [1 ms]
      Error Message:
       Collection fixture type 'Integration.Tests.PythonEnvironmentFixture' threw in its constructor
    ---- System.InvalidOperationException : Failed to install packages
      Stack Trace:
      
    ----- Inner Stack Trace -----
       at CSnakes.Runtime.ProcessUtils.ExecuteProcess(String fileName, IEnumerable`1 arguments, String workingDirectory, String path, ILogger logger, IReadOnlyDictionary`2 extraEnv) in /_/src/CSnakes.Runtime/ProcessUtils.cs:line 129
       at CSnakes.Runtime.PackageManagement.PipInstaller.RunPipInstall(String home, IEnvironmentManagement environmentManager, String[] requirements, ILogger logger) in /_/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs:line 59
       at CSnakes.Runtime.PackageManagement.PipInstaller.InstallPackagesFromRequirements(String home, String fileName) in /_/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs:line 19
       at CSnakes.Runtime.PackageManagement.PipInstaller.InstallPackagesFromRequirements(String home) in /_/src/CSnakes.Runtime/PackageManagement/PipInstaller.cs:line 11
       at CSnakes.Runtime.PythonEnvironment..ctor(IEnumerable`1 locators, IEnumerable`1 packageInstallers, PythonEnvironmentOptions options, ILogger`1 logger, IEnvironmentManagement environmentManager) in /_/src/CSnakes.Runtime/PythonEnvironment.cs:line 81
       at CSnakes.Runtime.PythonEnvironment.GetPythonEnvironment(IEnumerable`1 locators, IEnumerable`1 packageInstallers, PythonEnvironmentOptions options, ILogger`1 logger, IEnvironmentManagement environmentManager) in /_/src/CSnakes.Runtime/PythonEnvironment.cs:line 33
       at CSnakes.Runtime.ServiceCollectionExtensions.<>c.<WithPython>b__0_0(IServiceProvider sp) in /_/src/CSnakes.Runtime/ServiceCollectionExtensions.cs:line 35
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite callSite, RuntimeResolverContext context)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
       at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
       at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
       at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
       at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
       at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType)
       at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
       at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
       at CSnakes.Runtime.Tests.PythonEnvironmentFixtureBase..ctor(String home, Action`1 configure) in /_/src/CSnakes.Runtime.Tests/PythonEnvironmentFixtures.cs:line 35
       at CSnakes.Runtime.Tests.RedistributablePythonEnvironmentFixture..ctor(String home, Action`2 configure) in /_/src/CSnakes.Runtime.Tests/PythonEnvironmentFixtures.cs:line 85
       at Integration.Tests.PythonEnvironmentFixture..ctor() in /_/src/Integration.Tests/IntegrationTestBase.cs:line 20
       at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Constructor(Object obj, IntPtr* args)
       at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

This PR introduces a new PowerShell script to pre-install Python packages for each test target framework, and updates the CI workflow to use this script. This way, all the necessary Python environments & dependencies are prepared before running integration tests so infrastructure problem don't surface as test failures. 

The script is run as a separate CI step. It uses [MSBuild property evaluation](https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-properties) (`dotnet build -getProperty:`) to discover target frameworks and output paths, then invokes `CSnakes.Stage` to create virtual environments and install packages for each TFM. If installation fails, the CI job fails at this step and tests never run—making the root cause obvious. It also runs the staging tool with verbose output so there'll be hopefully more information from pip than just the exception message “Failed to install packages”.

The test fixture remains idempotent (packages already installed = fast no-op), so local development is unaffected.

The script can also be run locally for testing, e.g.:

```pwsh
# From anywhere (builds automatically):
./src/Integration.Tests/python/install.ps1 -PythonVersion 3.12

# After a prior build (skips redundant build):
./src/Integration.Tests/python/install.ps1 -PythonVersion 3.12 -NoBuild
```

The staging tool was also updated to allow for free-threaded Python installations via the new flag `--free-threaded`.