### PR TITLE
Update GH actions in CI that depend on Node.js 20

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
         id: installpython
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -135,7 +135,7 @@ jobs:
           conda info
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -235,7 +235,7 @@ jobs:
           python-version: "${{ matrix.python }}"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -67,7 +67,7 @@ jobs:
             9.0.x
             10.0.x
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         name: Cache NuGet packages
         with:
           path: ~/.nuget/packages
@@ -142,7 +142,7 @@ jobs:
             9.0.x
             10.0.x
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         name: Cache NuGet packages
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -199,7 +199,7 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python }}
           UV_NO_CACHE: 1
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: logs-${{ matrix.os }}-${{ matrix.python }}
@@ -207,7 +207,7 @@ jobs:
             ${{ github.workspace }}/*.binlog
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.python }}

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -32,12 +32,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Setup Python
         id: installpython
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python }}"
 
@@ -56,7 +56,7 @@ jobs:
       fail-fast: true
     runs-on: "${{ matrix.os }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Setup .NET
@@ -113,7 +113,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - uses: conda-incubator/setup-miniconda@v3.1.0
@@ -225,12 +225,12 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Setup Python
         id: installpython
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python }}"
 

--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -16,7 +16,7 @@ jobs:
   publish-github-packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
 

--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: 'true'
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/dotnet-publish-ci.yml
+++ b/.github/workflows/dotnet-publish-ci.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet packages as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nuget-packages
           path: ./nuget

--- a/.github/workflows/dotnet-publish-gh-packages.yml
+++ b/.github/workflows/dotnet-publish-gh-packages.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: nuget-packages
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Setup .NET

--- a/.github/workflows/dotnet-publish-main.yml
+++ b/.github/workflows/dotnet-publish-main.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet packages as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nuget-packages
           path: ./nuget

--- a/.github/workflows/dotnet-publish-release.yml
+++ b/.github/workflows/dotnet-publish-release.yml
@@ -44,7 +44,7 @@ jobs:
         working-directory: src
 
       - name: Publish NuGet packages as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nuget-packages
           path: ./nuget

--- a/.github/workflows/dotnet-publish-release.yml
+++ b/.github/workflows/dotnet-publish-release.yml
@@ -19,7 +19,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
 

--- a/.github/workflows/dotnet-publish-release.yml
+++ b/.github/workflows/dotnet-publish-release.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: 'true'
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,8 +8,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/sdk-compat.yml
+++ b/.github/workflows/sdk-compat.yml
@@ -34,14 +34,14 @@ jobs:
         run: dotnet pack --tl:off -c Release -p:VersionSuffix='alpha.${{ github.run_number }}' -bl:pack.binlog src
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: pack.binlog
           path: "*.binlog"
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: packages
           path: nuget
@@ -81,7 +81,7 @@ jobs:
         working-directory: .github/workflows/sdk-compat
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: build-${{ matrix.dotnet-version }}.binlog

--- a/.github/workflows/sdk-compat.yml
+++ b/.github/workflows/sdk-compat.yml
@@ -21,7 +21,7 @@ jobs:
   pack:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
 
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/sdk-compat.yml
+++ b/.github/workflows/sdk-compat.yml
@@ -67,7 +67,7 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Download NuGet packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: packages
           path: .github/workflows/sdk-compat/packages

--- a/.github/workflows/sdk-compat.yml
+++ b/.github/workflows/sdk-compat.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: 'true'
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         id: setup-dotnet
         with:
           dotnet-version: ${{ matrix.dotnet-version }}

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -6,6 +6,6 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v5"
       - name: "TODO to Issue"
         uses: "alstr/todo-to-issue-action@v4"


### PR DESCRIPTION
This PR addresses the following warning in CI runs:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.
