### PR TITLE
Add support for specifying tuple element names

### DIFF
--- a/docs/user-guide/type-system.md
+++ b/docs/user-guide/type-system.md
@@ -158,6 +158,54 @@ var (x, y, z) = module.GetCoordinates();
 Console.WriteLine($"Position: ({x}, {y}, {z})");
 ```
 
+#### Named tuple elements
+
+By default, tuple elements are positional and unnamed. You can give a C# tuple
+element a name by wrapping its Python type in `typing.Annotated` and supplying a
+metadata string that starts with `@` followed by the desired name:
+
+```python
+from typing import Annotated
+
+def get_location() -> tuple[Annotated[float, '@Latitude'],
+                            Annotated[float, '@Longitude']]:
+    return (12.34, 56.78)
+```
+
+The generated C# method returns a tuple with named elements:
+
+```csharp
+public (double Latitude, double Longitude) GetLocation();
+```
+
+so callers can access the elements by name:
+
+```csharp
+var location = module.GetLocation();
+Console.WriteLine($"{location.Latitude}, {location.Longitude}");
+```
+
+The following rules apply to the annotation:
+
+- The metadata string must start with `@` and the remainder must be a valid C#
+  identifier (for example, `'@Latitude'`).
+- If an element is annotated with more than one metadata string, the first valid
+  `@`-prefixed name is used.
+- An annotation that is missing, empty, does not start with `@`, or does not
+  contain a valid C# identifier is ignored, and the element remains positional.
+  This means named and unnamed elements can be freely mixed within the same
+  tuple:
+
+  ```python
+  def get_partial(
+  ) -> tuple[Annotated[int, '@Id'], int, Annotated[str, '@Name']]:
+      return (1, 2, "Alice")
+  ```
+
+  ```csharp
+  public (long Id, long, string Name) GetPartial();
+  ```
+
 ## Default Values
 
 Python default values for types which support compile-time constants in C# (string, int, float, bool) are preserved in the generated C# methods:

--- a/src/CSnakes.Runtime/PythonLogger.cs
+++ b/src/CSnakes.Runtime/PythonLogger.cs
@@ -71,8 +71,24 @@ file sealed class Bridge(PyObject closeCallable, Task listenerTask) : IAsyncDisp
         {
             using (GIL.Acquire())
             {
-                (var generator, closeCallable) = module.Monitor(loggerName);
-                listenerTask = StartRecordListener(generator, logger);
+                var result = module.Monitor(loggerName);
+                closeCallable = result.Close;
+                listenerTask = StartRecordListener(result.Generator,
+                                                   static r =>
+                                                       (checked((int)r.DropCount),
+                                                        // https://docs.python.org/3/library/logging.html#levels
+                                                        (r.Level / 10) switch
+                                                        {
+                                                            1 => LogLevel.Debug,
+                                                            2 => LogLevel.Information,
+                                                            3 => LogLevel.Warning,
+                                                            4 => LogLevel.Error,
+                                                            >= 5 => LogLevel.Critical,
+                                                            _ => LogLevel.None,
+                                                        },
+                                                        r.Message,
+                                                        r.ExceptionInfo),
+                                                   logger);
             }
         }
         catch
@@ -88,15 +104,19 @@ file sealed class Bridge(PyObject closeCallable, Task listenerTask) : IAsyncDisp
         return new(closeCallable, listenerTask);
     }
 
-    private static Task StartRecordListener(IEnumerator<(long, long, string, ExceptionInfo?)> record, ILogger logger)
+    private static Task
+        StartRecordListener<T>(
+            IEnumerator<T> enumerator,
+            Func<T, (int DropCount, LogLevel Level, string Message, ExceptionInfo? ExceptionInfo)> selector,
+            ILogger logger)
     {
         return Task.Run(() =>
         {
-            while (record.MoveNext()) // TODO Restart log records reading loop on failure
+            while (enumerator.MoveNext()) // TODO Restart log records reading loop on failure
             {
-                var (dropCount, level, message, exceptionInfo) = record.Current;
+                var record = selector(enumerator.Current);
 
-                if (dropCount > 0)
+                if (record is { DropCount: > 0 and var dropCount })
                 {
                     // One could log a warning here:
                     //
@@ -111,7 +131,7 @@ file sealed class Bridge(PyObject closeCallable, Task listenerTask) : IAsyncDisp
 
                 try
                 {
-                    LogRecord(logger, level, message, exceptionInfo);
+                    LogRecord(logger, record.Level, record.Message, record.ExceptionInfo);
                 }
                 catch (Exception ex)
                 {
@@ -120,7 +140,7 @@ file sealed class Bridge(PyObject closeCallable, Task listenerTask) : IAsyncDisp
             }
         });
 
-        static void LogRecord(ILogger logger, long level, string message, ExceptionInfo? exceptionInfo)
+        static void LogRecord(ILogger logger, LogLevel level, string message, ExceptionInfo? exceptionInfo)
         {
             Exception? exception = null;
             if (exceptionInfo is { } info)
@@ -132,21 +152,10 @@ file sealed class Bridge(PyObject closeCallable, Task listenerTask) : IAsyncDisp
                 exception = new PythonInvocationException(name?.ToString() ?? "Exception", pyException, traceback, message);
             }
 
-            // https://docs.python.org/3/library/logging.html#levels
-            var mappedLevel = (level / 10) switch
-            {
-                1 => LogLevel.Debug,
-                2 => LogLevel.Information,
-                3 => LogLevel.Warning,
-                4 => LogLevel.Error,
-                >= 5 => LogLevel.Critical,
-                _ => LogLevel.None,
-            };
-
-            if (mappedLevel == LogLevel.None || !logger.IsEnabled(mappedLevel))
+            if (level == LogLevel.None || !logger.IsEnabled(level))
                 return;
 
-            logger.Log(mappedLevel, exception, message);
+            logger.Log(level, exception, message);
         }
     }
 

--- a/src/CSnakes.Runtime/csnakes_logging.py
+++ b/src/CSnakes.Runtime/csnakes_logging.py
@@ -4,7 +4,7 @@ import threading
 
 from collections.abc import Callable, Generator, Iterator
 from logging import LogRecord
-from typing import Any, Union
+from typing import Annotated, Any, Union
 
 
 class _Handler(logging.Handler):
@@ -48,7 +48,34 @@ class _Handler(logging.Handler):
         logging.Handler.close(self)
 
 
-def monitor(name: Union[str, None] = None) -> tuple[Generator[tuple[int, int, str, Union[tuple[Any, Any, Any], None]], None, None], Callable[[], None]]:
+def monitor(
+    name: Union[str, None] = None
+) -> tuple[
+    Annotated[
+        Generator[
+            tuple[
+                Annotated[int, "@DropCount"],
+                Annotated[int, "@Level"],
+                Annotated[str, "@Message"],
+                Annotated[
+                    Union[
+                        tuple[
+                            Annotated[Any, "@ExceptionType"],
+                            Annotated[Any, "@Exception"],
+                            Annotated[Any, "@Traceback"]
+                        ],
+                        None
+                    ],
+                    "@ExceptionInfo"
+                ]
+            ],
+            None,
+            None
+        ],
+        "@Generator"
+    ],
+    Annotated[Callable[[], None], "@Close"]
+]:
     handler = _Handler()
     logger = logging.getLogger(name)
     logger.addHandler(handler)

--- a/src/CSnakes.Runtime/csnakes_logging.py
+++ b/src/CSnakes.Runtime/csnakes_logging.py
@@ -49,7 +49,7 @@ class _Handler(logging.Handler):
 
 
 def monitor(
-    name: Union[str, None] = None
+    name: Union[str, None] = None,
 ) -> tuple[
     Annotated[
         Generator[
@@ -62,19 +62,19 @@ def monitor(
                         tuple[
                             Annotated[Any, "@ExceptionType"],
                             Annotated[Any, "@Exception"],
-                            Annotated[Any, "@Traceback"]
+                            Annotated[Any, "@Traceback"],
                         ],
-                        None
+                        None,
                     ],
-                    "@ExceptionInfo"
-                ]
+                    "@ExceptionInfo",
+                ],
             ],
             None,
-            None
+            None,
         ],
-        "@Generator"
+        "@Generator",
     ],
-    Annotated[Callable[[], None], "@Close"]
+    Annotated[Callable[[], None], "@Close"],
 ]:
     handler = _Handler()
     logger = logging.getLogger(name)

--- a/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
@@ -1,4 +1,5 @@
 using CSnakes.Parser.Types;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Immutable;
@@ -11,6 +12,20 @@ public static class TypeReflection
     {
         ToPython,
         FromPython
+    }
+
+    public static SyntaxToken? FindAnnotatedIdentifier(this PythonTypeSpec typeSpec)
+    {
+        foreach (var md in typeSpec.Metadata)
+        {
+            if (md is PythonConstant.String { Value: { Length: > 1 } and ['@', .. var name] }
+                && SyntaxFacts.IsValidIdentifier(name))
+            {
+                return SyntaxFactory.Identifier(name);
+            }
+        }
+
+        return null;
     }
 
     public static IEnumerable<TypeSyntax> AsPredefinedType(PythonTypeSpec pythonType, ConversionDirection direction, RefSafetyContext refSafetyContext = RefSafetyContext.Safe) =>
@@ -66,12 +81,16 @@ public static class TypeReflection
             yield break;
         }
 
-        var tupleTypeSpecs = tupleTypes.Select((x, i) => new { Index = i, Value = x })
-            .GroupBy(x => x.Index / 7)
-            .Select(x => x.Select(v => v.Value))
+        var tupleTypeSpecs =
+            from t in tupleTypes.Select(static (t, i) => (Index: i, Value: t))
+            group t.Value by t.Index / 7 into ts
+            from t in ts
             /* TODO: Iterate potential Tuple types */
-            .Select(typeSpecs => typeSpecs.Select(t => AsPredefinedType(t, direction).First()))
-            .SelectMany(item => item.Select(SyntaxFactory.TupleElement));
+            select (AsPredefinedType(t, direction).First(), t.FindAnnotatedIdentifier()) switch
+            {
+                (var typeSyntax, { } name) => SyntaxFactory.TupleElement(typeSyntax, name),
+                var (typeSyntax, _) => SyntaxFactory.TupleElement(typeSyntax),
+            };
 
         yield return SyntaxFactory.TupleType(
             SyntaxFactory.Token(SyntaxKind.OpenParenToken),

--- a/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
+++ b/src/CSnakes.SourceGeneration/Reflection/TypeReflection.cs
@@ -14,7 +14,7 @@ public static class TypeReflection
         FromPython
     }
 
-    public static SyntaxToken? FindAnnotatedIdentifier(this PythonTypeSpec typeSpec)
+    private static SyntaxToken? FindAnnotatedIdentifier(this PythonTypeSpec typeSpec)
     {
         foreach (var md in typeSpec.Metadata)
         {

--- a/src/CSnakes.Tests/GeneratedSignatureTests.cs
+++ b/src/CSnakes.Tests/GeneratedSignatureTests.cs
@@ -64,6 +64,22 @@ public class GeneratedSignatureTests
     [InlineData("def hello(a: str, b: int = 4, *, kw: str) -> None:\n ...\n", "void Hello(string a, string kw, long b = 4)")]
     [InlineData("def hello() -> str | int: \n  ...\n", "PyObject Hello()")]
     [InlineData("def escape(s: str, quote: bool = True) -> str: ...\n", "string Escape(string s, bool quote = true)")]
+    [InlineData("def hello() -> tuple[Annotated[int, '@X'], Annotated[int, '@Y']]: ...\n", "(long X, long Y) Hello()")]
+    [InlineData("""
+                def hello() -> tuple[Annotated[int, '@'],       # missing name
+                                     Annotated[int, '@Foo'],    # ok
+                                     Annotated[int, '@@'],      # invalid name
+                                     Annotated[int, ''],        # empty name
+                                     Annotated[int, '8eer'],    # invalid name (starts with digit)
+                                     Annotated[int, 'Foo'],     # does not start with @
+                                     Annotated[int, 'Foo',
+                                                    '@Bar',     # first valid name
+                                                    'Baz',
+                                                    '@Qux'],
+                                     int]: ...                  # no annotation
+
+                """,
+                "(long, long Foo, long, long, long, long, long Bar, long) Hello()")]
     [InlineData("""
 
         # csharp: ignore

--- a/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
+++ b/src/CSnakes.Tests/PythonStaticGeneratorTests/FormatClassFromMethods.test_tuples.approved.txt
@@ -25,7 +25,7 @@ static partial class TestClassExtensions
 {
     private static ITestClass? instance;
 
-    private static ReadOnlySpan<byte> HotReloadHash => "6c64fd97abd301f2df3bc4c42102abac"u8;
+    private static ReadOnlySpan<byte> HotReloadHash => "779689ac6274a20ded5c31cf5cf470fb"u8;
 
     public static ITestClass TestClass(this IPythonEnvironment env)
     {
@@ -64,6 +64,7 @@ static partial class TestClassExtensions
         private PyObject __func_tuple_15;
         private PyObject __func_tuple_16;
         private PyObject __func_tuple_17;
+        private PyObject __func_named_elements;
 
         internal TestClassInternal(ILogger<IPythonEnvironment>? logger)
         {
@@ -89,6 +90,7 @@ static partial class TestClassExtensions
                 this.__func_tuple_15 = module.GetAttr("tuple_15");
                 this.__func_tuple_16 = module.GetAttr("tuple_16");
                 this.__func_tuple_17 = module.GetAttr("tuple_17");
+                this.__func_named_elements = module.GetAttr("named_elements");
             }
         }
 
@@ -116,6 +118,7 @@ static partial class TestClassExtensions
                 this.__func_tuple_15.Dispose();
                 this.__func_tuple_16.Dispose();
                 this.__func_tuple_17.Dispose();
+                this.__func_named_elements.Dispose();
                 // Bind to new functions
                 this.__func_tuple_1 = module.GetAttr("tuple_1");
                 this.__func_tuple_2 = module.GetAttr("tuple_2");
@@ -134,6 +137,7 @@ static partial class TestClassExtensions
                 this.__func_tuple_15 = module.GetAttr("tuple_15");
                 this.__func_tuple_16 = module.GetAttr("tuple_16");
                 this.__func_tuple_17 = module.GetAttr("tuple_17");
+                this.__func_named_elements = module.GetAttr("named_elements");
             }
         }
 
@@ -157,6 +161,7 @@ static partial class TestClassExtensions
             this.__func_tuple_15.Dispose();
             this.__func_tuple_16.Dispose();
             this.__func_tuple_17.Dispose();
+            this.__func_named_elements.Dispose();
             module.Dispose();
         }
 
@@ -380,6 +385,19 @@ static partial class TestClassExtensions
                 return __return;
             }
         }
+
+        public (long X, long Y, long Z) NamedElements((long, long, long) a)
+        {
+            using (GIL.Acquire())
+            {
+                this.logger?.LogDebug("Invoking Python function: {FunctionName}", "named_elements");
+                PyObject __underlyingPythonFunc = this.__func_named_elements;
+                using PyObject a_pyObject = PyObject.From(a)!;
+                using PyObject __result_pyObject = __underlyingPythonFunc.Call(a_pyObject);
+                var __return = __result_pyObject.BareImportAs<(long, long, long), global::CSnakes.Runtime.Python.PyObjectImporters.Tuple<long, long, long, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Int64, global::CSnakes.Runtime.Python.PyObjectImporters.Int64>>();
+                return __return;
+            }
+        }
     }
 }
 
@@ -523,6 +541,14 @@ partial interface ITestClass : IReloadableModuleImport
     /// ]]></code>
     /// </summary>
     (string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string) Tuple17((string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string) a);
+
+    /// <summary>
+    /// Invokes the Python function <c>named_elements</c>:
+    /// <code><![CDATA[
+    /// def named_elements(a: tuple[int, int, int]) -> tuple[Annotated[int, '@X'], Annotated[int, '@Y'], Annotated[int, '@Z']]: ...
+    /// ]]></code>
+    /// </summary>
+    (long X, long Y, long Z) NamedElements((long, long, long) a);
 }
 
 file static class ThisModule

--- a/src/Integration.Tests/TupleTests.cs
+++ b/src/Integration.Tests/TupleTests.cs
@@ -261,4 +261,13 @@ public class TupleTests(PythonEnvironmentFixture fixture) : IntegrationTestBase(
         Assert.Equal("p", p);
         Assert.Equal("q", q);
     }
+
+    [Fact]
+    public void NamedTupleElements()
+    {
+        var pt = TestTuples.NamedElements((123, 456, 789));
+        Assert.Equal(123, pt.X);
+        Assert.Equal(456, pt.Y);
+        Assert.Equal(789, pt.Z);
+    }
 }

--- a/src/Integration.Tests/python/test_tuples.py
+++ b/src/Integration.Tests/python/test_tuples.py
@@ -1,3 +1,6 @@
+from typing import Annotated
+
+
 def tuple_1(a: tuple[str]) -> tuple[str]:
     return a
 
@@ -47,4 +50,7 @@ def tuple_16(a: tuple[str, str, str, str, str, str, str, str, str, str, str, str
     return a
 
 def tuple_17(a: tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str, str, str, str]) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
+    return a
+
+def named_elements(a: tuple[int, int, int]) -> tuple[Annotated[int, '@X'], Annotated[int, '@Y'], Annotated[int, '@Z']]:
     return a


### PR DESCRIPTION
This PR adds support for named tuple elements in code generation, using Python's `Annotated` type with special string markers (e.g., `'@X'`) to specify tuple element names. It updates the source generation logic to recognize and translate these annotations into named tuple elements in the generated C# code, and adds comprehensive tests to verify this behavior.

A tuple element type can now carry a name via an `Annotated[...]` metadata string that starts with `@`. For example:

```python
def named_elements(a: tuple[int, int, int]) -> tuple[Annotated[int, '@X'], Annotated[int, '@Y'], Annotated[int, '@Z']]:
    return a
```

generates:

```c#
(long X, long Y, long Z) NamedElements((long, long, long) a);
```

The `@`-prefixed string is treated as the desired C# element name. The remainder (after `@`) must be a valid C# identifier for the name to be applied.

Since that the logging helper module has been embedded via the source generator in PR #831, we can take advantage of this support by making the complex and nested tuple return by `monitor`:

https://github.com/tonybaloney/CSnakes/blob/8e56847b232fc845f14e45f4f586787309a4fe72/src/CSnakes.Runtime/csnakes_logging.py#L51 much more readable and less error-prone:

```python
def monitor(
    name: Union[str, None] = None
) -> tuple[
    Annotated[
        Generator[
            tuple[
                Annotated[int, "@DropCount"],
                Annotated[int, "@Level"],
                Annotated[str, "@Message"],
                Annotated[
                    Union[
                        tuple[
                            Annotated[Any, "@ExceptionType"],
                            Annotated[Any, "@Exception"],
                            Annotated[Any, "@Traceback"]
                        ],
                        None
                    ],
                    "@ExceptionInfo"
                ]
            ],
            None,
            None
        ],
        "@Generator"
    ],
    Annotated[Callable[[], None], "@Close"]
]: ...
```

It's less error-prone because the C# code for logging has been updated to bind to the tuple element names rather than assume their position.

## Naming rules

The `@` convention is applied leniently — annotations that don't yield a valid name are simply ignored, leaving that element positional:

- `'@X'` → named `X`
- `'@'` → ignored (empty name)
- `'@@'` → ignored (invalid identifier)
- `''` → ignored (no `@` prefix)
- `'8eer'` / `'Foo'` → ignored (no `@` prefix; also invalid)
- Multiple metadata strings → the **first** valid `@`-name wins (e.g. `['Foo', '@Bar', 'Baz', '@Qux']` → `Bar`)
- No annotation → element stays positional

So a mixed tuple degrades gracefully, only naming the elements that carry a valid annotation.

The reason for choosing `@` as the prefix is that is should be very natural and easy to remember for C# developers; `@` is also used in C# as a prefix to a reserved keyword so it can be used as an identifier name, as in `@void`.
