### PR TITLE
Pin Python packages versions + distributions in test

### DIFF
--- a/src/Integration.Tests/python/requirements.txt
+++ b/src/Integration.Tests/python/requirements.txt
@@ -1,3 +1,5 @@
+--only-binary=numpy
+
 httpx==0.28.1
 numpy==2.0.2; python_version < '3.11'
 numpy==2.3.2; python_version >= '3.11'

--- a/src/Integration.Tests/python/requirements.txt
+++ b/src/Integration.Tests/python/requirements.txt
@@ -1,4 +1,5 @@
-httpx
-numpy
-typing-extensions
+httpx==0.28.1
+numpy==2.0.2; python_version < '3.11'
+numpy==2.3.2; python_version >= '3.11'
+typing-extensions==4.15.0
 pybind11-numpy-example==1.0.1


### PR DESCRIPTION
In PR #835, the Python environment & packages were installed before running integration tests in CI. This has revealed that some jobs intermittently fail, like while priming the free-threaded Python environment on Windows 11 ARM. `pip` sometimes fails to obtain the pre-built `cp313t-win_arm64` NumPy wheel and falls back to building NumPy from the `sdist`. The `windows-11-arm` runner's default C compiler is MinGW/GCC, which NumPy does not support on Windows ARM64, so the source build aborts with:

    ..\numpy\_core\src\multiarray\arraytypes.c.src:4664:6: error: #error "Did not find correct pointer sized integer."

When `pip` installs the pre-built wheel instead, the leg passes.

Retries appeared to _fix_ it only because each attempt re-rolled the resolution and sometimes landed on the wheel. For example, for PR #837, [a run for the `integration-test (windows-11-arm, 3.13)` job failed](https://github.com/tonybaloney/CSnakes/actions/runs/28674935253/job/85051844393) when falling back to compiling from source; see [`7_integration-test (windows-11-arm, 3.13).txt`](https://github.com/user-attachments/files/29662744/7_integration-test.windows-11-arm.3.13.txt). That [same job on a `main` run passes](https://github.com/tonybaloney/CSnakes/actions/runs/27002149533) because it finds and uses the pre-built wheel; see [`7_integration-test (windows-11-arm, 3.13).txt`](https://github.com/user-attachments/files/29662777/7_integration-test.windows-11-arm.3.13.txt). It proves that a compatible wheel exists and is installable on the runner.

This PR makes the install deterministic in `requirements.txt` by making the following changes:

- Forbid source builds for NumPy with `--only-binary=numpy`. `pip` must use a pre-built wheel. If it's unavailable, it should fail fast with a clear message about no matching distribution instead of a broken GCC compile. It's scoped to `numpy`, so `pybind11-numpy-example` can still build from its `sdist`.
- Pin exact dependency versions for reproducibility. Because no single NumPy release spans CI's Python 3.9–3.14 matrix, NumPy is pinned per Python version via environment markers.

