### PR TITLE
Permit trailing comma in generic type hints

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
@@ -176,7 +176,11 @@ public static partial class PythonParser
     private static TokenListParser<PythonToken, T> Return<T>(T value) => Parse.Return<PythonToken, T>(value);
 
     private static TokenListParser<PythonToken, T> Subscript<T>(this TokenListParser<PythonToken, T> parser) =>
-        parser.Between(Token.EqualTo(PythonToken.OpenBracket), Token.EqualTo(PythonToken.CloseBracket));
+        parser.Between(Token.EqualTo(PythonToken.OpenBracket),
+                       Token.EqualTo(PythonToken.CloseBracket)
+                            .Or(Token.EqualTo(PythonToken.CommaCloseBracket))
+                            .Named("`]`"));
+
 
     private static TokenListParser<PythonToken, TResult>
         Subscript<T, TResult>(this TokenListParser<PythonToken, T> parser,

--- a/src/CSnakes.SourceGeneration/Parser/PythonTokenizer.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonTokenizer.cs
@@ -19,6 +19,7 @@ public static class PythonTokenizer
         .Match(Character.EqualTo(',').IgnoreThen(Character.In(' ', '\t', '\n').Many()).IgnoreThen(Character.EqualTo('*')), PythonToken.CommaStar)
         .Match(Character.EqualTo(',').IgnoreThen(Character.In(' ', '\t', '\n').Many()).IgnoreThen(Character.EqualTo('/')), PythonToken.CommaSlash)
         .Match(Character.EqualTo(',').IgnoreThen(Character.In(' ', '\t', '\n').Many()).IgnoreThen(Character.EqualTo(')')), PythonToken.CommaCloseParenthesis)
+        .Match(Character.EqualTo(',').IgnoreThen(Character.In(' ', '\t', '\n').Many()).IgnoreThen(Character.EqualTo(']')), PythonToken.CommaCloseBracket)
         .Match(Character.EqualTo(','), PythonToken.Comma)
         .Match(Character.EqualTo('*').IgnoreThen(Character.EqualTo('*')), PythonToken.DoubleAsterisk)
         .Match(Character.EqualTo('*'), PythonToken.Asterisk)

--- a/src/CSnakes.SourceGeneration/Parser/PythonTokens.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonTokens.cs
@@ -78,4 +78,7 @@ public enum PythonToken
 
     [Token(Example = ", )")]
     CommaCloseParenthesis,
+
+    [Token(Example = ", ]")]
+    CommaCloseBracket,
 }

--- a/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
+++ b/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
@@ -513,8 +513,8 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Annotated[int, 'foobar', ]")]
     public void TrailingCommaInAnnotatedMetadata(string input)
     {
-        var type = TestParse<PythonTypeSpec>(input);
-        Assert.Single(type.Metadata);
-        Assert.Equal("'foobar'", type.Metadata[0].ToString());
+        var metadata = TestParse<IntType>(input).Metadata;
+        var datum = Assert.Single(metadata);
+        Assert.Equal("'foobar'", datum.ToString());
     }
 }

--- a/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
+++ b/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
@@ -510,9 +510,11 @@ public class PythonTypeDefinitionParserTests
     }
 
     [Theory]
-    [InlineData("Annotated[int, 'a number', ]")]
+    [InlineData("Annotated[int, 'foobar', ]")]
     public void TrailingCommaInAnnotatedMetadata(string input)
     {
-        _ = PythonParser.PythonTypeDefinitionParser.Parse(Tokenize(input));
+        var type = TestParse<PythonTypeSpec>(input);
+        Assert.Single(type.Metadata);
+        Assert.Equal("'foobar'", type.Metadata[0].ToString());
     }
 }

--- a/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
+++ b/src/CSnakes.Tests/PythonTypeDefinitionParserTests.cs
@@ -152,6 +152,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("list[int]")]
     [InlineData("List[int]")]
     [InlineData("typing.List[int]")]
+    // Trailing comma in generic type argument list
+    [InlineData("list[int, ]")]
+    [InlineData("List[int, ]")]
+    [InlineData("typing.List[int, ]")]
     public void ListTest(string input)
     {
         var type = TestParse<ListType>(input);
@@ -162,6 +166,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Sequence[str]")]
     [InlineData("typing.Sequence[str]")]
     [InlineData("collections.abc.Sequence[str]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Sequence[str, ]")]
+    [InlineData("typing.Sequence[str, ]")]
+    [InlineData("collections.abc.Sequence[str, ]")]
     public void SequenceTest(string input)
     {
         var type = TestParse<SequenceType>(input);
@@ -172,6 +180,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("dict[str, int]")]
     [InlineData("Dict[str, int]")]
     [InlineData("typing.Dict[str, int]")]
+    // Trailing comma in generic type argument list
+    [InlineData("dict[str, int, ]")]
+    [InlineData("Dict[str, int, ]")]
+    [InlineData("typing.Dict[str, int, ]")]
     public void DictTest(string input)
     {
         var type = TestParse<DictType>(input);
@@ -183,6 +195,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Mapping[str, float]")]
     [InlineData("typing.Mapping[str, float]")]
     [InlineData("collections.abc.Mapping[str, float]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Mapping[str, float, ]")]
+    [InlineData("typing.Mapping[str, float, ]")]
+    [InlineData("collections.abc.Mapping[str, float, ]")]
     public void MappingTest(string input)
     {
         var type = TestParse<MappingType>(input);
@@ -194,6 +210,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Generator[int, str, bool]")]
     [InlineData("typing.Generator[int, str, bool]")]
     [InlineData("collections.abc.Generator[int, str, bool]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Generator[int, str, bool, ]")]
+    [InlineData("typing.Generator[int, str, bool, ]")]
+    [InlineData("collections.abc.Generator[int, str, bool, ]")]
     public void GeneratorTest(string input)
     {
         var type = TestParse<GeneratorType>(input);
@@ -206,6 +226,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Awaitable[int]")]
     [InlineData("typing.Awaitable[int]")]
     [InlineData("collections.abc.Awaitable[int]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Awaitable[int, ]")]
+    [InlineData("typing.Awaitable[int, ]")]
+    [InlineData("collections.abc.Awaitable[int, ]")]
     public void AwaitableTest(string input)
     {
         var type = TestParse<AwaitableType>(input);
@@ -216,6 +240,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Coroutine[int, str, bool]")]
     [InlineData("typing.Coroutine[int, str, bool]")]
     [InlineData("collections.abc.Coroutine[int, str, bool]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Coroutine[int, str, bool, ]")]
+    [InlineData("typing.Coroutine[int, str, bool, ]")]
+    [InlineData("collections.abc.Coroutine[int, str, bool, ]")]
     public void CoroutineTest(string input)
     {
         var type = TestParse<CoroutineType>(input);
@@ -228,6 +256,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("Callable[[int, str], bool]")]
     [InlineData("typing.Callable[[int, str], bool]")]
     [InlineData("collections.abc.Callable[[int, str], bool]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Callable[[int, str], bool, ]")]
+    [InlineData("typing.Callable[[int, str], bool, ]")]
+    [InlineData("collections.abc.Callable[[int, str], bool, ]")]
     public void CallableTest(string input)
     {
         var type = TestParse<CallableType>(input);
@@ -240,6 +272,9 @@ public class PythonTypeDefinitionParserTests
     [Theory]
     [InlineData("Callable[[], None]")]
     [InlineData("typing.Callable[[], None]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Callable[[], None, ]")]
+    [InlineData("typing.Callable[[], None, ]")]
     public void CallableNoParametersTest(string input)
     {
         var type = TestParse<CallableType>(input);
@@ -250,6 +285,7 @@ public class PythonTypeDefinitionParserTests
 
     [Theory]
     [InlineData("Callable[..., Any]")]
+    [InlineData("Callable[..., Any, ]")]
     public void CallableEllipsisParametersTest(string input)
     {
         var type = TestParse<CallableType>(input);
@@ -260,6 +296,9 @@ public class PythonTypeDefinitionParserTests
     [Theory]
     [InlineData("Literal[1]")]
     [InlineData("typing.Literal[1]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Literal[1, ]")]
+    [InlineData("typing.Literal[1, ]")]
     public void LiteralIntTest(string input)
     {
         var type = TestParse<LiteralType>(input);
@@ -271,6 +310,9 @@ public class PythonTypeDefinitionParserTests
     [Theory]
     [InlineData("Literal['hello']")]
     [InlineData("typing.Literal['hello']")]
+    // Trailing comma in generic type argument list
+    [InlineData("Literal['hello', ]")]
+    [InlineData("typing.Literal['hello', ]")]
     public void LiteralStringTest(string input)
     {
         var type = TestParse<LiteralType>(input);
@@ -282,6 +324,9 @@ public class PythonTypeDefinitionParserTests
     [Theory]
     [InlineData("Literal[True, False]")]
     [InlineData("typing.Literal[True, False]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Literal[True, False, ]")]
+    [InlineData("typing.Literal[True, False, ]")]
     public void LiteralMultipleTest(string input)
     {
         var type = TestParse<LiteralType>(input);
@@ -295,6 +340,9 @@ public class PythonTypeDefinitionParserTests
     [Theory]
     [InlineData("Union[int, str]")]
     [InlineData("typing.Union[int, str]")]
+    // Trailing comma in generic type argument list
+    [InlineData("Union[int, str, ]")]
+    [InlineData("typing.Union[int, str, ]")]
     public void UnionTest(string input)
     {
         var type = TestParse<UnionType>(input);
@@ -326,6 +374,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("tuple[int, str]")]
     [InlineData("Tuple[int, str]")]
     [InlineData("typing.Tuple[int, str]")]
+    // Trailing comma in generic type argument list
+    [InlineData("tuple[int, str, ]")]
+    [InlineData("Tuple[int, str, ]")]
+    [InlineData("typing.Tuple[int, str, ]")]
     public void TupleTest(string input)
     {
         var type = TestParse<TupleType>(input);
@@ -337,6 +389,11 @@ public class PythonTypeDefinitionParserTests
     [Theory]
     [InlineData("tuple[int]")]
     [InlineData("Tuple[int]")]
+    [InlineData("typing.Tuple[int]")]
+    // Trailing comma in generic type argument list
+    [InlineData("tuple[int, ]")]
+    [InlineData("Tuple[int, ]")]
+    [InlineData("typing.Tuple[int, ]")]
     public void TupleSingleParameterTest(string input)
     {
         var type = TestParse<TupleType>(input);
@@ -348,6 +405,10 @@ public class PythonTypeDefinitionParserTests
     [InlineData("tuple[int, ...]")]
     [InlineData("Tuple[int, ...]")]
     [InlineData("typing.Tuple[int, ...]")]
+    // Trailing comma in generic type argument list
+    [InlineData("tuple[int, ..., ]")]
+    [InlineData("Tuple[int, ..., ]")]
+    [InlineData("typing.Tuple[int, ..., ]")]
     public void VariadicTupleTest(string input)
     {
         var type = TestParse<VariadicTupleType>(input);
@@ -364,6 +425,8 @@ public class PythonTypeDefinitionParserTests
     [InlineData("tuple[str | None, ...]", "Optional[str]")]
     [InlineData("tuple[Union[int, str], ...]", "Union[int, str]")]
     [InlineData("tuple[int | str, ...]", "Union[int, str]")]
+    // Trailing comma in generic type argument list
+    [InlineData("tuple[str, ..., ]", "str")]
     public void VariadicTupleWithDifferentTypesTest(string input, string expectedElementType)
     {
         var type = TestParse<VariadicTupleType>(input);
@@ -400,6 +463,7 @@ public class PythonTypeDefinitionParserTests
 
     [Theory]
     [InlineData("MyGeneric[int, str]")]
+    [InlineData("MyGeneric[int, str, ]")]
     public void GenericTypeWithMultipleArgumentsTest(string input)
     {
         var type = TestParse<ParsedPythonTypeSpec>(input);
@@ -443,5 +507,12 @@ public class PythonTypeDefinitionParserTests
         var dictType = Assert.IsType<DictType>(unionType.Choices[1]);
         _ = Assert.IsType<IntType>(dictType.Key);
         _ = Assert.IsType<BoolType>(dictType.Value);
+    }
+
+    [Theory]
+    [InlineData("Annotated[int, 'a number', ]")]
+    public void TrailingCommaInAnnotatedMetadata(string input)
+    {
+        _ = PythonParser.PythonTypeDefinitionParser.Parse(Tokenize(input));
     }
 }


### PR DESCRIPTION
This PR changes the type definition parser to support trailing commas in Python type argument lists (e.g., `tuple[int, str, ]`) as well as annotated metadata, which is perfectly legal. They appear frequently in code formatted by [Ruff formatter](https://docs.astral.sh/ruff/formatter/).