### PR TITLE
Update Superpower to 3.2.1

### DIFF
--- a/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
+++ b/src/CSnakes.SourceGeneration/Parser/PythonParser.TypeDef.cs
@@ -108,7 +108,7 @@ public static partial class PythonParser
             from name in Parse.OneOf(Token.EqualTo(PythonToken.None),
                                      Token.EqualTo(PythonToken.Identifier),
                                      Token.EqualTo(PythonToken.QualifiedIdentifier))
-            from type in name.CharSpan() switch
+            from type in name.Span.AsReadOnlySpan() switch
             {
                 "None"                                                           => TypeDefinitionSubParsers.None,
                 "Any"                                                            => TypeDefinitionSubParsers.Any,
@@ -154,7 +154,7 @@ public static partial class PythonParser
             //
             from id in Parse.OneOf(Token.EqualTo(PythonToken.QualifiedIdentifier),
                                    Token.EqualTo(PythonToken.Identifier))
-            where id.CharSpan() is "Annotated" or "typing.Annotated"
+            where id.Span.AsReadOnlySpan() is "Annotated" or "typing.Annotated"
             select id;
 
         var annotatedSubscriptionParser =

--- a/src/CSnakes.SourceGeneration/Parser/SuperpowerExtensions.cs
+++ b/src/CSnakes.SourceGeneration/Parser/SuperpowerExtensions.cs
@@ -13,14 +13,4 @@ static class SuperpowerExtensions
         from a in first
         from _ in second
         select a;
-
-    // TODO: Replace `CharSpan` with `TextSpan.AsReadOnlySpan` when available in Superpower
-    // See: https://github.com/datalust/superpower/blob/998091233e5ef7624be349b8df32ee6c72588a1c/src/Superpower/Model/TextSpan.cs#L240-L244
-
-    public static ReadOnlySpan<char> CharSpan(this Token<PythonToken> token) => token.Span.CharSpan();
-
-    public static ReadOnlySpan<char> CharSpan(this TextSpan span) =>
-        span.Source is { } source
-            ? source.AsSpan(span.Position.Absolute, span.Length)
-            : ReadOnlySpan<char>.Empty;
 }

--- a/src/CSnakes.SourceGeneration/Parser/SuperpowerExtensions.cs
+++ b/src/CSnakes.SourceGeneration/Parser/SuperpowerExtensions.cs
@@ -1,5 +1,4 @@
 using Superpower;
-using Superpower.Model;
 
 namespace CSnakes.Parser;
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="SharpCompress" Version="0.38.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="Superpower" Version="3.1.0" />
+    <PackageVersion Include="Superpower" Version="3.2.1" />
     <PackageVersion Include="ZstdSharp.Port" Version="0.8.7" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
This PR updates Superpower to the latest version of the package, addressing the following to-do comment:

https://github.com/tonybaloney/CSnakes/blob/66de599499a7759223f44ae86029ded6edca84c4/src/CSnakes.SourceGeneration/Parser/SuperpowerExtensions.cs#L17-L18
