### PR TITLE
Exclude private files from `EnableDefaultPythonItems` set

### DIFF
--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -100,12 +100,14 @@ This guide helps you diagnose and resolve common issues when working with CSnake
 
 1. **Check File Configuration**
 
-   By default, CSnakes automatically discovers `.py` and `.pyi` files in your project via `EnableDefaultPythonItems`, which is `true` by default — no additional configuration is needed. If generated code is missing, check whether this property has been explicitly set to `false` in your `.csproj`:
+    By default, CSnakes automatically discovers `.py` and `.pyi` files in your project via `EnableDefaultPythonItems`, which is `true` by default. Files whose names start with `_` are intentionally excluded from source generation input. If generated code is missing, check whether the `EnableDefaultPythonItems` property has been explicitly set to `false` in your `.csproj`:
 
    ```xml
    <!-- ❌ This disables automatic file discovery — remove or set to true -->
    <EnableDefaultPythonItems>false</EnableDefaultPythonItems>
    ```
+
+   Check also that the file name does not start with an underscore (`_`).
 
    If you need manual control over which files are included, keep `EnableDefaultPythonItems` set to `false` and explicitly add the Python files using `AdditionalFiles` (take care not to omit `SourceItemType="Python"`):
 

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -100,7 +100,7 @@ This guide helps you diagnose and resolve common issues when working with CSnake
 
 1. **Check File Configuration**
 
-    By default, CSnakes automatically discovers `.py` and `.pyi` files in your project via `EnableDefaultPythonItems`, which is `true` by default. Files whose names start with `_` are intentionally excluded from source generation input. If generated code is missing, check whether the `EnableDefaultPythonItems` property has been explicitly set to `false` in your `.csproj`:
+   By default, CSnakes automatically discovers `.py` and `.pyi` files in your project via `EnableDefaultPythonItems`, which is `true` by default. Files whose names start with `_` are intentionally excluded from source generation input. If generated code is missing, check whether the `EnableDefaultPythonItems` property has been explicitly set to `false` in your `.csproj`:
 
    ```xml
    <!-- ❌ This disables automatic file discovery — remove or set to true -->

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -46,7 +46,7 @@ Add the `CSnakes.Runtime` package reference to your `.csproj`:
 </Project>
 ```
 
-By default, CSnakes automatically discovers all `.py` and `.pyi` files in your project — no additional configuration is needed. See [Discovering Python files for Source Generation](configuration.md) if you need manual control over which files are included.
+By default, CSnakes automatically discovers `.py` and `.pyi` files in your project — no additional configuration is needed. However, files whose names start with an underscore (`_`) are by-convention considered private and excluded. See [Discovering Python files for Source Generation](configuration.md) if you need manual control over which files are included.
 
 ### 3. Initialize Python Environment
 

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -46,7 +46,7 @@ Add the `CSnakes.Runtime` package reference to your `.csproj`:
 </Project>
 ```
 
-By default, CSnakes automatically discovers `.py` and `.pyi` files in your project — no additional configuration is needed. However, files whose names start with an underscore (`_`) are by-convention considered private and excluded. See [Discovering Python files for Source Generation](configuration.md) if you need manual control over which files are included.
+By default, CSnakes automatically discovers `.py` and `.pyi` files in your project — no additional configuration is needed. However, files whose names start with an underscore (`_`) are by convention considered private and excluded. See [Discovering Python files for Source Generation](configuration.md) if you need manual control over which files are included.
 
 ### 3. Initialize Python Environment
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -9,7 +9,7 @@ There are two options for configuring how CSnakes discovers Python files in your
 
 ### Automatic Example
 
-By default, CSnakes automatically finds `.py` and `.pyi` files in your project, except those whose names start with an underscore, (`_`). This is controlled by the `EnableDefaultPythonItems` setting, which is `true` by default:
+By default, CSnakes automatically finds `.py` and `.pyi` files in your project, except those whose names start with an underscore (`_`). This is controlled by the `EnableDefaultPythonItems` setting, which is `true` by default:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -9,7 +9,7 @@ There are two options for configuring how CSnakes discovers Python files in your
 
 ### Automatic Example
 
-By default, CSnakes automatically finds any `.py` and `.pyi` files in your project and generates .NET classes. This is controlled by the `EnableDefaultPythonItems` setting, which is `true` by default:
+By default, CSnakes automatically finds `.py` and `.pyi` files in your project, except those whose names start with an underscore, (`_`). This is controlled by the `EnableDefaultPythonItems` setting, which is `true` by default:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -58,6 +58,8 @@ from a particular folder. Set the `EmbedPythonSources` property to `true` (defau
 For this option, the source of the Python file is embedded into the generated class by CSnakes and the `.WithHome` extension method for the Python environment doesn't need
 to contain the Python file.
 
+When embedding is disabled (the default), underscore-prefixed Python files discovered automatically (for example `__init__.py`) are copied to the output directory so package/module imports still work at runtime.
+
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
@@ -93,6 +95,8 @@ If the home were `python_src\`:
 - To import `library.py` you would `import library`
 - To import `utils\__init__.py` you would `import utils`
 - To import `utils\parser.py` you would `import utils.parser`
+
+Note: `__init__.py` participates in Python package imports, but underscore-prefixed files are excluded from source generation input by default.
 
 CSnakes will automatically generate these namespaces and import directives once you configure the root of the project using the `PythonRoot` property in your `.csproj`.
 

--- a/src/CSnakes.SourceGeneration/NuGet/buildTransitive/net8.0/CSnakes.SourceGeneration.targets
+++ b/src/CSnakes.SourceGeneration/NuGet/buildTransitive/net8.0/CSnakes.SourceGeneration.targets
@@ -2,11 +2,32 @@
 
   <Target Name="_InjectCSnakesAdditionalFiles" BeforeTargets="PrepareForBuild;CompileDesignTime;GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
+      <!--
+      Promote loose "None" items to "AdditionalFiles" so the source generator can see the Python
+      sources. The condition only selects an item when all of the following hold:
+
+      * "EnableDefaultPythonItems" is "true" or unset/empty (i.e. enabled by default);
+      * the item's extension is ".py" or ".pyi"; and
+      * the item's file name does not begin with an underscore, which excludes files such as
+        "__init__.py" and "_private.py" by convention.
+      -->
       <AdditionalFiles Include="@(None)"
-                       Condition="('$(EnableDefaultPythonItems)' == 'true' Or '$(EnableDefaultPythonItems)' == '') And ($([System.Text.RegularExpressions.Regex]::IsMatch('%(Extension)', '.py$')) Or $([System.Text.RegularExpressions.Regex]::IsMatch('%(Extension)', '.pyi$')))"
+                       Condition="('$(EnableDefaultPythonItems)' == 'true' Or '$(EnableDefaultPythonItems)' == '')
+                                  And $([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)%(Extension)', '^[^_].*\.pyi?$'))"
                        SourceItemType="Python">
         <CopyToOutputDirectory Condition="'$(EmbedPythonSources)' != 'true'">Always</CopyToOutputDirectory>
       </AdditionalFiles>
+      <!--
+      Keep underscore-prefixed Python sources copied to output when default Python item handling is
+      enabled and sources are not being embedded. These files stay out of "AdditionalFiles" because
+      underscore-prefixed names are intentionally excluded from source generation input.
+      -->
+      <None Update="@(None)"
+            Condition="('$(EnableDefaultPythonItems)' == 'true' Or '$(EnableDefaultPythonItems)' == '')
+                       And '$(EmbedPythonSources)' != 'true'
+                       And $([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)%(Extension)', '^[_].*\.pyi?$'))">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This PR excludes any Python file whose name starts with an underscore (`_`) from being processed by the source generator, while ensuring these files are still copied to the output directory when needed for runtime package/module imports. This only affects when `EnableDefaultPythonItems` is `true` (the default).

This means the source generator will not see files like `_foobar.py` and `__init__.py` at all.

Documentation is updated to explain this behavior.

## Testing

Checkout `main` (at commit 66de599499a7759223f44ae86029ded6edca84c4 at the time of opening this PR), create an empty Python file starting with an underscore (`_foobar.py` below) and then query the [evaluated MSBuild items](https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-properties?view=visualstudio) `None` and `AdditionalFiles`:

```
git checkout 66de599499a7759223f44ae86029ded6edca84c4
touch src/Integration.Tests/python/_foobar.py
dotnet build -v q -t build -f net10.0 -getItem:None -getItem:AdditionalFiles src/Integration.Tests |
    jq -c '.Items | to_entries[]
                  | .key as $t
                  | .value[]
                  | . + {ItemType: $t}
                  | select((.Extension == ".py" or .Extension == ".pyi") and .CopyToOutputDirectory != null)
                  | { ItemType, Identity, CopyToOutputDirectory }'
```

The output should be:

```jsonl
{"ItemType":"None","Identity":"python\\html.pyi","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\submodule\\html.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\submodule\\__init__.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_args.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_args_underscore.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_awaitables.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_basic.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_buffer.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_coroutines.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_defaults.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_dependency.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_dicts.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_exceptions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_false_returns.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_generators.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_keywords.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_logging.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_none.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_optional.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_overload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_pybind11.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_reload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_reserved.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_source.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_sys.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_tuples.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_unions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_windows_arm64.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\_foobar.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\html.pyi","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\submodule\\html.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\submodule\\__init__.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_args.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_args_underscore.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_awaitables.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_basic.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_buffer.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_coroutines.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_defaults.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_dependency.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_dicts.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_exceptions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_false_returns.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_generators.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_keywords.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_logging.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_none.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_optional.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_overload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_pybind11.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_reload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_reserved.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_source.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_sys.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_tuples.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_unions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_windows_arm64.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\_foobar.py","CopyToOutputDirectory":"Always"}
```

If you filter through `grep` for just `_foobar.py`:

```
dotnet build -v q -t build -f net10.0 -getItem:None -getItem:AdditionalFiles src/Integration.Tests |
    jq -c '.Items | to_entries[]
                  | .key as $t
                  | .value[]
                  | . + {ItemType: $t}
                  | select((.Extension == ".py" or .Extension == ".pyi") and .CopyToOutputDirectory != null)
                  | { ItemType, Identity, CopyToOutputDirectory }' |
    grep -F _foobar.py
```

then you'll notice two entries:

```jsonl
{"ItemType":"None","Identity":"python\\_foobar.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\_foobar.py","CopyToOutputDirectory":"Always"}
```

Next, switch to the branch of this PR:

    git switch auto-exclude-underscore-pefix-files

and run the evaluation of items once more:

```
dotnet build -v q -t build -f net10.0 -getItem:None -getItem:AdditionalFiles src/Integration.Tests |
    jq -c '.Items | to_entries[]
                  | .key as $t
                  | .value[]
                  | . + {ItemType: $t}
                  | select((.Extension == ".py" or .Extension == ".pyi") and .CopyToOutputDirectory != null)
                  | { ItemType, Identity, CopyToOutputDirectory }'
```

the output should be:

```json
{"ItemType":"None","Identity":"python\\submodule\\__init__.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\_foobar.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\html.pyi","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\submodule\\html.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_args.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_args_underscore.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_awaitables.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_basic.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_buffer.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_coroutines.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_defaults.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_dependency.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_dicts.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_exceptions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_false_returns.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_generators.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_keywords.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_logging.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_none.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_optional.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_overload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_pybind11.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_reload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_reserved.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_source.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_sys.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_tuples.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_unions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"None","Identity":"python\\test_windows_arm64.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\html.pyi","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\submodule\\html.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_args.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_args_underscore.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_awaitables.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_basic.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_buffer.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_coroutines.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_defaults.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_dependency.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_dicts.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_exceptions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_false_returns.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_generators.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_keywords.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_logging.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_none.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_optional.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_overload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_pybind11.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_reload.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_reserved.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_source.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_sys.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_tuples.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_unions.py","CopyToOutputDirectory":"Always"}
{"ItemType":"AdditionalFiles","Identity":"python\\test_windows_arm64.py","CopyToOutputDirectory":"Always"}
```

Again, filtering through `grep` for just `_foobar.py`:

```
dotnet build -v q -t build -f net10.0 -getItem:None -getItem:AdditionalFiles src/Integration.Tests |
    jq -c '.Items | to_entries[]
                  | .key as $t
                  | .value[]
                  | . + {ItemType: $t}
                  | select((.Extension == ".py" or .Extension == ".pyi") and .CopyToOutputDirectory != null)
                  | { ItemType, Identity, CopyToOutputDirectory }' |
    grep -F _foobar.py
```

will reveal just one entry:

```jsonl
{"ItemType":"None","Identity":"python\\_foobar.py","CopyToOutputDirectory":"Always"}
```

Since the `AdditionalFiles` entry is gone, the source generator won't process this file, but it will still be copied to the output directory per the entry above.