### PR TITLE
Remove unused installer property from redist test fixture

### DIFF
--- a/src/RedistributablePython.Tests/RedistributablePythonTestBase.cs
+++ b/src/RedistributablePython.Tests/RedistributablePythonTestBase.cs
@@ -1,6 +1,4 @@
-using CSnakes.Runtime.PackageManagement;
 using CSnakes.Runtime.Tests;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace RedistributablePython.Tests;
@@ -13,27 +11,22 @@ public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvir
 }
 
 /// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
-public sealed class PythonEnvironmentFixture : RedistributablePythonEnvironmentFixture
-{
-    public PythonEnvironmentFixture() :
-        base(home: Path.Join(Environment.CurrentDirectory, "python"),
-             static (context, sku) =>
-             {
-                 var venv = FormattableString.Invariant($".venv-{sku.VersionMajor}.{sku.VersionMinor}{(sku.FreeThreaded ? "t" : "")}{(sku.Debug ? "d" : "")}");
-                 _ = context.Environment.DisableSignalHandlers()
-                            .WithUvInstaller()
-                            .WithVirtualEnvironment(Path.Join(Environment.CurrentDirectory, "python", venv))
-                            .CapturePythonLogs();
+public sealed class PythonEnvironmentFixture() :
+    RedistributablePythonEnvironmentFixture(
+        home: Path.Join(Environment.CurrentDirectory, "python"),
+        static (context, sku) =>
+        {
+            var venv = FormattableString.Invariant($".venv-{sku.VersionMajor}.{sku.VersionMinor}{(sku.FreeThreaded ? "t" : "")}{(sku.Debug ? "d" : "")}");
+            _ = context.Environment
+                       .DisableSignalHandlers()
+                       .WithUvInstaller()
+                       .WithVirtualEnvironment(Path.Join(Environment.CurrentDirectory, "python", venv))
+                       .CapturePythonLogs();
 
-                 context.Logging.SetMinimumLevel(LogLevel.Debug)
-                                .AddFilter(_ => true);
-             })
-    {
-        Installer = Services.GetRequiredService<IPythonPackageInstaller>();
-    }
-
-    public IPythonPackageInstaller Installer { get; }
-}
+            context.Logging
+                   .SetMinimumLevel(LogLevel.Debug)
+                   .AddFilter(_ => true);
+        });
 
 [Collection(PythonEnvironmentCollection.Name)]
 public class RedistributablePythonTestBase(PythonEnvironmentFixture fixture)


### PR DESCRIPTION
This PR removes the `Installer` property of `PythonEnvironmentFixture` that seemsto have never been needed.