### PR TITLE
Convert redistributable Python SKU into a test fixture

### DIFF
--- a/src/CSnakes.Runtime.Tests/PythonEnvironmentFixtures.cs
+++ b/src/CSnakes.Runtime.Tests/PythonEnvironmentFixtures.cs
@@ -1,8 +1,11 @@
-using System;
 using CSnakes.Runtime.Locators;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+
+[assembly: AssemblyFixture(typeof(CSnakes.Runtime.Tests.RedistributablePythonSkuFixture))]
 
 namespace CSnakes.Runtime.Tests;
 
@@ -47,14 +50,16 @@ public abstract class PythonEnvironmentFixtureBase : IDisposable
     protected IServiceProvider Services => app.Services;
 }
 
-public sealed record RedistributablePythonSku
+public sealed class RedistributablePythonSkuFixture : IDisposable
 {
-    public RedistributablePythonSku(int versionMajor, int versionMinor)
+    public RedistributablePythonSkuFixture()
     {
-        if (versionMajor is not 3)
-            throw new ArgumentException($"Python version {versionMajor}.x is not supported.", nameof(versionMajor));
+        var version = ServiceCollectionExtensions.ParsePythonVersion(Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.9");
 
-        Version = versionMinor switch
+        if (version.Major is not 3)
+            throw new NotSupportedException($"Python version {version.Major}.x is not supported.");
+
+        Version = version.Minor switch
         {
              9 => RedistributablePythonVersion.Python3_9,
             10 => RedistributablePythonVersion.Python3_10,
@@ -62,11 +67,17 @@ public sealed record RedistributablePythonSku
             12 => RedistributablePythonVersion.Python3_12,
             13 => RedistributablePythonVersion.Python3_13,
             14 => RedistributablePythonVersion.Python3_14,
-            var minor => throw new ArgumentException($"Python version 3.{minor} is not supported.", nameof(versionMinor)),
+            var minor => throw new NotSupportedException($"Python version 3.{minor} is not supported."),
         };
 
-        VersionMajor = versionMajor;
-        VersionMinor = versionMinor;
+        VersionMajor = version.Major;
+        VersionMinor = version.Minor;
+
+        var debug = Debug = Environment.GetEnvironmentVariable("PYTHON_DEBUG") == "1";
+        var freeThreaded = FreeThreaded = Environment.GetEnvironmentVariable("PYTHON_FREETHREADED") == "1";
+
+        var venv = FormattableString.Invariant($".venv-{version.Major}.{version.Minor}{(freeThreaded ? "t" : "")}{(debug ? "d" : "")}");
+        VirtualEnvironmentPath = Path.Join(Environment.CurrentDirectory, "python", venv);
     }
 
     public RedistributablePythonVersion Version { get; }
@@ -76,22 +87,18 @@ public sealed record RedistributablePythonSku
 
     public bool Debug { get; init; }
     public bool FreeThreaded { get; init; }
+
+    public string VirtualEnvironmentPath { get;}
+
+    public void Dispose() { }
 }
 
 /// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
-public abstract class RedistributablePythonEnvironmentFixture(
-                          string? home = null,
-                          Action<PythonEnvironmentFixtureBuildContext, RedistributablePythonSku>? configure = null) :
+public abstract class RedistributablePythonEnvironmentFixture(RedistributablePythonSkuFixture sku,
+                                                              string? home = null,
+                                                              Action<PythonEnvironmentFixtureBuildContext>? configure = null) :
     PythonEnvironmentFixtureBase(home, context =>
     {
-        var version = ServiceCollectionExtensions.ParsePythonVersion(Environment.GetEnvironmentVariable("PYTHON_VERSION") ?? "3.12.9");
-        var sku = new RedistributablePythonSku(version.Major, version.Minor)
-        {
-            Debug = Environment.GetEnvironmentVariable("PYTHON_DEBUG") == "1",
-            FreeThreaded = Environment.GetEnvironmentVariable("PYTHON_FREETHREADED") == "1",
-        };
-
         context.Environment.FromRedistributable(sku.Version, debug: sku.Debug, freeThreaded: sku.FreeThreaded);
-
-        configure?.Invoke(context, sku);
+        configure?.Invoke(context);
     });

--- a/src/CSnakes.Runtime.Tests/RuntimeTestBase.cs
+++ b/src/CSnakes.Runtime.Tests/RuntimeTestBase.cs
@@ -7,7 +7,8 @@ public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvir
     public const string Name = "PythonEnvironment";
 }
 
-public sealed class PythonEnvironmentFixture : RedistributablePythonEnvironmentFixture;
+public sealed class PythonEnvironmentFixture(RedistributablePythonSkuFixture sku) :
+    RedistributablePythonEnvironmentFixture(sku);
 
 [Collection(PythonEnvironmentCollection.Name)]
 public abstract class RuntimeTestBase(PythonEnvironmentFixture fixture)

--- a/src/Integration.Tests/IntegrationTestBase.cs
+++ b/src/Integration.Tests/IntegrationTestBase.cs
@@ -16,18 +16,20 @@ public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvir
 /// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
 public sealed class PythonEnvironmentFixture : RedistributablePythonEnvironmentFixture
 {
-    public PythonEnvironmentFixture() :
-        base(home: Path.Join(Environment.CurrentDirectory, "python"),
-             (context, sku) =>
-             {
-                 var venv = FormattableString.Invariant($".venv-{sku.VersionMajor}.{sku.VersionMinor}{(sku.FreeThreaded ? "t" : "")}{(sku.Debug ? "d" : "")}");
-                 context.Environment
-                        .WithVirtualEnvironment(Path.Join(Environment.CurrentDirectory, "python", venv))
-                        .WithPipInstaller();
-             })
+    public PythonEnvironmentFixture(RedistributablePythonSkuFixture skuFixture) :
+        base(skuFixture, home: Path.Join(Environment.CurrentDirectory, "python"),
+             context => context.Environment
+                               .WithVirtualEnvironment(skuFixture.VirtualEnvironmentPath)
+                               .WithPipInstaller())
     {
         Installer = Services.GetRequiredService<IPythonPackageInstaller>();
+        VirtualEnvironmentPath = skuFixture.VirtualEnvironmentPath;
     }
+
+    /// <summary>The Python home directory shared by all tests in the collection.</summary>
+    public string Home { get; } = Path.Join(Environment.CurrentDirectory, "python");
+
+    public string VirtualEnvironmentPath { get; }
 
     public IPythonPackageInstaller Installer { get; }
 }

--- a/src/RedistributablePython.Tests/RedistributablePythonTestBase.cs
+++ b/src/RedistributablePython.Tests/RedistributablePythonTestBase.cs
@@ -11,16 +11,15 @@ public sealed class PythonEnvironmentCollection : ICollectionFixture<PythonEnvir
 }
 
 /// <seealso href="https://xunit.net/docs/shared-context.html#collection-fixture"/>
-public sealed class PythonEnvironmentFixture() :
+public sealed class PythonEnvironmentFixture(RedistributablePythonSkuFixture sku) :
     RedistributablePythonEnvironmentFixture(
-        home: Path.Join(Environment.CurrentDirectory, "python"),
-        static (context, sku) =>
+        sku, home: Path.Join(Environment.CurrentDirectory, "python"),
+        context =>
         {
-            var venv = FormattableString.Invariant($".venv-{sku.VersionMajor}.{sku.VersionMinor}{(sku.FreeThreaded ? "t" : "")}{(sku.Debug ? "d" : "")}");
             _ = context.Environment
                        .DisableSignalHandlers()
                        .WithUvInstaller()
-                       .WithVirtualEnvironment(Path.Join(Environment.CurrentDirectory, "python", venv))
+                       .WithVirtualEnvironment(sku.VirtualEnvironmentPath)
                        .CapturePythonLogs();
 
             context.Logging


### PR DESCRIPTION
Previously, the redistributable Python SKU (version, debug/free-threaded flags, and derived virtual-environment path) was resolved inside each collection fixture's constructor. This meant every test project independently read environment variables (`PYTHON_VERSION`, `PYTHON_DEBUG`, `PYTHON_FREETHREADED`) and re-derived the `.venv-x.y` path, duplicating logic across three test bases. This PR promotes the SKU to a shared xUnit assembly fixture, so the Python version and its virtual-environment path are resolved once and injected wherever needed.

There are no behavioral change to tests; this is a structural refactor consolidating SKU resolution.